### PR TITLE
Convert ModelArray to Eigen::Array

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ else()
 endif()
 find_package(Boost COMPONENTS program_options log REQUIRED)
 find_package(Catch2 REQUIRED)
+find_package(Eigen3 3.3 REQUIRED)
 
 # To add netCDF to a target:
 # target_include_directories(target PUBLIC ${netCDF_INCLUDE_DIR})
@@ -62,4 +63,4 @@ target_include_directories(nextsim PRIVATE
     "${netCDF_INCLUDE_DIR}"
     )
 target_link_directories(nextsim PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(nextsim LINK_PUBLIC ${Boost_LIBRARIES} "${NSDG_NetCDF_Library}")
+target_link_libraries(nextsim LINK_PUBLIC ${Boost_LIBRARIES} "${NSDG_NetCDF_Library}" Eigen3::Eigen)

--- a/core/src/ModelArray.cpp
+++ b/core/src/ModelArray.cpp
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <cstdarg>
+#include <iterator>
 #include <set>
 #include <utility>
 
@@ -22,6 +23,7 @@ const std::map<ModelArray::Type, std::string> ModelArray::typeNames = {
     { ModelArray::Type::U, "UField" },
     { ModelArray::Type::V, "VField" },
     { ModelArray::Type::Z, "ZField" },
+    { ModelArray::Type::DG, "DGHField--DO-NOT-USE--" },
 };
 
 ModelArray::ModelArray(const Type type, const std::string& name)
@@ -29,7 +31,7 @@ ModelArray::ModelArray(const Type type, const std::string& name)
     , m_name(name)
 {
     if (m_sz.at(type) > 0) {
-        m_data.reserve(m_sz.at(type));
+        m_data.resize(m_sz.at(type), nComponents());
     }
 }
 
@@ -41,14 +43,14 @@ ModelArray::ModelArray()
 ModelArray::ModelArray(const ModelArray& orig)
     : ModelArray(orig.type, orig.m_name)
 {
-    setData(orig.m_data.data());
+    setData(orig.m_data);
 }
 
 ModelArray& ModelArray::operator=(const ModelArray& orig)
 {
     type = orig.type;
     m_name = orig.m_name;
-    setData(orig.m_data.data());
+    setData(orig.m_data);
 
     return *this;
 }
@@ -56,10 +58,10 @@ ModelArray& ModelArray::operator=(const ModelArray& orig)
 void ModelArray::setData(const double* pData)
 {
     resize();
-    m_data.assign(pData, pData + m_sz.at(type));
+    std::copy(pData, pData + m_sz.at(type), m_data.data());
 }
 
-void ModelArray::setData(const std::vector<double>& from) { setData(from.data()); }
+void ModelArray::setData(const DataType& from) { setData(from.data()); }
 
 void ModelArray::setDimensions(Type type, const Dimensions& newDims)
 {

--- a/core/src/ModelArray.cpp
+++ b/core/src/ModelArray.cpp
@@ -74,6 +74,69 @@ void ModelArray::setDimensions(Type type, const Dimensions& newDims)
     m_sz.at(type) = newSize;
 }
 
+inline size_t indexr(size_t i, size_t j, const size_t* d) { return i * d[1] + j; }
+
+inline size_t indexr(size_t i, size_t j, size_t k, const size_t* d)
+{
+    size_t dLast = d[2];
+    return indexr(i * dLast, j * dLast + k, d);
+}
+
+inline size_t indexr(size_t i, size_t j, size_t k, size_t l, const size_t* d)
+{
+    size_t dLast = d[3];
+    return indexr(i * dLast, j * dLast, k * dLast + l, d);
+}
+
+inline size_t indexr(size_t i, size_t j, size_t k, size_t l, size_t m, const size_t* d)
+{
+    size_t dLast = d[4];
+    return indexr(i * dLast, j * dLast, k * dLast, l * dLast + m, d);
+}
+
+inline size_t indexr(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n, const size_t* d)
+{
+    size_t dLast = d[5];
+    return indexr(i * dLast, j * dLast, k * dLast, l * dLast, m * dLast + n, d);
+}
+
+inline size_t indexr(
+    size_t i, size_t j, size_t k, size_t l, size_t m, size_t n, size_t p, const size_t* d)
+{
+    size_t dLast = d[6];
+    return indexr(i * dLast, j * dLast, k * dLast, l * dLast, m * dLast, n * dLast + p, d);
+}
+
+inline size_t indexr(
+    size_t i, size_t j, size_t k, size_t l, size_t m, size_t n, size_t p, size_t q, const size_t* d)
+{
+    size_t dLast = d[6];
+    return indexr(
+        i * dLast, j * dLast, k * dLast, l * dLast, m * dLast, n * dLast, p * dLast + q, d);
+}
+
+size_t indexr(const ModelArray::Dimensions& loc, const size_t* dims)
+{
+    switch (loc.size()) {
+    case (1):
+        return loc[0];
+    case (2):
+        return indexr(loc[0], loc[1], dims);
+    case (3):
+        return indexr(loc[0], loc[1], loc[2], dims);
+    case (4):
+        return indexr(loc[0], loc[1], loc[2], loc[3], dims);
+    case (5):
+        return indexr(loc[0], loc[1], loc[2], loc[3], loc[4], dims);
+    case (6):
+        return indexr(loc[0], loc[1], loc[2], loc[3], loc[4], loc[5], dims);
+    case (7):
+        return indexr(loc[0], loc[1], loc[2], loc[3], loc[4], loc[5], loc[6], dims);
+    default:
+        return indexr(loc[0], loc[1], loc[2], loc[3], loc[4], loc[5], loc[6], loc[7], dims);
+    }
+}
+
 const double& ModelArray::operator[](const Dimensions& dims) const
 {
     switch (dims.size()) {
@@ -98,46 +161,40 @@ const double& ModelArray::operator[](const Dimensions& dims) const
 
 const double& ModelArray::operator()(size_t i, size_t j) const
 {
-    return (*this)(i * m_dims.at(type)[1] + j);
+    return (*this)(indexr(i, j, dimensions().data()));
 }
 
 const double& ModelArray::operator()(size_t i, size_t j, size_t k) const
 {
-    size_t dim2 = m_dims.at(type)[2];
-    return (*this)(i * dim2, j * dim2 + k);
+    return (*this)(indexr(i, j, k, dimensions().data()));
 }
 
 const double& ModelArray::operator()(size_t i, size_t j, size_t k, size_t l) const
 {
-    size_t dim3 = m_dims.at(type)[3];
-    return (*this)(i * dim3, j * dim3, k * dim3 + l);
+    return (*this)(indexr(i, j, k, l, dimensions().data()));
 }
 
 const double& ModelArray::operator()(size_t i, size_t j, size_t k, size_t l, size_t m) const
 {
-    size_t dim4 = m_dims.at(type)[4];
-    return (*this)(i * dim4, j * dim4, k * dim4, l * dim4 + m);
+    return (*this)(indexr(i, j, k, l, m, dimensions().data()));
 }
 
 const double& ModelArray::operator()(
     size_t i, size_t j, size_t k, size_t l, size_t m, size_t n) const
 {
-    size_t dim5 = m_dims.at(type)[5];
-    return (*this)(i * dim5, j * dim5, k * dim5, l * dim5, m * dim5 + n);
+    return (*this)(indexr(i, j, k, l, m, n, dimensions().data()));
 }
 
 const double& ModelArray::operator()(
     size_t i, size_t j, size_t k, size_t l, size_t m, size_t n, size_t p) const
 {
-    size_t dim6 = m_dims.at(type)[6];
-    return (*this)(i * dim6, j * dim6, k * dim6, l * dim6, m * dim6, n * dim6 + p);
+    return (*this)(indexr(i, j, k, l, m, n, p, dimensions().data()));
 }
 
 const double& ModelArray::operator()(
     size_t i, size_t j, size_t k, size_t l, size_t m, size_t n, size_t p, size_t q) const
 {
-    size_t dim7 = m_dims.at(type)[7];
-    return (*this)(i * dim7, j * dim7, k * dim7, l * dim7, m * dim7, n * dim7, p * dim7 + q);
+    return (*this)(indexr(i, j, k, l, m, n, p, q, dimensions().data()));
 }
 
 double& ModelArray::operator[](const Dimensions& dims)
@@ -174,4 +231,8 @@ double& ModelArray::operator()(
     return const_cast<double&>(std::as_const(*this)(i, j, k, l, m, n, p, q));
 }
 
+ModelArray::Component ModelArray::components(const Dimensions& loc)
+{
+    return components(indexr(loc, dimensions().data()));
+}
 } /* namespace Nextsim */

--- a/core/src/include/ModelArray.hpp
+++ b/core/src/include/ModelArray.hpp
@@ -15,6 +15,8 @@
 
 namespace Nextsim {
 
+const static int DGdegree = 0; // TODO: Replace with the same source as the dynamics
+const static int CellDoF = (DGdegree == 0 ? 1 : (DGdegree == 1 ? 3 : (DGdegree == 2 ? 6 : -1)));
 class ModelArray {
 public:
     enum class Type {

--- a/core/src/include/ModelArray.hpp
+++ b/core/src/include/ModelArray.hpp
@@ -53,6 +53,18 @@ public:
     typedef Eigen::Array<double, Eigen::Dynamic, Eigen::Dynamic, majority> DataType;
 //    typedef std::vector<double> DataType;
 
+    class Component : Eigen::Array<double, 1, Eigen::Dynamic> {
+    public:
+        Component()
+            : Eigen::Array<double, 1, Eigen::Dynamic>()
+        {
+        }
+        Component(const Eigen::Array<double, 1, Eigen::Dynamic>& other)
+            : Eigen::Array<double, 1, Eigen::Dynamic>(other)
+        {
+        }
+    };
+
     static ModelArray HField(const std::string& name) { return ModelArray(Type::H, name); }
     static ModelArray UField(const std::string& name) { return ModelArray(Type::U, name); }
     static ModelArray VField(const std::string& name) { return ModelArray(Type::V, name); }
@@ -120,6 +132,23 @@ public:
     double& operator()(size_t i, size_t j, size_t k, size_t l, size_t m, size_t n, size_t p);
     double& operator()(
         size_t i, size_t j, size_t k, size_t l, size_t m, size_t n, size_t p, size_t q);
+
+    /*!
+     * @brief Accesses the full Discontinuous Galerkin coefficient vector at
+     * the indexed location.
+     *
+     * @param i one-dimensional index of the target point.
+     */
+    Component components(size_t i) {
+        return Component(m_data.col(i));
+    }
+
+    /*!
+     * @brief Accesses the full Discontinuous Galerkin coefficient vector at the specified location.
+     *
+     * @param dims indexing argument of the target point.
+     */
+    Component components(const Dimensions& loc);
 
     /*!
      * @brief Special access function for ZFields.

--- a/core/src/include/ModelArray.hpp
+++ b/core/src/include/ModelArray.hpp
@@ -96,7 +96,7 @@ public:
     const double& operator[](size_t i) const { return m_data(i, 0); }
     const double& operator[](const Dimensions& dims) const;
 
-    const double& operator()(size_t i) const { return this->operator[](i); }
+    const double& operator()(size_t i) const { return (*this)[i]; }
     const double& operator()(size_t i, size_t j) const;
     const double& operator()(size_t i, size_t j, size_t k) const;
     const double& operator()(size_t i, size_t j, size_t k, size_t l) const;
@@ -108,10 +108,10 @@ public:
         size_t i, size_t j, size_t k, size_t l, size_t m, size_t n, size_t p, size_t q) const;
 
     //! One dimensional indexing
-    double& operator[](size_t i) { return m_data(i, 0); }
+    double& operator[](size_t i) { return const_cast<double&>(std::as_const(*this)(i)); }
     double& operator[](const Dimensions&);
     //! Multi (one) dimensional indexing
-    double& operator()(size_t i) { return this->operator[](i); }
+    double& operator()(size_t i) { return (*this)[i]; }
     double& operator()(size_t i, size_t j);
     double& operator()(size_t i, size_t j, size_t k);
     double& operator()(size_t i, size_t j, size_t k, size_t l);

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -153,7 +153,7 @@ add_executable(testDevGrid
 
 target_include_directories(testDevGrid PUBLIC "${ModuleLoaderIppTargetDirectory}" "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}")
 target_link_directories(testDevGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testDevGrid LINK_PUBLIC "${Boost_LIBRARIES}" Catch2::Catch2 "${NSDG_NetCDF_Library}")
+target_link_libraries(testDevGrid LINK_PUBLIC "${Boost_LIBRARIES}" Catch2::Catch2 "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
 add_executable(testRectGrid
     "RectGrid_test.cpp"
@@ -181,7 +181,7 @@ add_executable(testRectGrid
 
 target_include_directories(testRectGrid PUBLIC "${ModuleLoaderIppTargetDirectory}" "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}")
 target_link_directories(testRectGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testRectGrid LINK_PUBLIC Boost::program_options Catch2::Catch2 "${NSDG_NetCDF_Library}")
+target_link_libraries(testRectGrid LINK_PUBLIC Boost::program_options Catch2::Catch2 "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
 add_executable(testStructureFactory
     "StructureFactory_test.cpp"
@@ -213,7 +213,7 @@ add_executable(testStructureFactory
 
 target_include_directories(testStructureFactory PRIVATE "${ModuleLoaderIppTargetDirectory}" "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}")
 target_link_directories(testStructureFactory PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testStructureFactory PRIVATE "${Boost_LIBRARIES}" Catch2::Catch2 "${NSDG_NetCDF_Library}")
+target_link_libraries(testStructureFactory PRIVATE "${Boost_LIBRARIES}" Catch2::Catch2 "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
 add_executable(testModelArray
     "ModelArray_test.cpp"
@@ -221,7 +221,7 @@ add_executable(testModelArray
     )
 
 target_include_directories(testModelArray PRIVATE "${CoreSrc}")
-target_link_libraries(testModelArray PRIVATE Catch2::Catch2)
+target_link_libraries(testModelArray PRIVATE Catch2::Catch2 Eigen3::Eigen)
 
 add_executable(testModelModule
     "ModelModule_test.cpp"
@@ -230,4 +230,4 @@ add_executable(testModelModule
 )
 
 target_include_directories(testModelModule PRIVATE "${CoreSrc}")
-target_link_libraries(testModelModule PRIVATE Catch2::Catch2)
+target_link_libraries(testModelModule PRIVATE Catch2::Catch2 Eigen3::Eigen)

--- a/core/test/ModelArray_test.cpp
+++ b/core/test/ModelArray_test.cpp
@@ -91,6 +91,33 @@ TEST_CASE("Higher dimensional indexing", "[ModelArray]")
     REQUIRE(check4d[{4, 7, 2, 6}] == 4726);
 }
 
+TEST_CASE("Higher dimensional indexing 2", "[ModelArray]")
+{
+    ModelArray::Dimensions dims4 = {3, 5, 7, 11};
+    size_t totalSize = dims4[0] * dims4[1] * dims4[2] * dims4[3];
+    ModelArray::setDimensions(ModelArray::Type::H, dims4);
+
+    HField primorial = ModelArray::HField("primorial");
+
+    REQUIRE(primorial.nDimensions() == 4);
+    REQUIRE(primorial.size() == totalSize);
+
+    for (size_t i = 0; i < primorial.size(); ++i) {
+        primorial[i] = i;
+    }
+
+    size_t i = 2;
+    size_t j = 4;
+    size_t k = 5;
+    size_t l = 7;
+
+    size_t target = (((i) * dims4[1] + j) * dims4[2] + k) * dims4[3] + l;
+    REQUIRE(primorial[target] == target);
+
+    REQUIRE(primorial(i, j, k, l) == target);
+
+}
+
 TEST_CASE("Naming", "[ModelArray]")
 {
     std::string dataName = "u10m";

--- a/core/test/ModelArray_test.cpp
+++ b/core/test/ModelArray_test.cpp
@@ -83,7 +83,7 @@ TEST_CASE("Higher dimensional indexing", "[ModelArray]")
         vData[i] = i;
     }
 
-    check4d.setData(vData);
+    check4d.setData(vData.data());
 
     REQUIRE(check4d(4, 7, 2, 5) == 4725);
 


### PR DESCRIPTION
ModelArray is now based on Eigen::Array. This should permit easier communication between the physics and dynamics parts of NextSIM_DG.

Also add support (or rather space to support) DG fields in the same way as in the dynamics code.