### PR TITLE
WIP: Implementation errors with penetrating short wave radiation into the ice.

### DIFF
--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -80,6 +80,7 @@ public:
         Q_IO, // Ice to ocean heat flux W m⁻²
         Q_OW, // Open water heat flux W m⁻²
         DQIA_DT, // Derivative of Qᵢₐ w.r.t. ice surface temperature  W m⁻² K⁻¹
+        Q_PEN_SW, // Short-wave flux penetrating the very surface of the ice W m⁻²
         // Mass fluxes
         HSNOW_MELT, // Thickness of snow that melted, m
         // Atmospheric conditions

--- a/core/test/PrognosticData_test.cpp
+++ b/core/test/PrognosticData_test.cpp
@@ -7,8 +7,8 @@
 
 #include "include/PrognosticData.hpp"
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
 
 #include "include/PrognosticData.hpp"
 
@@ -23,7 +23,8 @@
 
 namespace Nextsim {
 
-TEST_CASE("PrognosticData call order test", "[PrognosticData]")
+TEST_SUITE_BEGIN("PrognosticData");
+TEST_CASE("PrognosticData call order test")
 {
     ModelArray::setDimensions(ModelArray::Type::H, { 1, 1 });
     ModelArray::setDimensions(ModelArray::Type::Z, { 1, 1, 1 });
@@ -98,8 +99,8 @@ TEST_CASE("PrognosticData call order test", "[PrognosticData]")
 
     double prec = 1e-5;
     // Correct value
-    REQUIRE(qow[0] == Approx(-109.923).epsilon(prec));
+    REQUIRE(qow[0] == doctest::Approx(-109.923).epsilon(prec));
     // Value if pAtmBdy->update and pOcnBdy->updateBefore are switched in PrognosticData::update
-    REQUIRE(qow[0] != Approx(-92.1569).epsilon(prec));
+    REQUIRE(qow[0] != doctest::Approx(-92.1569).epsilon(prec));
 }
 } /* namespace Nextsim */

--- a/physics/src/modules/CCSMIceAlbedo.cpp
+++ b/physics/src/modules/CCSMIceAlbedo.cpp
@@ -40,7 +40,7 @@ std::tuple<double, double> CCSMIceAlbedo::albedo(
     const double albedo = snowCoverFraction * snowAlbedoT + (1 - snowCoverFraction) * iceAlbedoT;
     const double penSW = (1. - snowCoverFraction) * i0;
 
-    return std::make_tuple(albedo, penSW);
+    return {albedo, penSW};
 }
 
 void CCSMIceAlbedo::configure()

--- a/physics/src/modules/CCSMIceAlbedo.cpp
+++ b/physics/src/modules/CCSMIceAlbedo.cpp
@@ -29,14 +29,18 @@ static const std::string pfx = "CCSMIceAlbedo";
 static const std::string iceAlbedoKey = pfx + ".iceAlbedo";
 static const std::string snowAlbedoKey = pfx + ".snowAlbedo";
 
-double CCSMIceAlbedo::albedo(double temperature, double snowThickness)
+std::tuple<double, double> CCSMIceAlbedo::albedo(
+    double temperature, double snowThickness, double i0)
 {
     const double tLimit = -1.;
     double iceAlbedoT = iceAlbedo - std::fmax(0., 0.075 * (temperature - tLimit));
     double snowAlbedoT = snowAlbedo - std::fmax(0., 0.124 * (temperature - tLimit));
     double snowCoverFraction = snowThickness / (snowThickness + 0.02);
 
-    return snowCoverFraction * snowAlbedoT + (1 - snowCoverFraction) * iceAlbedoT;
+    const double albedo = snowCoverFraction * snowAlbedoT + (1 - snowCoverFraction) * iceAlbedoT;
+    const double penSW = (1. - snowCoverFraction) * i0;
+
+    return std::make_tuple(albedo, penSW);
 }
 
 void CCSMIceAlbedo::configure()

--- a/physics/src/modules/FiniteElementFluxes.cpp
+++ b/physics/src/modules/FiniteElementFluxes.cpp
@@ -145,8 +145,11 @@ void FiniteElementFluxes::calculateIce(size_t i, const TimestepTime& tst)
         = dragIce_t * rho_air[i] * cp_air[i] * v_air[i] * (tice.zIndexAndLayer(i, 0) - t_air[i]);
     double dQsh_dT = dragIce_t * rho_air[i] * cp_air[i] * v_air[i];
     // Shortwave flux
-    double albedoValue = iIceAlbedoImpl->albedo(tice.zIndexAndLayer(i, 0), h_snow_true[i]);
-    Q_sw_ia[i] = -sw_in[i] * (1. - m_I0) * (1 - albedoValue);
+    double albedoValue, i0;
+    std::tie(albedoValue, i0)
+        = iIceAlbedoImpl->albedo(tice.zIndexAndLayer(i, 0), h_snow_true[i], m_I0);
+    Q_sw_ia[i] = -sw_in[i] * (1. - albedoValue) * (1. - i0);
+    penSW[i] = -sw_in[i] * (1. - albedoValue) * i0;
     // Longwave flux
     Q_lw_ia[i] = stefanBoltzmannLaw(tice.zIndexAndLayer(i, 0)) - lw_in[i];
     double dQlw_dT

--- a/physics/src/modules/FiniteElementFluxes.cpp
+++ b/physics/src/modules/FiniteElementFluxes.cpp
@@ -149,7 +149,7 @@ void FiniteElementFluxes::calculateIce(size_t i, const TimestepTime& tst)
     std::tie(albedoValue, i0)
         = iIceAlbedoImpl->albedo(tice.zIndexAndLayer(i, 0), h_snow_true[i], m_I0);
     Q_sw_ia[i] = -sw_in[i] * (1. - albedoValue) * (1. - i0);
-    penSW[i] = -sw_in[i] * (1. - albedoValue) * i0;
+    penSW[i] = sw_in[i] * (1. - albedoValue) * i0;
     // Longwave flux
     Q_lw_ia[i] = stefanBoltzmannLaw(tice.zIndexAndLayer(i, 0)) - lw_in[i];
     double dQlw_dT

--- a/physics/src/modules/SMU2IceAlbedo.cpp
+++ b/physics/src/modules/SMU2IceAlbedo.cpp
@@ -29,6 +29,6 @@ std::tuple<double, double> SMU2IceAlbedo::albedo(
         albedo = ICE_ALBEDO;
         penSW = 0.;
     }
-    return std::make_tuple(albedo, penSW);
+    return {albedo, penSW};
 }
 }

--- a/physics/src/modules/SMU2IceAlbedo.cpp
+++ b/physics/src/modules/SMU2IceAlbedo.cpp
@@ -17,13 +17,18 @@ namespace Nextsim {
 const double ICE_ALBEDO = 0.64;
 const double SNOW_ALBEDO = 0.85;
 
-double SMU2IceAlbedo::albedo(double temperature, double snowThickness)
+std::tuple<double, double> SMU2IceAlbedo::albedo(
+    double temperature, double snowThickness, double i0)
 {
+    double albedo, penSW;
     if (snowThickness > 0.) {
-        return std::fmin(
-            SNOW_ALBEDO, ICE_ALBEDO + (SNOW_ALBEDO - ICE_ALBEDO) * snowThickness / 0.2);
+        albedo
+            = std::fmin(SNOW_ALBEDO, ICE_ALBEDO + (SNOW_ALBEDO - ICE_ALBEDO) * snowThickness / 0.2);
+        penSW = i0;
     } else {
-        return ICE_ALBEDO + 0.4 * (1 - ICE_ALBEDO) * 0.17;// FIXME NextsimPhysics::i0();
+        albedo = ICE_ALBEDO;
+        penSW = 0.;
     }
+    return std::make_tuple(albedo, penSW);
 }
 }

--- a/physics/src/modules/SMUIceAlbedo.cpp
+++ b/physics/src/modules/SMUIceAlbedo.cpp
@@ -15,12 +15,16 @@ namespace Nextsim {
 const double ICE_ALBEDO = 0.64;
 const double SNOW_ALBEDO = 0.85;
 
-double SMUIceAlbedo::albedo(double temperature, double snowThickness)
+std::tuple<double, double> SMUIceAlbedo::albedo(double temperature, double snowThickness, double i0)
 {
+    double albedo, penSW;
     if (snowThickness > 0.) {
-        return SNOW_ALBEDO;
+        albedo = SNOW_ALBEDO;
+        penSW = 0.;
     } else {
-        return ICE_ALBEDO + 0.4 * (1 - ICE_ALBEDO) * 0.17;// FIXME NextsimPhysics::i0();
+        albedo = ICE_ALBEDO;
+        penSW = i0;
     }
+    return std::make_tuple(albedo, penSW);
 }
 }

--- a/physics/src/modules/SMUIceAlbedo.cpp
+++ b/physics/src/modules/SMUIceAlbedo.cpp
@@ -25,6 +25,6 @@ std::tuple<double, double> SMUIceAlbedo::albedo(double temperature, double snowT
         albedo = ICE_ALBEDO;
         penSW = i0;
     }
-    return std::make_tuple(albedo, penSW);
+    return {albedo, penSW};
 }
 }

--- a/physics/src/modules/ThermoIce0.cpp
+++ b/physics/src/modules/ThermoIce0.cpp
@@ -86,12 +86,16 @@ void ThermoIce0::calculateElement(size_t i, const TimestepTime& tst)
     static const double bulkLHFusionSnow = Water::Lf * Ice::rhoSnow;
     static const double bulkLHFusionIce = Water::Lf * Ice::rho;
 
+    // Semtner's fudge factors for the zero-layer model
+    constexpr double beta = 0.4;
+    constexpr double gamma = 1.065;
+
     // Create a reference to the local updated Tice value here to avoid having
     // to write the array access expression out in full every time
     double& tice_i = tice.zIndexAndLayer(i, 0);
-    double k_lSlab = kappa_s * Ice::kappa / (kappa_s * hice[i] + Ice::kappa * hsnow[i]);
+    double k_lSlab = kappa_s * Ice::kappa / (kappa_s * hice[i] + Ice::kappa * hsnow[i]) * gamma;
     qic[i] = k_lSlab * (tf[i] - tice0.zIndexAndLayer(i, 0));
-    double remainingFlux = qic[i] - qia[i];
+    double remainingFlux = qic[i] - (qia[i] + (1. - beta) * penSw[i]);
     tice_i = tice0.zIndexAndLayer(i, 0) + remainingFlux / (k_lSlab + dQia_dt[i]);
 
     // Clamp the temperature of the ice to a maximum of the melting point

--- a/physics/src/modules/ThermoWinton.cpp
+++ b/physics/src/modules/ThermoWinton.cpp
@@ -303,8 +303,7 @@ void ThermoWinton::calculateTemps(
 
     double a1 = hi * cVol / (2 * dt) + k32 * (4 * dt * k32 + hi * cVol) / (6 * dt * k32 + hi * cVol)
         + b * k12 / (k12 + b); // (16)
-    double b1 = -hi * (cVol * tUppr + Ice::Lf * Ice::rho * seaIceTf / tUppr) / (2 * dt)
-        - i0 * sw_in[i]
+    double b1 = -hi * (cVol * tUppr + Ice::Lf * Ice::rho * seaIceTf / tUppr) / (2 * dt) - penSw[i]
         - k32 * (4 * dt * k32 * tBase + hi * cVol * tLowr) / (6 * dt * k32 + hi * cVol)
         + a * k12 / (k12 + b); // (17)
     double c1 = hi * Ice::Lf * Ice::rho * seaIceTf / (2 * dt); // (18)

--- a/physics/src/modules/include/CCSMIceAlbedo.hpp
+++ b/physics/src/modules/include/CCSMIceAlbedo.hpp
@@ -22,7 +22,7 @@ public:
      * @param temperature The temperature of the ice surface.
      * @param snowThickness The true snow thickness on top of the ice.
      */
-    double albedo(double temperature, double snowThickness) override;
+    std::tuple<double, double> albedo(double temperature, double snowThickness, double i0) override;
 
     void configure() override;
 

--- a/physics/src/modules/include/IAtmosphereBoundary.hpp
+++ b/physics/src/modules/include/IAtmosphereBoundary.hpp
@@ -32,6 +32,7 @@ public:
         registerSharedArray(SharedArray::Q_OW, &qow);
         registerSharedArray(SharedArray::SUBLIM, &subl);
         registerProtectedArray(ProtectedArray::SNOW, &snow);
+        registerSharedArray(SharedArray::Q_PEN_SW, &penSW);
     }
     virtual ~IAtmosphereBoundary() = default;
 
@@ -50,6 +51,7 @@ public:
         evap.resize();
         uwind.resize();
         vwind.resize();
+        penSW.resize();
     }
     virtual void update(const TimestepTime& tst) { }
 
@@ -75,6 +77,7 @@ protected:
     HField evap;
     UField uwind;
     VField vwind;
+    HField penSW;
 
     MARBackingStore m_couplingArrays;
 };

--- a/physics/src/modules/include/IFluxCalculation.hpp
+++ b/physics/src/modules/include/IFluxCalculation.hpp
@@ -21,6 +21,7 @@ public:
         : qow(getSharedArray())
         , subl(getSharedArray())
         , qia(getSharedArray())
+        , penSW(getSharedArray())
         , dqia_dt(getSharedArray())
     {
     }
@@ -50,6 +51,7 @@ protected:
     ModelArrayRef<SharedArray::Q_OW, MARBackingStore, RW> qow;
     ModelArrayRef<SharedArray::SUBLIM, MARBackingStore, RW> subl;
     ModelArrayRef<SharedArray::Q_IA, MARBackingStore, RW> qia;
+    ModelArrayRef<SharedArray::Q_PEN_SW, MARBackingStore, RW> penSW;
     ModelArrayRef<SharedArray::DQIA_DT, MARBackingStore, RW> dqia_dt;
 };
 }

--- a/physics/src/modules/include/IIceAlbedo.hpp
+++ b/physics/src/modules/include/IIceAlbedo.hpp
@@ -22,7 +22,8 @@ public:
      * @param temperature The temperature of the ice surface.
      * @param snowThickness The true snow thickness on top of the ice.
      */
-    virtual double albedo(double temperature, double snowThickness) = 0;
+    virtual std::tuple<double, double> albedo(double temperature, double snowThickness, double i0)
+        = 0;
 
     /*!
      * Sets the time parameter for the implementation, if it is time dependent.

--- a/physics/src/modules/include/IIceThermodynamics.hpp
+++ b/physics/src/modules/include/IIceThermodynamics.hpp
@@ -56,6 +56,7 @@ protected:
         , qio(getSharedArray())
         , qia(getSharedArray())
         , dQia_dt(getSharedArray())
+        , penSw(getSharedArray())
         , sublim(getSharedArray())
         , tice0(getProtectedArray())
         , tf(getProtectedArray())
@@ -76,6 +77,7 @@ protected:
     ModelArrayRef<SharedArray::Q_IO, MARBackingStore, RW> qio; // From FluxCalculation
     ModelArrayRef<SharedArray::Q_IA, MARBackingStore, RO> qia; // From FluxCalculation
     ModelArrayRef<SharedArray::DQIA_DT, MARBackingStore, RO> dQia_dt; // From FluxCalculation
+    ModelArrayRef<SharedArray::Q_PEN_SW, MARBackingStore, RO> penSw; // From FluxCalculation
     ModelArrayRef<SharedArray::SUBLIM, MARBackingStore, RO> sublim; // From AtmosphereState
     ModelArrayRef<ProtectedArray::T_ICE, MARConstBackingStore>
         tice0; // Timestep initial ice temperature

--- a/physics/src/modules/include/SMU2IceAlbedo.hpp
+++ b/physics/src/modules/include/SMU2IceAlbedo.hpp
@@ -22,7 +22,7 @@ class SMU2IceAlbedo : public IIceAlbedo {
      * @param temperature The temperature of the ice surface.
      * @param snowThickness The true snow thickness on top of the ice.
      */
-    double albedo(double temperature, double snowThickness);
+    std::tuple<double, double> albedo(double temperature, double snowThickness, double i0);
 };
 
 }

--- a/physics/src/modules/include/SMUIceAlbedo.hpp
+++ b/physics/src/modules/include/SMUIceAlbedo.hpp
@@ -22,7 +22,7 @@ class SMUIceAlbedo : public IIceAlbedo {
      * @param temperature The temperature of the ice surface.
      * @param snowThickness The true snow thickness on top of the ice.
      */
-    double albedo(double temperature, double snowThickness);
+    std::tuple<double, double> albedo(double temperature, double snowThickness, double i0);
 };
 
 }

--- a/physics/test/ConfiguredAtmosphere_test.cpp
+++ b/physics/test/ConfiguredAtmosphere_test.cpp
@@ -134,7 +134,7 @@ TEST_CASE("ConfiguredAtmosphere melting test")
 
     double prec = 1e-5;
     REQUIRE(qow[0] == doctest::Approx(-109.923).epsilon(prec));
-    REQUIRE(qia[0] == doctest::Approx(-84.5952).epsilon(prec));
+    REQUIRE(qia[0] == doctest::Approx(-85.6364).epsilon(prec));
     REQUIRE(dqia_dt[0] == doctest::Approx(19.7016).epsilon(prec));
     REQUIRE(subl[0] == doctest::Approx(-7.3858e-06).epsilon(prec));
 }

--- a/physics/test/FiniteElementFluxes_test.cpp
+++ b/physics/test/FiniteElementFluxes_test.cpp
@@ -153,6 +153,10 @@ TEST_CASE("Melting conditions")
     qia.resize();
     ModelComponent::registerExternalSharedArray(ModelComponent::SharedArray::Q_IA, &qia);
 
+    HField penSW;
+    penSW.resize();
+    ModelComponent::registerExternalSharedArray(ModelComponent::SharedArray::Q_PEN_SW, &penSW);
+
     HField dqia_dt;
     dqia_dt.resize();
     ModelComponent::registerExternalSharedArray(ModelComponent::SharedArray::DQIA_DT, &dqia_dt);
@@ -303,6 +307,10 @@ TEST_CASE("Freezing conditions")
     HField qia;
     qia.resize();
     ModelComponent::registerExternalSharedArray(ModelComponent::SharedArray::Q_IA, &qia);
+
+    HField penSW;
+    penSW.resize();
+    ModelComponent::registerExternalSharedArray(ModelComponent::SharedArray::Q_PEN_SW, &penSW);
 
     HField dqia_dt;
     dqia_dt.resize();

--- a/physics/test/FiniteElementFluxes_test.cpp
+++ b/physics/test/FiniteElementFluxes_test.cpp
@@ -175,7 +175,7 @@ TEST_CASE("Melting conditions")
 
     double prec = 1e-5;
     REQUIRE(qow[0] == doctest::Approx(-109.923).epsilon(prec));
-    REQUIRE(qia[0] == doctest::Approx(-84.5952).epsilon(prec));
+    REQUIRE(qia[0] == doctest::Approx(-85.6364).epsilon(prec));
     REQUIRE(dqia_dt[0] == doctest::Approx(19.7016).epsilon(prec));
     REQUIRE(subl[0] == doctest::Approx(-7.3858e-06).epsilon(prec));
 }

--- a/physics/test/ThermoWintonTemperature_test.cpp
+++ b/physics/test/ThermoWintonTemperature_test.cpp
@@ -121,7 +121,7 @@ TEST_CASE("Melting conditions")
             IAtmosphereBoundary::setData(ms);
             snow[0] = 0.00;
             qow[0] = -109.923;
-            qia[0] = -84.5952;
+            qia[0] = -85.6364;
             dqia_dt[0] = 19.7016;
             subl[0] = -7.3858e-06;
         }
@@ -140,7 +140,7 @@ TEST_CASE("Melting conditions")
     double prec = 1e-5;
 
     REQUIRE(tice[0] == doctest::Approx(0.0).epsilon(prec));
-    REQUIRE(tice[1] == doctest::Approx(-0.999453).epsilon(prec));
+    REQUIRE(tice[1] == doctest::Approx(-0.999261).epsilon(prec));
     REQUIRE(tice[2] == doctest::Approx(-0.275).epsilon(prec));
     //    REQUIRE(qic[0] == doctest::Approx(-4.60879).epsilon(prec));
 }

--- a/physics/test/ThermoWintonTemperature_test.cpp
+++ b/physics/test/ThermoWintonTemperature_test.cpp
@@ -124,6 +124,7 @@ TEST_CASE("Melting conditions")
             qia[0] = -85.6364;
             dqia_dt[0] = 19.7016;
             subl[0] = -7.3858e-06;
+            penSW[0] = 1.04125;
         }
     } atmosState;
     atmosState.setData(ModelState().data);


### PR DESCRIPTION
This PR addresses issue #320 and mirrors changes in neXtSIM Lagrangian: [issue640_pen_sw](https://github.com/nansencenter/nextsim/tree/issue634_pen_sw) and [issue #640](https://github.com/nansencenter/nextsim/compare/issue634_pen_sw).

Three tests still fail because they give different results than the original neXtSIM Lagrangian implementation. But this one was also wrong. We need to update the tests here once we've checked the values in both models.