### PR TITLE
add catch2 include_dirs to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ if (OPENMP_FOUND)
    endif()
 endif()
 
+pkg_search_module(CATCH2 catch2)
+if (CATCH2_FOUND)
+    message(STATUS "CATCH2 found : ${CATCH2_INCLUDE_DIRS}")
+endif()
 
 # Regarding Boost.Log, if our application consists of more
 # than one modules that use it, we must link to the shared

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -212,6 +212,7 @@ add_executable(testPrognosticData
     "${CoreSrc}/Time.cpp"
     )
 target_include_directories(testPrognosticData PRIVATE
+    "${CATCH2_INCLUDE_DIRS}"
     "${CoreSrc}"
     "${CoreSrc}/${ModelArrayStructure}"
     "${CoreModulesDir}"


### PR DESCRIPTION
# Pull Request Title
## Fixes #345 

### Task List
- [x] add `pkg-config` detection of `catch2` to `CMakeLists.txt`
- [ ] Updated the README or other documentation

---
# Change Description

- Previously CMake could only compile `PrognosticData_test.cpp` is catch2 is installed in the `/usr` dir.
- I have now added the option to detect via `pkg-config` which will allow spack install 

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [ ] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
