### PR TITLE
Remove homebrew extractions from the test workflows

### DIFF
--- a/.github/workflows/clang-compile-tests.yml
+++ b/.github/workflows/clang-compile-tests.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: clang
       run: |
-        brew extract --version=13.0.1 clang-format homebrew/cask
+        brew extract --version=13.0.1 clang-format homebrew/cask-versions
         brew install clang-format@13.0.1
         cd core/src
         clang-format --dry-run -Werror *cpp include/*hpp

--- a/.github/workflows/clang-compile-tests.yml
+++ b/.github/workflows/clang-compile-tests.yml
@@ -74,8 +74,6 @@ jobs:
         brew install boost
         brew install eigen
         brew install cmake
-        brew extract --version=2.13.9 catch2 homebrew/cask
-        brew install catch2@2.13.9
     - name: make
       run: |
         cmake .

--- a/.github/workflows/clang-compile-tests.yml
+++ b/.github/workflows/clang-compile-tests.yml
@@ -16,7 +16,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: clang
       run: |
-        brew install clang-format
+        brew extract --version=13.0.1 clang-format homebrew/cask
+        brew install clang-format@13.0.1
         cd core/src
         clang-format --dry-run -Werror *cpp include/*hpp
         cd -

--- a/.github/workflows/clang-compile-tests.yml
+++ b/.github/workflows/clang-compile-tests.yml
@@ -16,8 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: clang
       run: |
-        brew extract --version=13.0.1 clang-format homebrew/cask
-        brew install clang-format@13.0.1
+        brew install clang-format
         cd core/src
         clang-format --dry-run -Werror *cpp include/*hpp
         cd -


### PR DESCRIPTION
# Remove homebrew extractions from the test workflows
## Fixes \#352

---

# Change Description

After an update from v4.0.28 to v4.1.3 the macOS package manager homebrew began failing to extract packages in the test workflow environment, causing the tests to fail. Extracting, rather than installing, is an unusual thing to do and since this is now causing problems, should be eliminated.

One of the extractions is to obtain the most recent v2.xx of catch2, before the change to the multi-header code layout. Since catch2 is no longer used, this can be removed, meaning (hopefully) that the Mac compile and test workflow will complete.

The other is to get version v13.0.1 of clang-format.

---
# Test Description

If the workflows on github successfully complete, then it is fixed. If they do not, it is not fixed.
