### PR TITLE
WIP: XIOS Integration (MVP) 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ set(CMAKE_CXX_STANDARD 17)
 
 project(nextsim_dg)
 
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/build")
+
 find_package(PkgConfig)
 pkg_search_module(NETCDF_CXX4 netcdf-cxx4)
 if (NETCDF_CXX4_FOUND)
@@ -30,6 +32,8 @@ if (OPENMP_FOUND)
    endif()
 endif()
 
+find_package(MPI REQUIRED)
+
 
 # Regarding Boost.Log, if our application consists of more
 # than one modules that use it, we must link to the shared
@@ -44,6 +48,17 @@ find_package(Boost COMPONENTS program_options log REQUIRED)
 
 find_package(Catch2 REQUIRED)
 find_package(Eigen3 3.4 REQUIRED)
+
+#find_library(xios libxios.a REQUIRED)# HINTS ENV LD_LIBRARY_PATH LIBRARY_PATH)
+
+include(CMakePrintHelpers)
+cmake_print_variables(CMAKE_SOURCE_DIR)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+
+#pkg_search_module(XIOS REQUIRED xios IMPORTED_TARGET)
+find_package(xios REQUIRED)
+
+cmake_print_variables(xios_INCLUDES)
 
 # To add netCDF to a target:
 # target_include_directories(target PUBLIC ${netCDF_INCLUDE_DIR})
@@ -91,6 +106,10 @@ target_include_directories(nextsim PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${NextsimIncludeDirs}"
     "${netCDF_INCLUDE_DIR}"
+    "${MPI_CXX_INCLUDE_PATH}"
+    "${xios_INCLUDES}"
+    "${xios_EXTERNS}/blitz/"
+    "${xios_EXTERNS}/rapidxml/include"
     )
-target_link_directories(nextsim PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(nextsim LINK_PUBLIC Boost::program_options Boost::log "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_directories(nextsim PUBLIC "${netCDF_LIB_DIR}" "${xios_LIBRARIES}")
+target_link_libraries(nextsim LINK_PUBLIC Boost::program_options Boost::log "${NSDG_NetCDF_Library}" Eigen3::Eigen MPI::MPI_CXX xios "-lhdf5_hl -lhdf5 -lifcore")

--- a/cmake/Findxios.cmake
+++ b/cmake/Findxios.cmake
@@ -1,0 +1,88 @@
+# Find xios
+# 
+# 26th January 2023
+# Dr Alexander Smith, ICCS, Cambridge (UK)
+#
+# Find the xios includes and library 
+#
+# Please set the xios_DIR to point to the top level directory for xios
+# (which contains the makexios executable). This is <path>/xios/trunk/
+# if you followed the instructions in the user/reference guide.
+#
+
+
+set(xios_DIR "/home/as3402/nextsim/xios/")
+set(xios_INCLUDES "${xios_DIR}/inc/")
+set(xios_LIBRARIES "${xios_DIR}/lib/")
+set(xios_EXTERNS "${xios_DIR}/extern/")
+
+find_path (xios_INCLUDES xios.hpp
+  HINTS xios_DIR ENV xios_DIR ENV CPATH ENV FPATH)
+#set(CMAKE_FIND_DEBUG_MODE FALSE)
+message (STATUS "so far xios_INCLUDES: ${xios_INCLUDES}")
+
+# - Find NetCDF
+# Find the native NetCDF includes and library
+#
+#  xios_INCLUDES    - where to find netcdf.h, etc
+#  xios_LIBRARIES   - Link these libraries when using NetCDF
+#  xios_FOUND       - True if NetCDF found including required interfaces (see below)
+
+#  find_package (xios REQUIRED)
+#  target_link_libraries (uses_f90_interface ${xios_LIBRARIES})
+#  target_link_libraries (only_uses_c_interface ${xios_LIBRARIES_C})
+
+if (xios_INCLUDES AND xios_LIBRARIES)
+  # Already in cache, be silent
+  set (xios_FIND_QUIETLY TRUE)
+endif (xios_INCLUDES AND xios_LIBRARIES)
+
+#set(CMAKE_FIND_DEBUG_MODE TRUE)
+find_path (xios_INCLUDES xios.hpp
+  HINTS xios_DIR ENV xios_DIR ENV CPATH ENV FPATH)
+#set(CMAKE_FIND_DEBUG_MODE FALSE)
+message (STATUS "so far xios_INCLUDES: ${xios_INCLUDES}")
+
+
+find_library (xios_LIBRARIES NAMES xios
+    HINTS ENV LD_LIBRARY_PATH LIBRARY_PATH)
+mark_as_advanced(xios_LIBRARIES)
+message (STATUS "so far xios_LIBRARIES: ${xios_LIBRARIES}")
+
+set (xois_has_interfaces "YES") # will be set to NO if we're missing any interfaces
+set (xios_libs "${xios_LIBRARIES}")
+
+get_filename_component (xios_lib_dirs "${xios_LIBRARIES}" PATH)
+
+message (STATUS "lang is set to:  ${lang}")
+
+#macro (NetCDF_check_interface lang header libs)
+#  if (xios_${lang})
+#    find_path (xios_INCLUDES_${lang} NAMES ${header}
+#      HINTS "${xios_INCLUDES}" NO_DEFAULT_PATH)
+#    find_library (xios_LIBRARIES_${lang} NAMES ${libs}
+#      HINTS "${NetCDF_lib_dirs}" NO_DEFAULT_PATH)
+#    mark_as_advanced (xios_INCLUDES_${lang} xios_LIBRARIES_${lang})
+#    if (xios_INCLUDES_${lang} AND xios_LIBRARIES_${lang})
+#      list (INSERT NetCDF_libs 0 ${xios_LIBRARIES_${lang}}) # prepend so that -lnetcdf is last
+#    else (xios_INCLUDES_${lang} AND xios_LIBRARIES_${lang})
+#      set (NetCDF_has_interfaces "NO")
+#      message (STATUS "Failed to find NetCDF interface for ${lang}")
+#    endif (xios_INCLUDES_${lang} AND xios_LIBRARIES_${lang})
+#  endif (xios_${lang})
+#endmacro (NetCDF_check_interface)
+
+#NetCDF_check_interface (CXX netcdfcpp.h netcdf_c++)
+#NetCDF_check_interface (F77 netcdf.inc  netcdff)
+#NetCDF_check_interface (F90 netcdf.mod  netcdff)
+
+set (xios_LIBRARIES "${xios_libs}" CACHE STRING "All xios libraries required for interface level")
+
+# handle the QUIETLY and REQUIRED arguments and set xios_FOUND to TRUE if
+# all listed variables are TRUE
+include (FindPackageHandleStandardArgs)
+find_package_handle_standard_args(xios DEFAULT_MSG xios_LIBRARIES xios_INCLUDES)# xios_has_interfaces)
+
+mark_as_advanced(xios_LIBRARIES xios_INCLUDES xios_EXTERNS)
+
+

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -24,6 +24,7 @@ set(BaseSources
     "PrognosticData.cpp"
     "Time.cpp"
     "${ModelArrayStructure}/ModelArrayDetails.cpp"
+    "Xios.cpp"
     )
 
 list(TRANSFORM BaseSources PREPEND "${CMAKE_CURRENT_SOURCE_DIR}/")

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -11,21 +11,41 @@
 
 namespace Nextsim {
 
-    void Xios::configure(int argc, char* argv[])
+template <>
+const std::map<int, std::string> Configured<Xios>::keyMap = {
+    { Xios::ENABLED_KEY, "xios.enable" }
+};
+
+    Xios::Xios() {
+        m_isConfigured = false; 
+    }
+
+    void Xios::configure()
     {
             cout << "XIOS --- CONFIGURE ENTRY POINT" << endl; 
+            m_enabledStr = Configured::getConfiguration(keyMap.at(ENABLED_KEY), std::string());
+            cout << "XIOS --- Enabled: " << Configured::getConfiguration(keyMap.at(ENABLED_KEY), std::string()) << endl;
 
+            m_isConfigured = true;
+            cout << "XIOS --- CONFIGURE EXIT POINT" << endl; 
+    }
+
+    //Setup XIOS server process, calendar and parse iodel.xml
+    void Xios::initialise(int argc, char* argv[])
+    {
+            cout << "XIOS --- INITIALISE ENTRY POINT" << endl; 
+            
+            Xios::configure();
+
+            //Temporary MPI setup until syncronisation with assoc branch
             MPI_Init(&argc, &argv);
-
             int n_ranks;
             MPI_Comm_size(MPI_COMM_WORLD, &n_ranks);
             cout << "MPI_RANKS " << n_ranks << endl;
 
-
             string clientId( "client" );
             MPI_Comm clientComm;
-
-            MPI_Fint clientComm_F ;
+            MPI_Fint clientComm_F;
             MPI_Fint nullComm_F = MPI_Comm_c2f( MPI_COMM_NULL );
 
             cxios_init_client( clientId.c_str(), clientId.length(), &nullComm_F, &clientComm_F );
@@ -73,16 +93,52 @@ namespace Nextsim {
             
             cxios_update_calendar_timestep( clientCalendar );
 
+            if (rank == 0) cout << "XIOS --- INITIALISE EXIT POINT" << endl; 
+    }
+
+    void Xios::Finalise()
+    {
+            cout << "XIOS --- FINALISE" << endl;
+            //cxios_context_close_definition();
             cxios_context_finalize();
             cxios_finalize();
 
             MPI_Finalize();
-            cout << "XIOS --- MPI FINALIZED" << endl;
+            cout << "XIOS --- FINALISE EXIT" << endl;
     }
 
-    void Xios::writeState()
+    Xios::~Xios()
+    {
+        if (m_isConfigured) {
+            Nextsim::Xios::Finalise();
+        }
+        
+    }
+
+    // Method to update the Xios data
+    // Model -> XIOS
+    void Xios::setState()
+    {
+
+    }
+
+    // Method to access the Xios data
+    // XIOS -> Model
+    void Xios::getState()
+    {
+
+    }
+
+    // Method to write state of Xios data to file
+    void Xios::writeStateData()
     {
         //configure();
+    }
+
+    // Method to update the Xios data state with data from file
+    void Xios::readStateData()
+    {
+        //Unsure if we want this tbh
     }
 
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -77,33 +77,35 @@ const std::map<int, std::string> Configured<Xios>::keyMap = {
 
 
 
-    std::string Xios::getCalendarOrigin()
+    std::string Xios::getCalendarOrigin(bool isoFormat)
     {
         cxios_date dorigin;
-        char dorigin_str[20];
+        //char dorigin_str[20];
         cxios_get_calendar_wrapper_date_time_origin( m_clientCalendar, &dorigin );
-        cxios_date_convert_to_string( dorigin, dorigin_str, 20);
-        return dorigin_str;
+        //cxios_date_convert_to_string( dorigin, dorigin_str, 20);
+        return convertXiosDatetimeToString(dorigin, isoFormat);
+    }
+
+    std::string Xios::getCalendarStart(bool isoFormat)
+    {
+        cout << "getCalendarstart" << endl;
+        cxios_date dstart;
+        cxios_get_calendar_wrapper_date_start_date( m_clientCalendar, &dstart);
+        return convertXiosDatetimeToString(dstart, isoFormat);
     }
 
     void Xios::setCalendarStart(char* dstart_str, int str_size)
     {
         //This string must be in YYYY-MM-DD HH-MM-SS format (I think the size of each can vary but the orders and delims cant)
-        cxios_date dstart = cxios_date_convert_from_string(dstart_str, str_size);//, m_clientCalendar);
-        cxios_set_calendar_wrapper_date_start_date( m_clientCalendar, &dstart );
+        cxios_date *dstart = new cxios_date();
+        dstart = cxios_date_convert_from_string(dstart_str, str_size);
+        cxios_set_calendar_wrapper_date_start_date( m_clientCalendar, dstart );
     }
 
-    std::string Xios::getCalendarStart(bool isoFormat = true)
-    {
-        cout << "getCalendarstart" << endl;
-        cxios_date dstart;
-        cxios_get_calendar_wrapper_date_start_date( m_clientCalendar, &dstart);
-        return formatXiosDatetime(dstart, isoFormat);
-    }
 
     //If I need an Xios utility class then this is a candidate
     //TODO: Create the reverse operation
-    static std::string Xios::formatXiosDatetime(cxios_date datetime, bool isoFormat)
+    std::string Xios::convertXiosDatetimeToString(cxios_date datetime, bool isoFormat)
     {
         const int str_size = 20;
         char datetime_str[20];
@@ -125,6 +127,22 @@ const std::map<int, std::string> Configured<Xios>::keyMap = {
         return datetime_str;
     }
 
+    // cxios_date Xios::convertStringToXiosDatetime(std::string datetime_str)
+    // {
+    //     int delimiter = std::string::find(datetime_str, 'T');
+    //     int terminator = std::string::find(datetime_str. 'Z');
+
+    //     if (delimiter) {
+    //         std::string::replace
+    //     }
+    //     if (terminator) {
+    //         std::string::replace
+    //     }
+
+    //     cxios_date datetime =cxios_date_convert_from_string
+    //     return datetime;
+    // }
+
     void Xios::configureCalendar() 
     {
 
@@ -136,7 +154,7 @@ const std::map<int, std::string> Configured<Xios>::keyMap = {
         //TODO: Take string as argument and convert to char for the extern c?
         char dstart_str[20] = "2021-03-01 00:00:00";
         cout << "Enter setCalendarStart" << endl;
-        //xios::CException
+        //TODO: xios::CException is thrown
         //setCalendarStart(dstart_str, 20);
         cout << "Enter setCalendarTimestep" << endl;
         setCalendarTimestep();
@@ -204,6 +222,21 @@ const std::map<int, std::string> Configured<Xios>::keyMap = {
     }
 
     bool Xios::validateConfiguration()
+    {
+        return validateServerConfiguration() && validateCalendarConfiguration() && validateAxisConfiguration();
+    }
+
+    bool Xios::validateServerConfiguration()
+    {
+        return true;
+    }
+
+    bool Xios::validateCalendarConfiguration()
+    {
+        return true;
+    }
+
+    bool Xios::validateAxisConfiguration()
     {
         return true;
     }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1,0 +1,88 @@
+/*!
+ * @file Xios.cpp
+ * @date 7th February 2023
+ * @author Dr Alexander Smith <as3402@cam.ac.uk>
+ */
+#include "include/Xios.hpp"
+
+#include <iostream>
+#include <mpi.h>
+#include <include/xios_c_interface.hpp>
+
+namespace Nextsim {
+
+    void Xios::configure(int argc, char* argv[])
+    {
+            cout << "XIOS --- CONFIGURE ENTRY POINT" << endl; 
+
+            MPI_Init(&argc, &argv);
+
+            int n_ranks;
+            MPI_Comm_size(MPI_COMM_WORLD, &n_ranks);
+            cout << "MPI_RANKS " << n_ranks << endl;
+
+
+            string clientId( "client" );
+            MPI_Comm clientComm;
+
+            MPI_Fint clientComm_F ;
+            MPI_Fint nullComm_F = MPI_Comm_c2f( MPI_COMM_NULL );
+
+            cxios_init_client( clientId.c_str(), clientId.length(), &nullComm_F, &clientComm_F );
+            clientComm = MPI_Comm_f2c( clientComm_F );
+
+            int rank(0);
+            MPI_Comm_rank( clientComm, &rank );
+            int size(1);
+            MPI_Comm_size( clientComm, &size );
+
+            cout << "Hello XIOS from proc " << rank << endl;
+
+            string contextId( "test" );
+            cxios_context_initialize( contextId.c_str(), contextId.length(), &clientComm_F );
+
+            cxios_date dorigin;
+            char dorigin_str[20];
+
+            xios::CCalendarWrapper* clientCalendar;
+            cxios_get_current_calendar_wrapper( &clientCalendar );
+            cxios_get_calendar_wrapper_date_time_origin( clientCalendar, &dorigin );
+
+            cxios_date_convert_to_string( dorigin, dorigin_str, 20);
+            if (rank == 0) cout << "calendar time_origin = " << dorigin_str << endl;
+
+            cxios_date dstart;
+            char dstart_str[20];
+
+            cxios_get_calendar_wrapper_date_start_date( clientCalendar, &dstart );
+            
+            cxios_date_convert_to_string( dstart, dstart_str, 20);
+            if (rank == 0) cout << "calendar start_date = " << dstart_str << endl;
+
+            cxios_duration dtime;
+            dtime.year = 0;
+            dtime.month = 0;
+            dtime.day = 0;
+            dtime.hour = 0;
+            dtime.minute = 0;
+            dtime.second = 0;
+            dtime.timestep = 0;
+            dtime.second = 3600;
+            
+            cxios_set_calendar_wrapper_timestep( clientCalendar, dtime );
+            
+            cxios_update_calendar_timestep( clientCalendar );
+
+            cxios_context_finalize();
+            cxios_finalize();
+
+            MPI_Finalize();
+            cout << "XIOS --- MPI FINALIZED" << endl;
+    }
+
+    void Xios::writeState()
+    {
+        //configure();
+    }
+
+}

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -9,7 +9,7 @@
 
 #include <mpi.h>
 #include <include/xios_c_interface.hpp>
-#include "include/Configured.hpp"
+#include "Configured.hpp"
 
 namespace Nextsim {
 
@@ -24,20 +24,22 @@ public:
     bool validateConfiguration();
     bool validateServerConfiguration();
     bool validateCalendarConfiguration();
+    bool validateAxisConfiguration();
 
     void configure() override; 
     void configureServer(int argc, char* argv[]);
     void configureCalendar();
 
     //Decide if I want these two and the best output type
-    std::string getCalendarOrigin();
+    std::string getCalendarOrigin(bool isoFormat = true);
     void setCalendarOrigin();
-    std::string getCalendarStart(bool isoFormat);
+    std::string getCalendarStart(bool isoFormat = true);
     void setCalendarStart(char *dstart_str, int str_size);
     std::string getCalendarTimestep();
     void setCalendarTimestep();
     void getCalendarConfiguration();
-    static std::string formatXiosDatetime(cxios_date datetime, bool isoFormat);
+    static std::string convertXiosDatetimeToString(cxios_date datetime, bool isoFormat);
+    //cxios_date convertStringToXiosDatetime(std::string datetime);
 
     static void writeState();
     //Arguments TBC

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -7,7 +7,8 @@
 #ifndef SRC_INCLUDE_XIOS_HPP
 #define SRC_INCLUDE_XIOS_HPP
 
-
+#include <mpi.h>
+#include <include/xios_c_interface.hpp>
 #include "include/Configured.hpp"
 
 namespace Nextsim {
@@ -15,15 +16,30 @@ namespace Nextsim {
 //! Class to handle interfacing with the XIOS library
 class Xios : public Configured<Xios> {
 public:
-    Xios();
+    Xios(int argc, char* argv[]);
     ~Xios();
+    
+    void initialise();//int argc, char* argv[]);
     void Finalise();
+    bool validateConfiguration();
+    bool validateServerConfiguration();
+    bool validateCalendarConfiguration();
+
+    void configure() override; 
+    void configureServer(int argc, char* argv[]);
+    void configureCalendar();
+
+    //Decide if I want these two and the best output type
+    std::string getCalendarOrigin();
+    void setCalendarOrigin();
+    std::string getCalendarStart(bool isoFormat);
+    void setCalendarStart(char *dstart_str, int str_size);
+    std::string getCalendarTimestep();
+    void setCalendarTimestep();
+    void getCalendarConfiguration();
+    static std::string formatXiosDatetime(cxios_date datetime, bool isoFormat);
 
     static void writeState();
-    //void configure() override;
-    void configure() override; 
-    void initialise(int argc, char* argv[]);
-
     //Arguments TBC
     void setState();
     void getState();
@@ -34,10 +50,14 @@ public:
         ENABLED_KEY,
     };
 
+    static void convertXiosDateStringToIsoDate(std::string& dateString);
+
 protected:
-    bool m_isConfigured;
+    bool m_isConfigured = false;
 private:
     std::string m_enabledStr;
+    MPI_Comm m_clientComm;
+    xios::CCalendarWrapper* m_clientCalendar;
 };
 
 } /* end namespace Nextsim */

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -7,18 +7,37 @@
 #ifndef SRC_INCLUDE_XIOS_HPP
 #define SRC_INCLUDE_XIOS_HPP
 
+
+#include "include/Configured.hpp"
+
 namespace Nextsim {
 
 //! Class to handle interfacing with the XIOS library
-class Xios {
+class Xios : public Configured<Xios> {
 public:
+    Xios();
+    ~Xios();
+    void Finalise();
+
     static void writeState();
-    static void configure(int argc, char* argv[]);
+    //void configure() override;
+    void configure() override; 
+    void initialise(int argc, char* argv[]);
+
+    //Arguments TBC
+    void setState();
+    void getState();
+    void writeStateData();
+    void readStateData();
+
+    enum {
+        ENABLED_KEY,
+    };
+
 protected:
-    bool isConfigured;
+    bool m_isConfigured;
 private:
-
-
+    std::string m_enabledStr;
 };
 
 } /* end namespace Nextsim */

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -1,0 +1,26 @@
+/*!
+ * @file Xios.hpp
+ * @date 7th February 2023
+ * @author Dr Alexander Smith <as3402@cam.ac.uk>
+ */
+
+#ifndef SRC_INCLUDE_XIOS_HPP
+#define SRC_INCLUDE_XIOS_HPP
+
+namespace Nextsim {
+
+//! Class to handle interfacing with the XIOS library
+class Xios {
+public:
+    static void writeState();
+    static void configure(int argc, char* argv[]);
+protected:
+    bool isConfigured;
+private:
+
+
+};
+
+} /* end namespace Nextsim */
+
+#endif

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -1,3 +1,5 @@
+#ifndef XIOS_C_INTERFACE
+#define XIOS_C_INTERFACE
 
 #include <calendar_wrapper.hpp>
 #include <icdate.hpp>
@@ -14,14 +16,26 @@ extern "C"
   void cxios_context_close_definition();
   void cxios_context_finalize();
 
+  //Calendar init
   void cxios_get_current_calendar_wrapper(xios::CCalendarWrapper** _ret);
-  void cxios_get_calendar_wrapper_date_time_origin(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* time_origin_c);
+  //Date Utility
   void cxios_date_convert_to_string(cxios_date date_c, char* str, int str_size);
-  void cxios_get_calendar_wrapper_date_start_date(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* start_date_c);
+  cxios_date cxios_date_convert_from_string(char* str, int str_size);
 
+  //Calendar Origin
+  void cxios_set_calendar_wrapper_date_time_origin(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* time_origin_c);
+  void cxios_get_calendar_wrapper_date_time_origin(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* time_origin_c);
+
+  //Calendar Start Date
+  void cxios_get_calendar_wrapper_date_start_date(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* start_date_c);
+  void cxios_set_calendar_wrapper_date_start_date(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* start_date_c);
+
+  //Calendar Timestep
   void cxios_set_calendar_wrapper_timestep(xios::CCalendarWrapper* calendar_wrapper_hdl, cxios_duration timestep_c);
+  void cxios_get_calendar_wrapper_timestep(xios::CCalendarWrapper* calendar_wrapper_hdl, cxios_duration timestep_c);
   void cxios_update_calendar_timestep(xios::CCalendarWrapper* calendarWrapper_hdl);
     
+  //Grid Axis
   void cxios_axis_handle_create (xios::CAxis** _ret, const char * _id, int _id_len);
   void cxios_get_axis_n_glo(xios::CAxis* axis_hdl, int* n_glo);
   void cxios_get_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
@@ -37,7 +51,10 @@ extern "C"
   void cxios_set_domain_lonvalue_1d(xios::CDomain* domain_hdl, double* lonvalue_1d, int* extent);
   void cxios_set_domain_latvalue_1d(xios::CDomain* domain_hdl, double* latvalue_1d, int* extent);
 
+  
   void cxios_update_calendar(int step);
   void cxios_write_data_k83(const char* fieldid, int fieldid_size, double* data_k8, int data_Xsize, int data_Ysize, int data_Zsize, int tileid);
 
 };
+
+#endif

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -1,0 +1,43 @@
+
+#include <calendar_wrapper.hpp>
+#include <icdate.hpp>
+#include <axis.hpp>
+#include <domain.hpp>
+#include <field.hpp>
+
+extern "C"
+{  
+  void cxios_init_client(const char* client_id , int len_client_id, MPI_Fint* f_local_comm, MPI_Fint* f_return_comm );
+  void cxios_finalize();
+
+  void cxios_context_initialize(const char* context_id , int len_context_id, MPI_Fint* f_comm);
+  void cxios_context_close_definition();
+  void cxios_context_finalize();
+
+  void cxios_get_current_calendar_wrapper(xios::CCalendarWrapper** _ret);
+  void cxios_get_calendar_wrapper_date_time_origin(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* time_origin_c);
+  void cxios_date_convert_to_string(cxios_date date_c, char* str, int str_size);
+  void cxios_get_calendar_wrapper_date_start_date(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* start_date_c);
+
+  void cxios_set_calendar_wrapper_timestep(xios::CCalendarWrapper* calendar_wrapper_hdl, cxios_duration timestep_c);
+  void cxios_update_calendar_timestep(xios::CCalendarWrapper* calendarWrapper_hdl);
+    
+  void cxios_axis_handle_create (xios::CAxis** _ret, const char * _id, int _id_len);
+  void cxios_get_axis_n_glo(xios::CAxis* axis_hdl, int* n_glo);
+  void cxios_get_axis_value(xios::CAxis* axis_hdl, double* value, int* extent);
+
+  void cxios_domain_handle_create(xios::CDomain** _ret, const char * _id, int _id_len);
+  void cxios_get_domain_type(xios::CDomain* domain_hdl, char * type, int type_size);
+  void cxios_get_domain_ni_glo(xios::CDomain* domain_hdl, int* ni_glo);
+  void cxios_get_domain_nj_glo(xios::CDomain* domain_hdl, int* nj_glo);
+  void cxios_set_domain_ni(xios::CDomain* domain_hdl, int ni);
+  void cxios_set_domain_nj(xios::CDomain* domain_hdl, int nj);
+  void cxios_set_domain_ibegin(xios::CDomain* domain_hdl, int ibegin);
+  void cxios_set_domain_jbegin(xios::CDomain* domain_hdl, int jbegin);
+  void cxios_set_domain_lonvalue_1d(xios::CDomain* domain_hdl, double* lonvalue_1d, int* extent);
+  void cxios_set_domain_latvalue_1d(xios::CDomain* domain_hdl, double* latvalue_1d, int* extent);
+
+  void cxios_update_calendar(int step);
+  void cxios_write_data_k83(const char* fieldid, int fieldid_size, double* data_k8, int data_Xsize, int data_Ysize, int data_Zsize, int tileid);
+
+};

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -20,15 +20,21 @@ extern "C"
   void cxios_get_current_calendar_wrapper(xios::CCalendarWrapper** _ret);
   //Date Utility
   void cxios_date_convert_to_string(cxios_date date_c, char* str, int str_size);
-  cxios_date cxios_date_convert_from_string(char* str, int str_size);
+  //TODO: If I added this then consider void and making final arg cxios_date (again)
+  cxios_date* cxios_date_convert_from_string(char* str, int str_size);
+  //cxios_date cxios_date_convert_from_string(const char* str, int str_size);
+
+  //TODO: Can't be import definitions from the xios header file? Why does this file even exist?
+  void cxios_duration_convert_to_string(cxios_duration dur_c, char* str, int str_size);
+  cxios_duration* cxios_duration_convert_from_string(const char* str, int str_size);
 
   //Calendar Origin
   void cxios_set_calendar_wrapper_date_time_origin(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* time_origin_c);
   void cxios_get_calendar_wrapper_date_time_origin(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* time_origin_c);
 
   //Calendar Start Date
-  void cxios_get_calendar_wrapper_date_start_date(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* start_date_c);
-  void cxios_set_calendar_wrapper_date_start_date(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date* start_date_c);
+  void cxios_set_calendar_wrapper_date_start_date(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date *start_date_c);
+  void cxios_get_calendar_wrapper_date_start_date(xios::CCalendarWrapper* calendarWrapper_hdl, cxios_date *start_date_c);
 
   //Calendar Timestep
   void cxios_set_calendar_wrapper_timestep(xios::CCalendarWrapper* calendar_wrapper_hdl, cxios_duration timestep_c);

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -174,3 +174,22 @@ add_executable(testNewModelArrayRef
 
 target_include_directories(testNewModelArrayRef PRIVATE "${CoreSrc}" "${CoreSrc}/${ModelArrayStructure}")
 target_link_libraries(testNewModelArrayRef PRIVATE Catch2::Catch2 Eigen3::Eigen)
+
+
+
+add_executable(testXiosInit
+    "XiosInit_test.cpp"
+    "${CoreSrc}/Xios.cpp"
+    "${CoreSrc}/Configurator.cpp"
+)
+
+target_include_directories(testXiosInit PRIVATE 
+    "${CoreSrc}"
+    "${netCDF_INCLUDE_DIR}"
+    "${MPI_CXX_INCLUDE_PATH}"
+    "${xios_INCLUDES}"
+    "${xios_EXTERNS}/blitz/"
+    "${xios_EXTERNS}/rapidxml/include")
+
+target_link_directories(testXiosInit PUBLIC "${netCDF_LIB_DIR}" "${xios_LIBRARIES}")
+target_link_libraries(testXiosInit PRIVATE Catch2::Catch2 Eigen3::Eigen Boost::program_options "${NSDG_NetCDF_Library}" MPI::MPI_CXX xios "-lhdf5_hl -lhdf5 -lifcore")

--- a/core/test/XiosInit_test.cpp
+++ b/core/test/XiosInit_test.cpp
@@ -1,0 +1,51 @@
+/*!
+ * @file XiosInit_test.cpp
+ * @brief Initialisation Testing for XIOS
+ * @date Feb 28, 2023
+ * @author Dr Alexander Smith <as3402@cam.ac.uk>
+ * 
+ * Test file intended to validate the initialization of the server process of
+ * the XIOS class, including syncronising the state of the Nextsim grid. This
+ * file serves as a set of unit tests, the system tests are elsewhere.
+ */
+
+
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+#include "include/Xios.hpp"
+
+TEST_CASE("Init XIOS, check default validation") 
+{
+    // Configure the XIOS server
+    Nextsim::Xios *xios;
+    xios = new Nextsim::Xios::Xios(NULL, NULL);
+    xios->initialise();
+
+    // Validate initialization
+    REQUIRE(xios->validateServerConfiguration());
+
+    // Validate initialization
+    REQUIRE(xios->validateCalendarConfiguration());
+    // Delete XIOS object
+    delete xios;   
+}
+
+// TEST_CASE("Init XIOS, check config validation") 
+// {
+//     // Configure the XIOS server
+//     Nextsim::Xios *xios;
+//     xios = new Nextsim::Xios::Xios(NULL, NULL);
+//     xios->initialise();
+
+//     std::string xios_timestep = xios->getCalendarTimestep();
+//     std::string config_timestep = "P0-0T0:10:0";
+
+//     REQUIRE(xios_timestep == config_timestep);
+
+//     std::string xios_startDate = xios->getCalendarStart();
+//     std::string config_startDate = "2010-01-01T10:00:00Z";
+
+//     Nextsim::Xios::convertXiosDateStringToIsoDate(xios_startDate);
+//     // Delete XIOS object
+//     delete xios;   
+// }

--- a/core/test/iodef.xml
+++ b/core/test/iodef.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+
+<simulation>
+
+  <context id="test">
+
+    <calendar type="Gregorian" time_origin="2021-01-01" start_date="2021-03" />
+
+    <axis_definition>
+      <axis id="axis_A" n_glo="10" value="(0,9)[100 200 300 400 500 600 700 800 900 1000]">
+      </axis>
+    </axis_definition>
+
+    <domain_definition>
+      <domain id="domain_A" type="rectilinear" ni_glo="360" nj_glo="180"/>
+    </domain_definition>
+
+    <grid_definition>
+      <grid id="grid_A">
+        <domain domain_ref="domain_A"/>
+        <axis axis_ref="axis_A"/>
+      </grid>
+    </grid_definition>
+
+    <field_definition>
+      <field id="field_A" name="test_field" operation="instant" grid_ref="grid_A"/>
+    </field_definition>
+
+    <file_definition>
+      <file id="output" name="output_gridA" output_freq="1ts" type="one_file">
+        <field id="field_A"/>
+      </file>
+    </file_definition>
+    
+  </context>
+  
+  <context id="xios">
+    <variable_definition>
+      <variable_group id="parameters" >
+        <variable id="print_file" type="bool">true</variable>
+      </variable_group>
+    </variable_definition>
+  </context>
+  
+</simulation>

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -62,6 +62,10 @@ You must have root priviledge :
         cmake -Bbuild -H. -DBUILD_TESTING=OFF
         sudo cmake --build build/ --target install
         cd ..
+        svn checkout http://forge.ipsl.jussieu.fr/ioserver/svn/XIOS/trunk xios
+        cd xios
+        ./make_xios --arch <your_architecture>
+        cd ..
 
         cd nextsimdg
         mkdir -p build

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,7 +51,7 @@ If your package manager is `Homebrew`_ :
 Compilation on Ubuntu
 ---------------------
 
-You must have root priviledge :
+You must have root privilege :
 
 .. code::
 
@@ -77,7 +77,7 @@ You must have root priviledge :
 Compilation with dependencies installation via conda
 ----------------------------------------------------
 
-Install conda via anaconda or miniconda (no root priviledges required)
+Install conda via anaconda or miniconda (no root privileges required)
 
 .. code::
 

--- a/run/config_xios_example.cfg
+++ b/run/config_xios_example.cfg
@@ -1,0 +1,8 @@
+[model]
+init_file = init_rect30x30.nc
+start = 2010-04-01T00:00:00Z
+stop = 2010-04-02T00:00:00Z
+time_step = P0-0T0:10:0
+
+[xios]
+enable = true

--- a/run/config_xios_example.cfg
+++ b/run/config_xios_example.cfg
@@ -1,7 +1,7 @@
 [model]
 init_file = init_rect30x30.nc
 start = 2010-04-01T00:00:00Z
-stop = 2010-04-02T00:00:00Z
+stop = 2010-04-01T00:00:00Z
 time_step = P0-0T0:10:0
 
 [xios]

--- a/run/iodef.xml
+++ b/run/iodef.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+
+<simulation>
+
+  <context id="test">
+
+    <calendar type="Gregorian" time_origin="2021-01-01" start_date="2021-03" />
+
+    <axis_definition>
+      <axis id="axis_A" n_glo="10" value="(0,9)[100 200 300 400 500 600 700 800 900 1000]">
+      </axis>
+    </axis_definition>
+
+    <domain_definition>
+      <domain id="domain_A" type="rectilinear" ni_glo="360" nj_glo="180"/>
+    </domain_definition>
+
+    <grid_definition>
+      <grid id="grid_A">
+        <domain domain_ref="domain_A"/>
+        <axis axis_ref="axis_A"/>
+      </grid>
+    </grid_definition>
+
+    <field_definition>
+      <field id="field_A" name="test_field" operation="instant" grid_ref="grid_A"/>
+    </field_definition>
+
+    <file_definition>
+      <file id="output" name="output_gridA" output_freq="1ts" type="one_file">
+        <field id="field_A"/>
+      </file>
+    </file_definition>
+    
+  </context>
+  
+  <context id="xios">
+    <variable_definition>
+      <variable_group id="parameters" >
+        <variable id="print_file" type="bool">true</variable>
+      </variable_group>
+    </variable_definition>
+  </context>
+  
+</simulation>


### PR DESCRIPTION
Status: Draft

neXtSIM-DG XIOS Integration - Step 1/MVP

- [ ] CMake Configure to include XIOS, tests
- [ ] XIOS Handler Class with Server Init
    - [ ] Remove temporary and leverage new MPI (Branch???: https://github.com/nextsimdg/nextsimdg/tree/feat_mpi)
- [ ] Add XIOS Calendar Sync
- [ ] Add XIOS Axis Init & Grid Data Sync
- [ ] Add XIOS Output of Restart File

Summary: Provide (optional) file IO via XIOS. The goal of this change is to be able to write a restart file via XIOS using data stored on an XIOS grid after synchronising data and calendar using current data read infrastructure. 

See design document for more information on XIOS Integration: https://github.com/nextsimdg/nextsimdg/wiki/XIOS-Integration