### PR TITLE
Use CMake imported target for Boost dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,13 +56,12 @@ add_executable(nextsim "${NextsimSources}")
 
 target_include_directories(nextsim PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
-    "${Boost_INCLUDE_DIRS}"
     "${ModuleLoaderIppTargetDirectory}"
     "${NextsimIncludeDirs}"
     "${netCDF_INCLUDE_DIR}"
     )
 target_link_directories(nextsim PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(nextsim LINK_PUBLIC ${Boost_LIBRARIES} "${NSDG_NetCDF_Library}")
+target_link_libraries(nextsim LINK_PUBLIC Boost::program_options "${NSDG_NetCDF_Library}")
 
 #The parse_modules target is inherited from src
 add_dependencies(nextsim parse_modules)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(testCommandLineParser
     "${SRC_DIR}/CommandLineParser.cpp"
     )
 target_include_directories(testCommandLineParser PRIVATE ${Boost_INCLUDE_DIRS})
-target_link_libraries(testCommandLineParser LINK_PUBLIC ${Boost_LIBRARIES} Catch2::Catch2)
+target_link_libraries(testCommandLineParser LINK_PUBLIC Boost::program_options Catch2::Catch2)
 
 add_executable(testConfigurator
     "Configurator_test.cpp"
@@ -46,13 +46,13 @@ add_executable(testConfigurator
     "${SRC_DIR}/Configurator.cpp"
     )
 target_include_directories(testConfigurator PRIVATE ${Boost_INCLUDE_DIRS})
-target_link_libraries(testConfigurator LINK_PUBLIC ${Boost_LIBRARIES} Catch2::Catch2)
+target_link_libraries(testConfigurator LINK_PUBLIC Boost::program_options Catch2::Catch2)
 
 add_executable(testEnumWrapper
     "EnumWrapper_test.cpp"
     )
 target_include_directories(testEnumWrapper PRIVATE ${Boost_INCLUDE_DIRS})
-target_link_libraries(testEnumWrapper LINK_PUBLIC ${Boost_LIBRARIES} Catch2::Catch2)
+target_link_libraries(testEnumWrapper LINK_PUBLIC Boost::program_options Catch2::Catch2)
 
 # Set the location of the test module loader classes
 set(TEST_IPP_DIR "${CMAKE_CURRENT_SOURCE_DIR}/ModuleLoaderTestModules")
@@ -72,7 +72,7 @@ add_executable(testConfiguredModule
     "${SRC_DIR}/ConfiguredModule.cpp"
 )
 target_include_directories(testConfiguredModule PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${INCLUDE_DIR}" "${TEST_IPP_DIR}" ${Boost_INCLUDE_DIRS})
-target_link_libraries(testConfiguredModule PRIVATE Catch2::Catch2 ${Boost_LIBRARIES})
+target_link_libraries(testConfiguredModule PRIVATE Catch2::Catch2 Boost::program_options)
 
 add_executable(testTimer
     "Timer_test.cpp"
@@ -119,7 +119,7 @@ add_executable(testElementData
     )
 
 target_include_directories(testElementData PRIVATE "${ModuleLoaderIppTargetDirectory}" "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}")
-target_link_libraries(testElementData PRIVATE "${Boost_LIBRARIES}" Catch2::Catch2)
+target_link_libraries(testElementData PRIVATE Boost::program_options Catch2::Catch2)
 
 add_executable(exampleDevGridOutput
     "DevGrid_example.cpp"
@@ -140,7 +140,7 @@ add_executable(exampleDevGridOutput
 
 target_include_directories(exampleDevGridOutput PUBLIC "${ModuleLoaderIppTargetDirectory}" "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}")
 target_link_directories(exampleDevGridOutput PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(exampleDevGridOutput LINK_PUBLIC "${Boost_LIBRARIES}" Catch2::Catch2 "${NSDG_NetCDF_Library}")
+target_link_libraries(exampleDevGridOutput LINK_PUBLIC Boost::program_options Catch2::Catch2 "${NSDG_NetCDF_Library}")
 
 add_executable(testDevGrid
     "DevGrid_test.cpp"
@@ -161,7 +161,7 @@ add_executable(testDevGrid
 
 target_include_directories(testDevGrid PUBLIC "${ModuleLoaderIppTargetDirectory}" "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}")
 target_link_directories(testDevGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testDevGrid LINK_PUBLIC "${Boost_LIBRARIES}" Catch2::Catch2 "${NSDG_NetCDF_Library}")
+target_link_libraries(testDevGrid LINK_PUBLIC Boost::program_options Catch2::Catch2 "${NSDG_NetCDF_Library}")
 
 add_executable(testStructureFactory
     "StructureFactory_test.cpp"
@@ -184,4 +184,4 @@ add_executable(testStructureFactory
 
 target_include_directories(testStructureFactory PRIVATE "${ModuleLoaderIppTargetDirectory}" "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}")
 target_link_directories(testStructureFactory PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testStructureFactory PRIVATE "${Boost_LIBRARIES}" Catch2::Catch2 "${NSDG_NetCDF_Library}")
+target_link_libraries(testStructureFactory PRIVATE Boost::program_options Catch2::Catch2 "${NSDG_NetCDF_Library}")

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -38,7 +38,7 @@ target_include_directories(testNextsimPhysics PRIVATE
     "${ModulesDir}"
     "${netCDF_INCLUDE_DIR}"
     )
-target_link_libraries(testNextsimPhysics PRIVATE "${Boost_LIBRARIES}" Catch2::Catch2)
+target_link_libraries(testNextsimPhysics PRIVATE Boost::program_options Catch2::Catch2)
 
 #add_executable(testThermoIce0
 #    "ThermoIce0_test.cpp"


### PR DESCRIPTION
When both variables and imported targets are provided for
packages, projects should prefer the latter due to their
superior robustness and better integration with CMake’s
transitive dependency features.