### PR TITLE
Correct type of componentMap.

### DIFF
--- a/core/src/finitevolume/ModelArrayDetails.cpp
+++ b/core/src/finitevolume/ModelArrayDetails.cpp
@@ -73,6 +73,6 @@ ModelArray::DimensionMap::DimensionMap()
 {
 }
 
-const std::vector<ModelArray::Type, ModelArray::Dimension> ModelArray::componentMap = {};
+const std::map<ModelArray::Type, ModelArray::Dimension> ModelArray::componentMap = {};
 
 }


### PR DESCRIPTION
Closes #286 

> Fixes a typo in the finiteelement ModelArrayDetails.cpp file.