### PR TITLE
Issue140 Ice calculation

### DIFF
--- a/physics/src/AtmosphereOceanState.cpp
+++ b/physics/src/AtmosphereOceanState.cpp
@@ -15,19 +15,10 @@ AtmosphereOceanState::AtmosphereOceanState() { }
 
 void AtmosphereOceanState::setData(const ModelState::DataMap& ms)
 {
-//    registerProtectedArray(ProtectedArray::HTRUE_ICE, &hTrueIce);
-//    registerProtectedArray(ProtectedArray::HTRUE_SNOW, &hTrueSnow);
     atmosStateImpl->setData(ms);
     oceanStateImpl->setData(ms);
 }
-ModelState AtmosphereOceanState::getState() const
-{
-    return { {
-//                 { "True ice thickness", hTrueIce },
-//                 { "True snow thickness", hTrueSnow },
-             },
-        {} };
-}
+ModelState AtmosphereOceanState::getState() const { return { {}, {} }; }
 ModelState AtmosphereOceanState::getState(const OutputLevel&) const { return getState(); }
 ModelState AtmosphereOceanState::getStateRecursive(const OutputSpec& os) const
 {
@@ -63,9 +54,6 @@ void AtmosphereOceanState::update(const TimestepTime& tst)
 {
     atmosStateImpl->update(tst);
     oceanStateImpl->update(tst);
-//
-//    hTrueSnow = hSnowCell / cIce;
-//    hTrueIce = hIceCell / cIce;
 }
 
 } /* namespace Nextsim */

--- a/physics/src/AtmosphereOceanState.cpp
+++ b/physics/src/AtmosphereOceanState.cpp
@@ -15,16 +15,16 @@ AtmosphereOceanState::AtmosphereOceanState() { }
 
 void AtmosphereOceanState::setData(const ModelState::DataMap& ms)
 {
-    registerProtectedArray(ProtectedArray::HTRUE_ICE, &hTrueIce);
-    registerProtectedArray(ProtectedArray::HTRUE_SNOW, &hTrueSnow);
+//    registerProtectedArray(ProtectedArray::HTRUE_ICE, &hTrueIce);
+//    registerProtectedArray(ProtectedArray::HTRUE_SNOW, &hTrueSnow);
     atmosStateImpl->setData(ms);
     oceanStateImpl->setData(ms);
 }
 ModelState AtmosphereOceanState::getState() const
 {
     return { {
-                 { "True ice thickness", hTrueIce },
-                 { "True snow thickness", hTrueSnow },
+//                 { "True ice thickness", hTrueIce },
+//                 { "True snow thickness", hTrueSnow },
              },
         {} };
 }
@@ -63,9 +63,9 @@ void AtmosphereOceanState::update(const TimestepTime& tst)
 {
     atmosStateImpl->update(tst);
     oceanStateImpl->update(tst);
-
-    hTrueSnow = hSnowCell / cIce;
-    hTrueIce = hIceCell / cIce;
+//
+//    hTrueSnow = hSnowCell / cIce;
+//    hTrueIce = hIceCell / cIce;
 }
 
 } /* namespace Nextsim */

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -42,7 +42,6 @@ IceGrowth::IceGrowth()
 
     registerProtectedArray(ProtectedArray::HTRUE_ICE, &hice0);
     registerProtectedArray(ProtectedArray::HTRUE_SNOW, &hsnow0);
-
 }
 
 void IceGrowth::setData(const ModelState::DataMap& ms)
@@ -132,8 +131,8 @@ void IceGrowth::update(const TimestepTime& tsTime)
     // Copy the ice data from the prognostic fields to the modifiable fields.
     // Also divide by c_ice to go from cell-averaged to ice-averaged values.
     cice = cice0;
-    hice = hice0 = hSnowCell / cice0;
-    hsnow = hsnow0 = hIceCell / cice0;
+    hice = hice0 = hIceCell / cice0;
+    hsnow = hsnow0 = hSnowCell / cice0;
 
     iFluxes->update(tsTime);
 

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -129,10 +129,10 @@ void IceGrowth::update(const TimestepTime& tsTime)
 {
 
     // Copy the ice data from the prognostic fields to the modifiable fields.
-    // Also divide by c_ice to go from cell-averaged to ice-averaged values.
     cice = cice0;
-    hice = hice0 = hIceCell / cice0;
-    hsnow = hsnow0 = hSnowCell / cice0;
+    overElements(
+        std::bind(&IceGrowth::initializeThicknesses, this, std::placeholders::_1, std::placeholders::_2),
+        tsTime);
 
     iFluxes->update(tsTime);
 
@@ -141,6 +141,19 @@ void IceGrowth::update(const TimestepTime& tsTime)
     overElements(
         std::bind(&IceGrowth::updateWrapper, this, std::placeholders::_1, std::placeholders::_2),
         tsTime);
+}
+
+// Divide by ice concentration to go from cell-averaged to ice-averaged values,
+// but only if ice concentration is non-zero.
+void IceGrowth::initializeThicknesses(size_t i, const TimestepTime&)
+{
+    if (cice0[i] > 0) {
+        hice[i] = hice0[i] = hIceCell[i] / cice0[i];
+        hsnow[i] = hsnow0[i] = hSnowCell[i] / cice0[i];
+    } else {
+        hice[i] = hice0[i] = 0.;
+        hsnow[i] = hsnow0[i] = 0.;
+    }
 }
 
 void IceGrowth::newIceFormation(size_t i, const TimestepTime& tst)

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -35,10 +35,14 @@ IceGrowth::IceGrowth()
     , deltaCMelt(ModelArray::Type::H)
 {
     registerModule();
-    ModelComponent::registerSharedArray(SharedArray::H_ICE, &hice);
-    ModelComponent::registerSharedArray(SharedArray::C_ICE, &cice);
-    ModelComponent::registerSharedArray(SharedArray::H_SNOW, &hsnow);
-    ModelComponent::registerSharedArray(SharedArray::NEW_ICE, &newice);
+    registerSharedArray(SharedArray::H_ICE, &hice);
+    registerSharedArray(SharedArray::C_ICE, &cice);
+    registerSharedArray(SharedArray::H_SNOW, &hsnow);
+    registerSharedArray(SharedArray::NEW_ICE, &newice);
+
+    registerProtectedArray(ProtectedArray::HTRUE_ICE, &hice0);
+    registerProtectedArray(ProtectedArray::HTRUE_SNOW, &hsnow0);
+
 }
 
 void IceGrowth::setData(const ModelState::DataMap& ms)
@@ -124,12 +128,14 @@ ConfigMap IceGrowth::getConfiguration() const
 
 void IceGrowth::update(const TimestepTime& tsTime)
 {
-    iFluxes->update(tsTime);
+
     // Copy the ice data from the prognostic fields to the modifiable fields.
     // Also divide by c_ice to go from cell-averaged to ice-averaged values.
     cice = cice0;
-    hice = hice0;
-    hsnow = hsnow0;
+    hice = hice0 = hSnowCell / cice0;
+    hsnow = hsnow0 = hIceCell / cice0;
+
+    iFluxes->update(tsTime);
 
     iVertical->update(tsTime);
     // new ice formation

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -130,8 +130,8 @@ void IceGrowth::update(const TimestepTime& tsTime)
 
     // Copy the ice data from the prognostic fields to the modifiable fields.
     cice = cice0;
-    overElements(
-        std::bind(&IceGrowth::initializeThicknesses, this, std::placeholders::_1, std::placeholders::_2),
+    overElements(std::bind(&IceGrowth::initializeThicknesses, this, std::placeholders::_1,
+                     std::placeholders::_2),
         tsTime);
 
     iFluxes->update(tsTime);

--- a/physics/src/include/AtmosphereOceanState.hpp
+++ b/physics/src/include/AtmosphereOceanState.hpp
@@ -38,13 +38,6 @@ public:
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
 protected:
-//    HField hTrueSnow;
-//    HField hTrueIce;
-//
-//    ModelArrayRef<ProtectedArray::H_SNOW> hSnowCell;
-//    ModelArrayRef<ProtectedArray::H_ICE> hIceCell;
-//    ModelArrayRef<ProtectedArray::C_ICE> cIce;
-
     std::unique_ptr<AtmosphereState> atmosStateImpl;
     std::unique_ptr<OceanState> oceanStateImpl;
 };

--- a/physics/src/include/AtmosphereOceanState.hpp
+++ b/physics/src/include/AtmosphereOceanState.hpp
@@ -38,12 +38,12 @@ public:
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
 protected:
-    HField hTrueSnow;
-    HField hTrueIce;
-
-    ModelArrayRef<ProtectedArray::H_SNOW> hSnowCell;
-    ModelArrayRef<ProtectedArray::H_ICE> hIceCell;
-    ModelArrayRef<ProtectedArray::C_ICE> cIce;
+//    HField hTrueSnow;
+//    HField hTrueIce;
+//
+//    ModelArrayRef<ProtectedArray::H_SNOW> hSnowCell;
+//    ModelArrayRef<ProtectedArray::H_ICE> hIceCell;
+//    ModelArrayRef<ProtectedArray::C_ICE> cIce;
 
     std::unique_ptr<AtmosphereState> atmosStateImpl;
     std::unique_ptr<OceanState> oceanStateImpl;

--- a/physics/src/include/IceGrowth.hpp
+++ b/physics/src/include/IceGrowth.hpp
@@ -100,6 +100,7 @@ private:
         lateralIceSpread(i, tst);
         applyLimits(i, tst);
     }
+    void initializeThicknesses(size_t i, const TimestepTime&);
 };
 
 } /* namespace Nextsim */

--- a/physics/src/include/IceGrowth.hpp
+++ b/physics/src/include/IceGrowth.hpp
@@ -69,14 +69,16 @@ private:
     HField cice; // Updated ice concentration
     HField hsnow; // Updated true snow thickness, m
     HField newice; // New ice over open water this timestep, m
+    HField hice0; // Timestep initial true ice thickness, m
+    HField hsnow0; // Timestep initial true snow thickness, m
 
     // Owned data fields, not shared
     HField deltaCFreeze; // New ice concentration due to freezing (+ve)
     HField deltaCMelt; // Ice concentration loss due to melting (-ve)
 
-    ModelArrayRef<ProtectedArray::HTRUE_ICE> hice0; // initial ice thickness (ice averaged)
-    ModelArrayRef<ProtectedArray::C_ICE> cice0; // initial ice concentration
-    ModelArrayRef<ProtectedArray::HTRUE_SNOW> hsnow0; // initial snow thickness (ice averaged)
+    ModelArrayRef<ProtectedArray::H_ICE> hIceCell; // Timestep initial cell averaged ice thickness, m
+    ModelArrayRef<ProtectedArray::H_SNOW> hSnowCell; // Timestep initial cell averaged snow thickness, m
+    ModelArrayRef<ProtectedArray::C_ICE> cice0; // Timestep initial ice concentration
     ModelArrayRef<SharedArray::Q_OW, RW> qow; // open water heat flux, from FluxCalculation
     ModelArrayRef<ProtectedArray::ML_BULK_CP>
         mixedLayerBulkHeatCapacity; // J K⁻¹ m⁻², from atmospheric state

--- a/physics/src/include/IceGrowth.hpp
+++ b/physics/src/include/IceGrowth.hpp
@@ -76,8 +76,10 @@ private:
     HField deltaCFreeze; // New ice concentration due to freezing (+ve)
     HField deltaCMelt; // Ice concentration loss due to melting (-ve)
 
-    ModelArrayRef<ProtectedArray::H_ICE> hIceCell; // Timestep initial cell averaged ice thickness, m
-    ModelArrayRef<ProtectedArray::H_SNOW> hSnowCell; // Timestep initial cell averaged snow thickness, m
+    ModelArrayRef<ProtectedArray::H_ICE>
+        hIceCell; // Timestep initial cell averaged ice thickness, m
+    ModelArrayRef<ProtectedArray::H_SNOW>
+        hSnowCell; // Timestep initial cell averaged snow thickness, m
     ModelArrayRef<ProtectedArray::C_ICE> cice0; // Timestep initial ice concentration
     ModelArrayRef<SharedArray::Q_OW, RW> qow; // open water heat flux, from FluxCalculation
     ModelArrayRef<ProtectedArray::ML_BULK_CP>

--- a/physics/test/FiniteElementFluxes_test.cpp
+++ b/physics/test/FiniteElementFluxes_test.cpp
@@ -87,6 +87,9 @@ TEST_CASE("Melting conditions", "[FiniteElementFluxes]")
             registerProtectedArray(ProtectedArray::C_ICE, &cice);
             registerProtectedArray(ProtectedArray::H_SNOW, &hsnow);
             registerProtectedArray(ProtectedArray::T_ICE, &tice0);
+            registerProtectedArray(ProtectedArray::HTRUE_ICE, &hice0);
+            registerProtectedArray(ProtectedArray::HTRUE_SNOW, &hsnow0);
+
         }
         std::string getName() const override { return "ProgData"; }
 
@@ -97,12 +100,17 @@ TEST_CASE("Melting conditions", "[FiniteElementFluxes]")
             hice[0] = 0.1; // Here we are using the cell-averaged thicknesses
             hsnow[0] = 0.01;
             tice0[0] = -1.;
+
+            hice0[0] = hice[0] / cice[0];
+            hsnow0[0] = hsnow[0] / cice[0];
         }
 
         HField hice;
         HField cice;
         HField hsnow;
         HField tice0;
+        HField hice0;  // ice averaged ice thickness
+        HField hsnow0; // ice averaged snoew thickness
         ModelState getState() const override { return ModelState(); }
         ModelState getState(const OutputLevel&) const override { return getState(); }
     } iceState;

--- a/physics/test/IceGrowth_test.cpp
+++ b/physics/test/IceGrowth_test.cpp
@@ -40,9 +40,9 @@ TEST_CASE("New ice formation", "[IceGrowth]")
     public:
         AtmosphericData()
         {
-            registerProtectedArray(ProtectedArray::HTRUE_ICE, &hice);
+            registerProtectedArray(ProtectedArray::H_ICE, &hice);
             registerProtectedArray(ProtectedArray::C_ICE, &cice);
-            registerProtectedArray(ProtectedArray::HTRUE_SNOW, &hsnow);
+            registerProtectedArray(ProtectedArray::H_SNOW, &hsnow);
             registerProtectedArray(ProtectedArray::T_ICE, &tice0);
             registerProtectedArray(ProtectedArray::SST, &sst);
             registerProtectedArray(ProtectedArray::SSS, &sss);
@@ -56,8 +56,8 @@ TEST_CASE("New ice formation", "[IceGrowth]")
         {
             noLandMask();
             cice[0] = 0.5;
-            hice[0] = 0.2;
-            hsnow[0] = 0;
+            hice[0] = 0.1; // Cell averaged
+            hsnow[0] = 0; // Cell averaged
             tice0[0] = -2;
             sst[0] = -1.5;
             sss[0] = 32.;
@@ -141,9 +141,9 @@ TEST_CASE("Melting conditions", "[IceGrowth]")
     public:
         AtmosphericData()
         {
-            registerProtectedArray(ProtectedArray::HTRUE_ICE, &hice);
+            registerProtectedArray(ProtectedArray::H_ICE, &hice);
             registerProtectedArray(ProtectedArray::C_ICE, &cice);
-            registerProtectedArray(ProtectedArray::HTRUE_SNOW, &hsnow);
+            registerProtectedArray(ProtectedArray::H_SNOW, &hsnow);
             registerProtectedArray(ProtectedArray::T_ICE, &tice0);
             registerProtectedArray(ProtectedArray::SST, &sst);
             registerProtectedArray(ProtectedArray::SSS, &sss);
@@ -157,8 +157,8 @@ TEST_CASE("Melting conditions", "[IceGrowth]")
         {
             noLandMask();
             cice[0] = 0.5;
-            hice[0] = 0.1 / cice[0];
-            hsnow[0] = 0.01 / cice[0];
+            hice[0] = 0.1; // Cell averaged
+            hsnow[0] = 0.01; // Cell averaged
             tice0[0] = -1;
             sst[0] = -1;
             sss[0] = 32.;
@@ -222,9 +222,9 @@ TEST_CASE("Melting conditions", "[IceGrowth]")
     double prec = 1e-5;
     // The thickness values from old NextSIM are cell-averaged. Perform that
     // conversion here.
+    REQUIRE(cice[0] == Approx(0.368269).epsilon(prec));
     REQUIRE((hice[0] * cice[0]) == Approx(0.0473078).epsilon(prec));
     REQUIRE((hsnow[0] * cice[0]) == Approx(0.00720977).epsilon(prec));
-    REQUIRE(cice[0] == Approx(0.368269).epsilon(prec));
 
     REQUIRE(newice[0] == 0.0);
 }
@@ -268,8 +268,8 @@ TEST_CASE("Freezing conditions", "[IceGrowth]")
         {
             noLandMask();
             cice[0] = 0.5;
-            hice[0] = 0.1 / cice[0];
-            hsnow[0] = 0.01 / cice[0];
+            hice[0] = 0.1; // Cell averaged
+            hsnow[0] = 0.01; // Cell averaged
             tice0[0] = -9;
             sst[0] = -1.75;
             sss[0] = 32.;
@@ -333,9 +333,9 @@ TEST_CASE("Freezing conditions", "[IceGrowth]")
 
     // The thickness values from old NextSIM are cell-averaged. Perform that
     // conversion here.
+    REQUIRE(cice[0] == Approx(0.5002).epsilon(prec));
     REQUIRE((hice[0] * cice[0]) == Approx(0.100039).epsilon(prec));
     REQUIRE((hsnow[0] * cice[0]) == Approx(0.0109012).epsilon(prec));
-    REQUIRE(cice[0] == Approx(0.5002).epsilon(prec));
 
     REQUIRE(newice[0] == Approx(6.79906e-5).epsilon(prec));
 }


### PR DESCRIPTION
Move the calculation of the true (ice averaged) ice and snow thicknesses from `AtmosphereOceanState` to `IceGrowth` as the latter might not be called. If `IceGrowth::update()` is not called then the ice thicknesses are probably not needed.

Closes #140 