### PR TITLE
Get develop up to date with main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Doxygen -> gh-pages](https://github.com/nextsimdg/nextsimdg/actions/workflows/doxygen.yml/badge.svg)](https://nextsimdg.github.io/nextsimdg/index.html) 
 [![Documentation Status](https://readthedocs.org/projects/nextsim-dg/badge/?version=latest)](https://nextsim-dg.readthedocs.io/en/latest/?badge=latest)
+[![compile code and tests](https://github.com/nextsimdg/nextsimdg/actions/workflows/compile.yml/badge.svg)](https://github.com/nextsimdg/nextsimdg/actions/workflows/compile.yml)
 
 # neXtSIM_DG : next generation sea-ice model with DG
 


### PR DESCRIPTION
``main`` is currently ahead of ``develop``, but this should never be the case. This PR just merges ``main`` into ``develop`` to fix that issue. It's a simple merge, as it's only a question of an addition to the README file.