### PR TITLE
Address issue where model crashes without command line options (#78)

### DIFF
--- a/core/src/CommandLineParser.cpp
+++ b/core/src/CommandLineParser.cpp
@@ -45,7 +45,7 @@ CommandLineParser::CommandLineParser(int argc, char* argv[])
     boost::program_options::store(parsed, m_arguments);
 
     // Print help and exit
-    if (m_arguments.count("help") || m_arguments.size()==0) {
+    if (m_arguments.count("help") || m_arguments.empty()) {
         std::cerr << opt << std::endl;
         std::exit(EXIT_SUCCESS);
     }

--- a/core/src/CommandLineParser.cpp
+++ b/core/src/CommandLineParser.cpp
@@ -45,7 +45,7 @@ CommandLineParser::CommandLineParser(int argc, char* argv[])
     boost::program_options::store(parsed, m_arguments);
 
     // Print help and exit
-    if (m_arguments.count("help")) {
+    if (m_arguments.count("help") || m_arguments.size()==0) {
         std::cerr << opt << std::endl;
         std::exit(EXIT_SUCCESS);
     }


### PR DESCRIPTION
I added a simple check for the length of ``m_arguments`` in ``CommandLineParser.cpp``. This means the help message is printed when no command line options are given.

This is just me familiarising myself better with the code :)