### PR TITLE
Issue296 zindexanslayer test

### DIFF
--- a/core/test/ModelArray_test.cpp
+++ b/core/test/ModelArray_test.cpp
@@ -139,7 +139,7 @@ TEST_CASE("Moving data")
 
 TEST_CASE("Instance setDimensions sets instance dimensions")
 {
-    DosDField uu = ModelArray::DosDField();
+    ZUField uu = ModelArray::ZUField();
     ModelArray::MultiDim udim = {5, 5};
     uu.setDimensions(udim);
     REQUIRE(uu.size() == udim[0] * udim[1]);
@@ -256,7 +256,8 @@ TEST_CASE("Location from index")
     REQUIRE(loc[2] == z);
 }
 
-// Test the zIndexAndLayer function
+// Test the zIndexAndLayer function to ensure that it accesses the correct
+// point in a three-dimensional ModelArray.
 TEST_CASE("zIndexAndLayer")
 {
     const size_t nx = 29;

--- a/core/test/ModelArray_test.cpp
+++ b/core/test/ModelArray_test.cpp
@@ -255,6 +255,36 @@ TEST_CASE("Location from index")
     REQUIRE(loc[1] == y);
     REQUIRE(loc[2] == z);
 }
+
+// Test the zIndexAndLayer function
+TEST_CASE("zIndexAndLayer")
+{
+    const size_t nx = 29;
+    const size_t ny = 23;
+    const size_t nz = 11;
+
+    ModelArray::setDimensions(ModelArray::Type::THREED, {nx, ny, nz});
+
+    ThreeDField threeD(ModelArray::Type::THREED);
+    threeD.resize();
+
+    size_t mul = 100;
+    // Fill the array fastest last
+    for (size_t i = 0; i < nx; ++i) {
+        for (size_t j = 0; j < ny; ++j) {
+            for (size_t k = 0; k < nz; ++k) {
+                threeD(i, j, k) = k + mul * (j + mul * (i));
+            }
+        }
+    }
+
+    size_t x = 19;
+    size_t y = 17;
+    size_t z = 7;
+    size_t ind = ModelArray::indexFromLocation(ModelArray::Type::TWOD, {x, y});
+    REQUIRE(threeD.zIndexAndLayer(ind, z) == threeD(x, y, z));
+
+}
 TEST_SUITE_END();
 
 } /* namespace Nextsim */

--- a/core/test/testmodelarraydetails/ModelArrayDetails.cpp
+++ b/core/test/testmodelarraydetails/ModelArrayDetails.cpp
@@ -25,7 +25,7 @@ ModelArray::TypeDimensions ModelArray::typeDimensions = {
             ModelArray::Dimension::X,
             ModelArray::Dimension::Y,
         } },
-    { ModelArray::Type::DOSD,
+    { ModelArray::Type::ZUFIELD,
         {
             ModelArray::Dimension::Z,
             ModelArray::Dimension::U,
@@ -48,8 +48,8 @@ ModelArray::TypeDimensions ModelArray::typeDimensions = {
 const std::map<ModelArray::Type, std::string> ModelArray::typeNames = {
     { ModelArray::Type::ONED, "OneDField" },
     { ModelArray::Type::TWOD, "TwoDField" },
-    { ModelArray::Type::DOSD, "TwoDField" },
-    { ModelArray::Type::DOSD, "ThreeDField" },
+    { ModelArray::Type::ZUFIELD, "TwoDField" },
+    { ModelArray::Type::THREED, "ThreeDField" },
     { ModelArray::Type::FOURD, "FourDField" },
 };
 
@@ -64,7 +64,7 @@ ModelArray::SizeMap::SizeMap()
     : m_sizes({
         { Type::ONED, 1 },
         { Type::TWOD, 1 },
-        { Type::DOSD, 1 },
+        { Type::ZUFIELD, 1 },
         { Type::THREED, 1 },
         { Type::FOURD, 1 },
     })
@@ -75,7 +75,7 @@ ModelArray::DimensionMap::DimensionMap()
     : m_dimensions({
         { Type::ONED, { 1 } },
         { Type::TWOD, { 1, 1 } },
-        { Type::DOSD, { 1, 1 } },
+        { Type::ZUFIELD, { 1, 1 } },
         { Type::THREED, { 1, 1, 1 } },
         { Type::FOURD, { 1, 1, 1, 1 } },
     })

--- a/core/test/testmodelarraydetails/ModelArrayDetails.cpp
+++ b/core/test/testmodelarraydetails/ModelArrayDetails.cpp
@@ -30,6 +30,12 @@ ModelArray::TypeDimensions ModelArray::typeDimensions = {
             ModelArray::Dimension::Z,
             ModelArray::Dimension::U,
         } },
+    { ModelArray::Type::THREED,
+        {
+            ModelArray::Dimension::X,
+            ModelArray::Dimension::Y,
+            ModelArray::Dimension::Z,
+        } },
     { ModelArray::Type::FOURD,
         {
             ModelArray::Dimension::X,
@@ -43,6 +49,7 @@ const std::map<ModelArray::Type, std::string> ModelArray::typeNames = {
     { ModelArray::Type::ONED, "OneDField" },
     { ModelArray::Type::TWOD, "TwoDField" },
     { ModelArray::Type::DOSD, "TwoDField" },
+    { ModelArray::Type::DOSD, "ThreeDField" },
     { ModelArray::Type::FOURD, "FourDField" },
 };
 
@@ -58,6 +65,7 @@ ModelArray::SizeMap::SizeMap()
         { Type::ONED, 1 },
         { Type::TWOD, 1 },
         { Type::DOSD, 1 },
+        { Type::THREED, 1 },
         { Type::FOURD, 1 },
     })
 {
@@ -68,6 +76,7 @@ ModelArray::DimensionMap::DimensionMap()
         { Type::ONED, { 1 } },
         { Type::TWOD, { 1, 1 } },
         { Type::DOSD, { 1, 1 } },
+        { Type::THREED, { 1, 1, 1 } },
         { Type::FOURD, { 1, 1, 1, 1 } },
     })
 {

--- a/core/test/testmodelarraydetails/include/ModelArrayDetails.hpp
+++ b/core/test/testmodelarraydetails/include/ModelArrayDetails.hpp
@@ -20,12 +20,14 @@
         ONED,
         TWOD,
         DOSD,
+        THREED,
         FOURD,
     };
 
     static ModelArray OneDField() { return ModelArray(Type::ONED); }
     static ModelArray TwoDField() { return ModelArray(Type::TWOD); }
     static ModelArray DosDField() { return ModelArray(Type::DOSD); }
+    static ModelArray ThreeDField() { return ModelArray(Type::THREED); }
     static ModelArray FourDField() { return ModelArray(Type::FOURD); }
 
 #endif /* MODELARRAYDETAILS_HPP */

--- a/core/test/testmodelarraydetails/include/ModelArrayDetails.hpp
+++ b/core/test/testmodelarraydetails/include/ModelArrayDetails.hpp
@@ -19,14 +19,14 @@
     enum class Type {
         ONED,
         TWOD,
-        DOSD,
+        ZUFIELD,
         THREED,
         FOURD,
     };
 
     static ModelArray OneDField() { return ModelArray(Type::ONED); }
     static ModelArray TwoDField() { return ModelArray(Type::TWOD); }
-    static ModelArray DosDField() { return ModelArray(Type::DOSD); }
+    static ModelArray ZUField() { return ModelArray(Type::ZUFIELD); }
     static ModelArray ThreeDField() { return ModelArray(Type::THREED); }
     static ModelArray FourDField() { return ModelArray(Type::FOURD); }
 

--- a/core/test/testmodelarraydetails/include/ModelArrayTypedefs.hpp
+++ b/core/test/testmodelarraydetails/include/ModelArrayTypedefs.hpp
@@ -8,4 +8,5 @@
 typedef ModelArray OneDField;
 typedef ModelArray TwoDField;
 typedef ModelArray DosDField;
+typedef ModelArray ThreeDField;
 typedef ModelArray FourDField;

--- a/core/test/testmodelarraydetails/include/ModelArrayTypedefs.hpp
+++ b/core/test/testmodelarraydetails/include/ModelArrayTypedefs.hpp
@@ -7,6 +7,6 @@
 
 typedef ModelArray OneDField;
 typedef ModelArray TwoDField;
-typedef ModelArray DosDField;
+typedef ModelArray ZUField;
 typedef ModelArray ThreeDField;
 typedef ModelArray FourDField;


### PR DESCRIPTION
Add a test for the ModelArray::zIndexAndLayer function.

Will close #296 
 
> It seemed like such a simple function, but when messing around with array index ordering, it becomes a headache.
> 
> Write a test that ensures that zIndexAndLayer accesses the correct point in a three-dimensional ModelArray.