### PR TITLE
Issue48 configmod

### DIFF
--- a/core/src/ConfiguredModule.cpp
+++ b/core/src/ConfiguredModule.cpp
@@ -27,6 +27,8 @@ ConfiguredModule::~ConfiguredModule()
 
 void ConfiguredModule::parseConfigurator()
 {
+    // A default string that can never be a valid C++ class name
+    std::string defaultStr = "+++DEFAULT+++";
     // Construct a new options map
     boost::program_options::options_description opt;
 
@@ -34,7 +36,7 @@ void ConfiguredModule::parseConfigurator()
     for (const std::string& module : loader.listModules()) {
         std::string defaultImpl = *loader.listImplementations(module).begin();
         opt.add_options()(addPrefix(module).c_str(),
-            boost::program_options::value<std::string>()->default_value(defaultImpl),
+            boost::program_options::value<std::string>()->default_value(defaultStr),
             ("Load an implementation of " + module).c_str());
     }
 
@@ -42,7 +44,10 @@ void ConfiguredModule::parseConfigurator()
 
     for (const std::string& module : loader.listModules()) {
         std::string implString = vm[addPrefix(module)].as<std::string>();
-        loader.setImplementation(module, implString);
+        // Only do anything if the retrieved option is not the default value
+        if (implString != defaultStr) {
+            loader.setImplementation(module, implString);
+        }
     }
 }
 

--- a/core/src/ConfiguredModule.cpp
+++ b/core/src/ConfiguredModule.cpp
@@ -11,6 +11,7 @@
 #include "include/ModuleLoader.hpp"
 
 #include <boost/program_options.hpp>
+#include <stdexcept>
 namespace Nextsim {
 
 const std::string ConfiguredModule::MODULE_PREFIX = "Modules";
@@ -52,7 +53,13 @@ void ConfiguredModule::parseConfigurator()
             for (const std::string implName : loader.listImplementations(module)) {
                 if (implString == implName) moduleImpl = implName;
             }
-            if (moduleImpl != "") loader.setImplementation(module, implString);
+            if (moduleImpl != "") {
+                loader.setImplementation(module, implString);
+            } else {
+                std::string what = "Invalid implementation \"";
+                what += implString + "\" of module " + module +".";
+                throw std::domain_error(what);
+            }
         }
     }
 }

--- a/core/src/ConfiguredModule.cpp
+++ b/core/src/ConfiguredModule.cpp
@@ -46,7 +46,13 @@ void ConfiguredModule::parseConfigurator()
         std::string implString = vm[addPrefix(module)].as<std::string>();
         // Only do anything if the retrieved option is not the default value
         if (implString != defaultStr) {
-            loader.setImplementation(module, implString);
+            // Check that the retrieved value is one of the implementations
+            // defined for this module
+            std::string moduleImpl = "";
+            for (const std::string implName : loader.listImplementations(module)) {
+                if (implString == implName) moduleImpl = implName;
+            }
+            if (moduleImpl != "") loader.setImplementation(module, implString);
         }
     }
 }

--- a/core/src/ModuleLoader.cpp
+++ b/core/src/ModuleLoader.cpp
@@ -47,3 +47,15 @@ void ModuleLoader::setImplementation(const std::string& module, const std::strin
 {
 #include "moduleLoaderAssignments.ipp"
 }
+
+void ModuleLoader::setDefault(const std::string& module)
+{
+    setImplementation(module, listImplementations(module).front());
+}
+
+void ModuleLoader::setAllDefaults()
+{
+    for (const std::string module : listModules()) {
+        setDefault(module);
+    }
+}

--- a/core/src/include/ModuleLoader.hpp
+++ b/core/src/include/ModuleLoader.hpp
@@ -81,6 +81,16 @@ public:
      */
     void setImplementation(const std::string& module, const std::string& impl);
 
+    /*!
+     * @brief Sets the default implementation for a module.
+     *
+     * @param module The module for which the default implementation is to be
+     * loaded.
+     */
+    void setDefault(const std::string& module);
+
+    //! Sets the default implementation for all modules.
+    void setAllDefaults();
 private:
     ModuleLoader() {};
 

--- a/core/test/ConfiguredModule_test.cpp
+++ b/core/test/ConfiguredModule_test.cpp
@@ -9,7 +9,6 @@
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
-#include </opt/home/include/catch2/catch.hpp> // FIXME!
 
 #include "ArgV.hpp"
 #include "moduleTestClasses.hpp"

--- a/core/test/ConfiguredModule_test.cpp
+++ b/core/test/ConfiguredModule_test.cpp
@@ -9,6 +9,7 @@
 
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
+#include </opt/home/include/catch2/catch.hpp> // FIXME!
 
 #include "ArgV.hpp"
 #include "moduleTestClasses.hpp"
@@ -45,6 +46,27 @@ TEST_CASE("Configure a module from a stream", "[Configurator, ModuleLoader]")
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
+    ConfiguredModule::parseConfigurator();
+
+    ITest& impler = ModuleLoader::getLoader().getImplementation<ITest>();
+    REQUIRE(impler() == 2);
+}
+
+TEST_CASE("Don't configure a module from a stream", "[Configurator, ModuleLoader]")
+{
+    Configurator::clear();
+    std::stringstream config;
+    config << "[Modules]" << std::endl
+            << "ITestNotReally = NotImpl2" << std::endl;
+
+    // Set the implementation to not the default
+    ModuleLoader::getLoader().setImplementation("ITest", "Impl2");
+
+    std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
+    Configurator::addStream(std::move(pcstream));
+
+    // Parse the available modules. This should not change the implementation
+    // to the default.
     ConfiguredModule::parseConfigurator();
 
     ITest& impler = ModuleLoader::getLoader().getImplementation<ITest>();

--- a/core/test/ConfiguredModule_test.cpp
+++ b/core/test/ConfiguredModule_test.cpp
@@ -73,5 +73,19 @@ TEST_CASE("Don't configure a module from a stream", "[Configurator, ModuleLoader
     REQUIRE(impler() == 2);
 }
 
+TEST_CASE("Configure a module with an incorrect name", "[Configurator, ModuleLoader]")
+{
+    Configurator::clear();
+    std::stringstream config;
+    config << "[Modules]" << std::endl
+            << "ITest = Graham" << std::endl;
+
+    std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
+    Configurator::addStream(std::move(pcstream));
+
+    // Should throw a domain_error as "Graham" is not a valid implementation.
+    REQUIRE_THROWS_AS(ConfiguredModule::parseConfigurator(), std::domain_error);
+
+}
 
 }

--- a/physics/test/NextsimPhysics_test.cpp
+++ b/physics/test/NextsimPhysics_test.cpp
@@ -94,6 +94,7 @@ TEST_CASE("New ice formation", "[NextsimPhysics]")
     double cice = 0.5;
     double dml = 10.; // m
 
+    ModuleLoader::getLoader().setAllDefaults();
     ConfiguredModule::parseConfigurator();
     data.configure(); // Configure with the default linear freezing point
 
@@ -135,6 +136,7 @@ TEST_CASE("Drag pressure", "[NextsimPhysics]")
     double cice = 0.5;
     double dml = 10.; // m
 
+    ModuleLoader::getLoader().setAllDefaults();
     ConfiguredModule::parseConfigurator();
     data.configure(); // Configure with the default linear freezing point
 
@@ -201,6 +203,7 @@ TEST_CASE("Melting conditions", "[NextsimPhysics]")
     double hsnow = 0.01; // m
     double dml = 10.; // m
 
+    ModuleLoader::getLoader().setAllDefaults();
     ConfiguredModule::parseConfigurator();
     tryConfigure(ModuleLoader::getLoader().getImplementation<IIceAlbedo>());
     data.configure(); // Configure with the UNESCO freezing point
@@ -270,6 +273,7 @@ TEST_CASE("Freezing conditions", "[NextsimPhysics]")
     double hsnow = 0.01; // m
     double dml = 10.; // m
 
+    ModuleLoader::getLoader().setAllDefaults();
     ConfiguredModule::parseConfigurator();
     tryConfigure(ModuleLoader::getLoader().getImplementation<IIceAlbedo>());
     data.configure(); // Configure with the UNESCO freezing point


### PR DESCRIPTION
Ensure that performing the parsing with ConfiguredModule does not wipe out previously configured modules. Also provide a way of loading the default implementations if required.

Fixes #48 .