### PR TITLE
Issue338 no thermo

### DIFF
--- a/core/src/ConfigurationHelpPrinter.cpp
+++ b/core/src/ConfigurationHelpPrinter.cpp
@@ -186,7 +186,6 @@ std::ostream& ConfigurationHelpPrinter::printBoolean(
     return os;
 }
 
-
 static std::string ansiMode(std::string mode) { return "\033[" + mode + "m"; }
 
 void ConfigurationHelpPrinter::setOutput(Output out)

--- a/core/src/ConfigurationHelpPrinter.cpp
+++ b/core/src/ConfigurationHelpPrinter.cpp
@@ -110,6 +110,9 @@ std::ostream& ConfigurationHelpPrinter::print(std::ostream& os, const Configurat
     case (ConfigType::MODULE):
         return printModule(os, help);
         break;
+    case (ConfigType::BOOLEAN):
+        return printBoolean(os, help);
+        break;
     default:
         return os;
     }
@@ -148,7 +151,7 @@ std::ostream& ConfigurationHelpPrinter::printInteger(
     os << type("integer") + "     range: " << help.range[0] << "—" << help.range[1] << " "
        << help.units;
     if (!help.defaultValue.empty()) {
-        os << " default = " << help.defaultValue << ")";
+        os << " (default = " << help.defaultValue << ")";
     }
     os << std::endl;
     os << help.text << std::endl;
@@ -170,6 +173,19 @@ std::ostream& ConfigurationHelpPrinter::printModule(std::ostream& os, const Conf
     os << help.text << std::endl;
     return os;
 }
+std::ostream& ConfigurationHelpPrinter::printBoolean(
+    std::ostream& os, const ConfigurationHelp& help)
+{
+    os << option(help.name) << std::endl;
+    os << type("Boolean") + "                ";
+    if (!help.defaultValue.empty()) {
+        os << " (default = " << help.defaultValue << ")";
+    }
+    os << std::endl;
+    os << help.text << std::endl;
+    return os;
+}
+
 
 static std::string ansiMode(std::string mode) { return "\033[" + mode + "m"; }
 

--- a/core/src/include/ConfigurationHelp.hpp
+++ b/core/src/include/ConfigurationHelp.hpp
@@ -20,7 +20,7 @@ public:
     typedef std::list<ConfigurationHelp> OptionList;
     typedef std::map<std::string, OptionList> HelpMap;
 
-    enum class ConfigType { STRING, NUMERIC, INTEGER, MODULE };
+    enum class ConfigType { STRING, NUMERIC, INTEGER, MODULE, BOOLEAN };
 
     std::string name;
     ConfigType type;

--- a/core/src/include/ConfigurationHelpPrinter.hpp
+++ b/core/src/include/ConfigurationHelpPrinter.hpp
@@ -40,6 +40,7 @@ protected:
     static std::ostream& printNumeric(std::ostream& os, const ConfigurationHelp& help);
     static std::ostream& printInteger(std::ostream& os, const ConfigurationHelp& help);
     static std::ostream& printModule(std::ostream& os, const ConfigurationHelp& help);
+    static std::ostream& printBoolean(std::ostream& os, const ConfigurationHelp& help);
 };
 
 inline std::ostream& operator<<(std::ostream& os, const ConfigurationHelp& help)

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -143,9 +143,6 @@ void IceGrowth::update(const TimestepTime& tsTime)
                      std::placeholders::_2),
         tsTime);
 
-    // reset the new ice volume array
-    newice = 0;
-
     if (doThermo) {
         iVertical->update(tsTime);
         // new ice formation
@@ -166,6 +163,9 @@ void IceGrowth::initializeThicknesses(size_t i, const TimestepTime&)
         hice[i] = hice0[i] = 0.;
         hsnow[i] = hsnow0[i] = 0.;
     }
+
+    // reset the new ice volume array
+    newice = 0;
 }
 
 void IceGrowth::newIceFormation(size_t i, const TimestepTime& tst)

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -143,6 +143,9 @@ void IceGrowth::update(const TimestepTime& tsTime)
                      std::placeholders::_2),
         tsTime);
 
+    // reset the new ice volume array
+    newice = 0;
+
     if (doThermo) {
         iVertical->update(tsTime);
         // new ice formation

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -192,7 +192,7 @@ void IceGrowth::newIceFormation(size_t i, const TimestepTime& tst)
         qow[i] = sensibleFlux;
         newice[i] = latentFlux * tst.step * (1 - cice[i]) / (Ice::Lf * Ice::rho);
     } else {
-        newice[0] = 0;
+        newice[i] = 0;
     }
 }
 

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -99,6 +99,8 @@ IceGrowth::HelpMap& IceGrowth::getHelpText(HelpMap& map, bool getAll)
             std::to_string(IceMinima::cMinDefault), "", "Minimum allowed ice concentration." },
         { keyMap.at(MINH_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(IceMinima::hMinDefault), "m", "Minimum allowed ice thickness." },
+        { keyMap.at(USE_THERMO_KEY), ConfigType::BOOLEAN, { "true", "false" }, "true", "",
+            "Perform ice physics calculations as part of the timestep." },
     };
     return map;
 }
@@ -135,11 +137,11 @@ ConfigMap IceGrowth::getConfiguration() const
 
 void IceGrowth::update(const TimestepTime& tsTime)
 {
-        // Copy the ice data from the prognostic fields to the modifiable fields.
-        cice = cice0;
-        overElements(std::bind(&IceGrowth::initializeThicknesses, this, std::placeholders::_1,
-                         std::placeholders::_2),
-            tsTime);
+    // Copy the ice data from the prognostic fields to the modifiable fields.
+    cice = cice0;
+    overElements(std::bind(&IceGrowth::initializeThicknesses, this, std::placeholders::_1,
+                     std::placeholders::_2),
+        tsTime);
 
     if (doThermo) {
         iVertical->update(tsTime);

--- a/physics/src/include/IceGrowth.hpp
+++ b/physics/src/include/IceGrowth.hpp
@@ -27,6 +27,7 @@ public:
         LATERAL_GROWTH_KEY,
         MINC_KEY,
         MINH_KEY,
+        USE_THERMO_KEY,
     };
 
     void configure() override;
@@ -91,6 +92,8 @@ private:
     ModelArrayRef<ProtectedArray::TF, MARConstBackingStore> tf; // ocean freezing point, ˚C
     ModelArrayRef<SharedArray::DELTA_HICE, MARBackingStore>
         deltaHi; // New ice thickness this timestep, m
+
+    bool doThermo = true; // Perform any thermodynamics calculations at all
 
     void newIceFormation(size_t i, const TimestepTime&);
     void lateralIceSpread(size_t i, const TimestepTime&);


### PR DESCRIPTION
## Fixes \#338

Add an option to turn off the ice physics (metonymically: thermodynamics). Prevent any updates to the ice concentration, ice thickness or show thickness fields. However, do continue to calculate the ice-averaged values of those fields. The option name is ported from the equivalent option in Lagrangian neXtSIM, becoming `nextsim_thermo.use_thermo_forcing`. This is a boolean configuration option which defaults to true.

---
# Test

Add an additional test case to the existing `IceGrowth` class test suite. This re-runs one of the previous tests, except with the configuration option set to `false`.

---
# Documentation Impact

Actually documented the options in the 'nextsim_thermo' configuration section.
Added the description of the new `use_thermo_forcing` option to that section.
