### PR TITLE
Issue264 netcdf strings

### DIFF
--- a/core/src/CommonRestartMetadata.cpp
+++ b/core/src/CommonRestartMetadata.cpp
@@ -31,18 +31,17 @@ netCDF::NcGroup& CommonRestartMetadata::writeRestartMetadata(
 
     // Current time
     netCDF::NcGroup timeGroup = metaGroup.addGroup(timeNodeName());
-    // As a formatted string
-    netCDF::NcVar formVar = timeGroup.addVar(formattedName(), netCDF::ncString);
-    const std::string fTime = metadata.m_time.format();
-    const char* timeCopy = fTime.c_str();
-    formVar.putVar(&timeCopy);
-    formVar.putAtt(std::string("format"), TimePoint::ymdhmsFormat);
     // As Unix time
     netCDF::NcVar unixVar = timeGroup.addVar(unformattedName(), netCDF::ncInt64);
     Duration sinceEpoch = metadata.time() - TimePoint();
     std::uint64_t secondsSinceEpoch = sinceEpoch.seconds();
     unixVar.putVar(&secondsSinceEpoch);
     unixVar.putAtt(std::string("units"), "seconds since 1970-01-01T00:00:00Z");
+
+    // Add formatted string as attribute as NetCDF4 does not support string variables
+    // in parallel mode
+    unixVar.putAtt(std::string("format"), TimePoint::ymdhmsFormat);
+    unixVar.putAtt(formattedName(), metadata.m_time.format());
 
     // All other configuration data
     netCDF::NcGroup configGroup = metaGroup.addGroup(configurationNode());

--- a/core/src/CommonRestartMetadata.cpp
+++ b/core/src/CommonRestartMetadata.cpp
@@ -50,25 +50,20 @@ netCDF::NcGroup& CommonRestartMetadata::writeRestartMetadata(
     for (auto entry : metadata.m_config) {
         switch (entry.second.index()) {
         case (CONFIGMAP_DOUBLE): {
-            netCDF::NcVar dblVar = configGroup.addVar(entry.first, netCDF::ncDouble);
-            dblVar.putVar(std::get_if<double>(&entry.second));
+            configGroup.putAtt(entry.first, netCDF::ncDouble, *std::get_if<double>(&entry.second));
             break;
         }
         case (CONFIGMAP_UNSIGNED): {
-            netCDF::NcVar uintVar = configGroup.addVar(entry.first, netCDF::ncUint);
-            uintVar.putVar(std::get_if<unsigned>(&entry.second));
+            configGroup.putAtt(entry.first, netCDF::ncUint, *std::get_if<unsigned>(&entry.second));
             break;
         }
         case (CONFIGMAP_INT): {
-            netCDF::NcVar intVar = configGroup.addVar(entry.first, netCDF::ncInt);
-            intVar.putVar(std::get_if<int>(&entry.second));
+            configGroup.putAtt(entry.first, netCDF::ncInt, *std::get_if<int>(&entry.second));
             break;
         }
         case (CONFIGMAP_STRING): {
-            netCDF::NcVar strVar = configGroup.addVar(entry.first, netCDF::ncString);
             std::string extring = std::get<std::string>(entry.second);
-            const char* ctring = extring.c_str();
-            strVar.putVar(&ctring);
+            configGroup.putAtt(entry.first, std::get<std::string>(entry.second));
             break;
         }
         }


### PR DESCRIPTION
## Fixes #264 

## Change description
The PR replaces NetCDF4 string variables with attributes as writing such variables is not supported in parallel mode. For consistency it also writes all other members of configuration group as attributes.

- [x] formatted time is written as attribute to time variable
- [x] write all members of configuration group as attributes for consistency