### PR TITLE
Two bug fixes for the Winton thermodynamics

### DIFF
--- a/physics/src/modules/ThermoWinton.cpp
+++ b/physics/src/modules/ThermoWinton.cpp
@@ -33,12 +33,7 @@ ThermoWinton::ThermoWinton()
     , oldHi(getProtectedArray())
     , sw_in(getProtectedArray())
     , subl(getSharedArray())
-{
-    snowMelt.resize();
-    topMelt.resize();
-    botMelt.resize();
-    snowToIce.resize();
-}
+{ }
 
 template <>
 const std::map<int, std::string> Configured<ThermoWinton>::keyMap = {
@@ -82,6 +77,13 @@ ThermoWinton::HelpMap& ThermoWinton::getHelpRecursive(HelpMap& map, bool getAll)
 
 void ThermoWinton::setData(const ModelState::DataMap& state)
 {
+    IIceThermodynamics::setData(state);
+
+    snowMelt.resize();
+    topMelt.resize();
+    botMelt.resize();
+    snowToIce.resize();
+
     // The Winton scheme requires three temperature levels in the ice
     if (tice0.data().size() != nLevels * hice.data().size()) {
         double actualLevels = static_cast<double>(tice0.data().size()) / hice.data().size();
@@ -291,7 +293,7 @@ void ThermoWinton::calculateTemps(
 
     double& hi = hice[i];
     double tBase = tf[i]; // Freezing point of seawater with the local salinity
-    double tMelt = (hsnow[i] > 0) ? 0 : Ice::Tm; // Melting point at the surface
+    double tMelt = (hsnow[i] > 0) ? 0 : seaIceTf; // Melting point at the surface
 
     // First some coefficients based on temperatures from the previous time step
     double k12 = 4 * Ice::kappa * kappa_s / (kappa_s * hi + 4 * Ice::kappa * hsnow[i]); // (5)


### PR DESCRIPTION
The first bug fix moves .resize() calls from the constructor to the setData method and adds a call to IIceThermodynamcis::setData to the ThermoWinton::setData method. This ensures that all data are properly initialised, as calling .resize() in the constructor is too early.

The second bug fix is a Celsius vs Kelvin error in the melting point temperature.