### PR TITLE
Fix issue 357 by adding include<tuple>

### DIFF
--- a/physics/src/modules/include/IIceAlbedo.hpp
+++ b/physics/src/modules/include/IIceAlbedo.hpp
@@ -1,7 +1,7 @@
 /*
  * @file IIceAlbedo.hpp
  *
- * @date Aug 10, 2021
+ * @date Aug 10, 2023
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Örn Ólason <einar.olason@nersc.no>
  */

--- a/physics/src/modules/include/IIceAlbedo.hpp
+++ b/physics/src/modules/include/IIceAlbedo.hpp
@@ -9,6 +9,7 @@
 #define IICEALBEDO_HPP
 
 #include "include/Time.hpp"
+#include <tuple>
 
 namespace Nextsim {
 //! The interface class for ice albedo calculation.

--- a/physics/src/modules/include/IIceAlbedo.hpp
+++ b/physics/src/modules/include/IIceAlbedo.hpp
@@ -1,8 +1,9 @@
 /*
  * @file IIceAlbedo.hpp
  *
- * @date Sep 28, 2021
+ * @date Aug 10, 2021
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Einar Örn Ólason <einar.olason@nersc.no>
  */
 
 #ifndef IICEALBEDO_HPP


### PR DESCRIPTION
# Fix issue 357 by adding header file
## Fixes #357

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

# Change Description

I added #include <tuple> to IIceAlbedo.hpp, which gives the compiler the information it needs to compile the program.

This behaviour appears to be compiler dependent, as it only appears (so far) with g++ version 12.3.0. But including the tuple header file shouldn't hurt with other compilers.

---
# Test Description

The GitHub actions tests should cover this, but the behaviour is compiler version specific.

---
# Documentation Impact

None

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README