### PR TITLE
Eliminate the compiler warning from PrognosticData_test.

### DIFF
--- a/core/test/PrognosticData_test.cpp
+++ b/core/test/PrognosticData_test.cpp
@@ -13,13 +13,14 @@
 #include "include/PrognosticData.hpp"
 
 #include "include/ConfiguredModule.hpp"
-#include "include/IOceanBoundary.hpp"
 #include "include/ModelComponent.hpp"
 #include "include/Module.hpp"
 #include "include/UnescoFreezing.hpp"
 #include "include/constants.hpp"
 
 #include <sstream>
+
+extern template class Module::Module<Nextsim::IOceanBoundary>;
 
 namespace Nextsim {
 


### PR DESCRIPTION
I made a mess of the original PR #309. So, I've closed that, cherry-picked the relevant commit and created this PR instead. The original text of PR #309 follows.

> Eliminate the compiler warnings.
>
> Will close https://github.com/nextsimdg/nextsimdg/issues/217
