### PR TITLE
Issue347 improve cmake build efficiency - Work in progress

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,13 +87,85 @@ foreach(compo ${CodeComponents})
     add_subdirectory("${compo}")
 endforeach()
 
-# Link the model
-add_executable(nextsim "${NextsimSources}")
+set(sources
+"./core/src/Logged.cpp"
+"./core/src/Timer.cpp"
+"./core/src/Model.cpp"
+"./core/src/Iterator.cpp"
+"./core/src/Configurator.cpp"
+"./core/src/ConfigurationHelpPrinter.cpp"
+"./core/src/ConfiguredModule.cpp"
+"./core/src/CommandLineParser.cpp"
+"./core/src/CommonRestartMetadata.cpp"
+"./core/src/DevGridIO.cpp"
+"./core/src/RectGridIO.cpp"
+"./core/src/ParaGridIO.cpp"
+"./core/src/DevStep.cpp"
+"./core/src/StructureFactory.cpp"
+"./core/src/MissingData.cpp"
+"./core/src/ModelArray.cpp"
+"./core/src/ModelComponent.cpp"
+"./core/src/ModelMetadata.cpp"
+"./core/src/NetcdfMetadataConfiguration.cpp"
+"./core/src/NZLevels.cpp"
+"./core/src/PrognosticData.cpp"
+"./core/src/Time.cpp"
+"./core/src/discontinuousgalerkin/ModelArrayDetails.cpp"
+"./core/src/modules/DevGrid.cpp"
+"./core/src/modules/RectangularGrid.cpp"
+"./core/src/modules/ParametricGrid.cpp"
+"./core/src/modules/IStructureModule.cpp"
+"./core/src/modules/IFreezingPointModule.cpp"
+"./core/src/modules/DiagnosticOutputModule.cpp"
+"./core/src/modules/SimpleOutput.cpp"
+"./core/src/modules/ConfigOutput.cpp"
+"./physics/src/IceGrowth.cpp"
+"./physics/src/IceMinima.cpp"
+"./physics/src/SlabOcean.cpp"
+"./physics/src/modules/IIceAlbedoModule.cpp"
+"./physics/src/modules/CCSMIceAlbedo.cpp"
+"./physics/src/modules/SMUIceAlbedo.cpp"
+"./physics/src/modules/SMU2IceAlbedo.cpp"
+"./physics/src/modules/IceOceanHeatFluxModule.cpp"
+"./physics/src/modules/BasicIceOceanHeatFlux.cpp"
+"./physics/src/modules/IceThermodynamicsModule.cpp"
+"./physics/src/modules/ThermoIce0.cpp"
+"./physics/src/modules/ThermoWinton.cpp"
+"./physics/src/modules/LateralIceSpreadModule.cpp"
+"./physics/src/modules/HiblerSpread.cpp"
+"./physics/src/modules/FluxCalculationModule.cpp"
+"./physics/src/modules/FiniteElementFluxes.cpp"
+"./physics/src/modules/FiniteElementSpecHum.cpp"
+"./physics/src/modules/AtmosphereBoundaryModule.cpp"
+"./physics/src/modules/ConstantAtmosphereBoundary.cpp"
+"./physics/src/modules/ConfiguredAtmosphere.cpp"
+"./physics/src/modules/FluxConfiguredAtmosphere.cpp"
+"./physics/src/modules/OceanBoundaryModule.cpp"
+"./physics/src/modules/ConstantOceanBoundary.cpp"
+"./physics/src/modules/ConfiguredOcean.cpp"
+"./physics/src/modules/FluxConfiguredOcean.cpp"
+)
 
-target_include_directories(nextsim PRIVATE
+add_library(nextsimlib SHARED ${sources})
+target_include_directories(nextsimlib PRIVATE
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${NextsimIncludeDirs}"
     "${netCDF_INCLUDE_DIR}"
     )
-target_link_directories(nextsim PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(nextsim LINK_PUBLIC Boost::program_options Boost::log "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_directories(nextsimlib PUBLIC "${netCDF_LIB_DIR}")
+target_link_libraries(nextsimlib LINK_PUBLIC Boost::program_options Boost::log "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+
+
+# Link the model
+add_executable(nextsim ./core/src/main.cpp)
+# target_link_libraries(nextsim nextsimlib)
+
+# add_executable(nextsim "${NextsimSources}")
+
+target_include_directories(nextsim PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${NextsimIncludeDirs}"
+    # "${netCDF_INCLUDE_DIR}"
+    )
+# target_link_directories(nextsim PUBLIC "${netCDF_LIB_DIR}")
+target_link_libraries(nextsim LINK_PUBLIC nextsimlib)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -1,142 +1,75 @@
 # Build the unit, integration and model tests for neXtSIM
 
-set(INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}
+set(COMMON_INCLUDE_DIRS
     "../src/include"
     "../../core/src"
     "../../core/src/modules"
-    "../../core/src/discontinuousgalerkin"
-    # "../../core/src/include"
+    "../../core/src/include"
     )
-
-add_executable(testIterator
-    "Iterator_test.cpp"
-    )
-target_include_directories(testIterator PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testIterator PRIVATE nextsimlib doctest::doctest)
-
-add_executable(testCommandLineParser
-    "CommandLineParser_test.cpp"
-    "ArgV.cpp"
-    )
-target_include_directories(testCommandLineParser PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testCommandLineParser PRIVATE nextsimlib doctest::doctest)
-
-add_executable(testConfigurator
-    "Configurator_test.cpp"
-    "ArgV.cpp"
-    )
-target_include_directories(testConfigurator PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testConfigurator PRIVATE nextsimlib doctest::doctest)
-
-add_executable(testConfiguredModule
-    "ConfiguredModule_test.cpp"
-    "ArgV.cpp"
-)
-target_include_directories(testConfiguredModule PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testConfiguredModule PRIVATE nextsimlib doctest::doctest)
-
-add_executable(testTimer
-    "Timer_test.cpp"
-    )
-target_include_directories(testTimer PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testTimer PRIVATE nextsimlib doctest::doctest)
-
-add_executable(testScopedTimer
-    "ScopedTimer_test.cpp"
-    "../src/ScopedTimer.cpp"
-    )
-target_include_directories(testScopedTimer PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testScopedTimer PRIVATE nextsimlib doctest::doctest)
-
-set(INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    "../src/include"
-    "../../core/src"
-    "../../core/src/modules"
-    "./testmodelarraydetails/"
-    # "../../core/src/include"
-    )
-
-add_executable(testModelArray
-    "ModelArray_test.cpp"
-    "testmodelarraydetails/ModelArrayDetails.cpp"
-    )
-
-target_include_directories(testModelArray PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testModelArray PRIVATE nextsimlib doctest::doctest)
-
-add_executable(testDevGrid
-    "DevGrid_test.cpp"
-    )
-
-set(INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    "../src/include"
-    "../../core/src"
-    "../../core/src/modules"
-    "../../core/src/discontinuousgalerkin"
-    "${netCDF_INCLUDE_DIR}"
-    # "../../core/src/include"
-    )
-
-target_include_directories(testDevGrid PRIVATE ${INCLUDE_DIRS})
-target_link_directories(testDevGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testDevGrid PRIVATE nextsimlib doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
-
-add_executable(testParaGrid
-    "ParaGrid_test.cpp"
-    )
-
-target_include_directories(testParaGrid PRIVATE ${INCLUDE_DIRS})
-target_link_directories(testParaGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testParaGrid PRIVATE nextsimlib Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
-
-set(INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR}
-    "../src/include"
-    "../../core/src"
-    "../../core/src/modules"
-    "../../core/src/finitevolume"
-    "${netCDF_INCLUDE_DIR}"
-    # "../../core/src/include"
-    )
-
-add_executable(testRectGrid
-    "RectGrid_test.cpp"
-    )
-
-target_include_directories(testRectGrid PRIVATE ${INCLUDE_DIRS})
-target_link_directories(testRectGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testRectGrid PRIVATE nextsimlib Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
-
-add_executable(testModelComponent
-    "ModelComponent_test.cpp"
-)
-
-target_include_directories(testModelComponent PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testModelComponent PRIVATE nextsimlib doctest::doctest)
-
-add_executable(testTime
-    "Time_test.cpp"
-)
-target_include_directories(testTime PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testTime PRIVATE nextsimlib doctest::doctest)
-
-add_executable(testNewModelArrayRef
-    "NewModelArrayRef_test.cpp"
-)
-
-target_include_directories(testNewModelArrayRef PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(testNewModelArrayRef PRIVATE nextsimlib doctest::doctest)
 
 set(PHYSICS_INCLUDE_DIRS
     "../../physics/src"
     "../../physics/src/modules"
     )
 
-add_executable(testPrognosticData
-    "PrognosticData_test.cpp"
-    )
-target_include_directories(testPrognosticData PRIVATE ${INCLUDE_DIRS} ${PHYSICS_INCLUDE_DIRS})
+add_executable(testIterator "Iterator_test.cpp")
+target_include_directories(testIterator PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testIterator PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testCommandLineParser "CommandLineParser_test.cpp" "ArgV.cpp")
+target_include_directories(testCommandLineParser PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testCommandLineParser PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testConfigurator "Configurator_test.cpp" "ArgV.cpp")
+target_include_directories(testConfigurator PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testConfigurator PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testConfiguredModule "ConfiguredModule_test.cpp" "ArgV.cpp")
+target_include_directories(testConfiguredModule PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testConfiguredModule PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testTimer "Timer_test.cpp")
+target_include_directories(testTimer PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testTimer PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testScopedTimer "ScopedTimer_test.cpp" "../src/ScopedTimer.cpp")
+target_include_directories(testScopedTimer PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testScopedTimer PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testTime "Time_test.cpp")
+target_include_directories(testTime PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testTime PRIVATE nextsimlib doctest::doctest)
+
+set(MODEL_INCLUDE_DIRS "./testmodelarraydetails")
+
+add_executable(testModelArray "ModelArray_test.cpp" "testmodelarraydetails/ModelArrayDetails.cpp")
+target_include_directories(testModelArray PRIVATE ${COMMON_INCLUDE_DIRS} ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testModelArray PRIVATE nextsimlib doctest::doctest)
+
+set(MODEL_INCLUDE_DIRS "../../core/src/discontinuousgalerkin")
+
+add_executable(testDevGrid "DevGrid_test.cpp")
+target_include_directories(testDevGrid PRIVATE ${COMMON_INCLUDE_DIRS} ${MODEL_INCLUDE_DIRS} ${netCDF_INCLUDE_DIR})
+target_link_libraries(testDevGrid PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testParaGrid "ParaGrid_test.cpp")
+target_include_directories(testParaGrid PRIVATE ${COMMON_INCLUDE_DIRS} ${MODEL_INCLUDE_DIRS} ${netCDF_INCLUDE_DIR})
+target_link_libraries(testParaGrid PRIVATE nextsimlib doctest::doctest)
+
+set(MODEL_INCLUDE_DIRS "../../core/src/finitevolume")
+
+add_executable(testRectGrid "RectGrid_test.cpp")
+target_include_directories(testRectGrid PRIVATE ${COMMON_INCLUDE_DIRS} ${MODEL_INCLUDE_DIRS} ${netCDF_INCLUDE_DIR})
+target_link_libraries(testRectGrid PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testModelComponent "ModelComponent_test.cpp")
+target_include_directories(testModelComponent PRIVATE ${COMMON_INCLUDE_DIRS} ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testModelComponent PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testNewModelArrayRef "NewModelArrayRef_test.cpp")
+target_include_directories(testNewModelArrayRef PRIVATE ${COMMON_INCLUDE_DIRS} ${MODEL_INCLUDE_DIRS})
+target_link_libraries(testNewModelArrayRef PRIVATE nextsimlib doctest::doctest)
+
+add_executable(testPrognosticData "PrognosticData_test.cpp")
+target_include_directories(testPrognosticData PRIVATE ${COMMON_INCLUDE_DIRS} ${PHYSICS_INCLUDE_DIRS} ${MODEL_INCLUDE_DIRS})
 target_link_libraries(testPrognosticData PRIVATE nextsimlib doctest::doctest)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -1,221 +1,137 @@
 # Build the unit, integration and model tests for neXtSIM
 
-set(CoreSrc "../src")
-set(SRC_DIR "${CoreSrc}")
-set(INCLUDE_DIR "${CoreSrc}/include")
-set(CoreModulesDir "${CoreSrc}/modules")
-set(ModelArrayDetails "testmodelarraydetails")
-
-# add_executable(testexe
-#   test/TestSrc.cpp
-#   otherSource.cpp)
-#target_link_libraries(testexe PRIVATE doctest::doctest)
-
-include_directories(${INCLUDE_DIR})
+set(INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    "../src/include"
+    "../../core/src"
+    "../../core/src/modules"
+    "../../core/src/discontinuousgalerkin"
+    # "../../core/src/include"
+    )
 
 add_executable(testIterator
     "Iterator_test.cpp"
-    "${SRC_DIR}/Iterator.cpp"
-    "${SRC_DIR}/Time.cpp"
-    "${SRC_DIR}/Timer.cpp"
-    "${SRC_DIR}/Logged.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    
     )
-target_include_directories(testIterator PUBLIC "${SRC_DIR}")
-target_link_libraries(testIterator PRIVATE doctest::doctest Boost::program_options Boost::log)
+target_include_directories(testIterator PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testIterator PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testCommandLineParser
     "CommandLineParser_test.cpp"
     "ArgV.cpp"
-    "${SRC_DIR}/CommandLineParser.cpp"
-    "${SRC_DIR}/ConfigurationHelpPrinter.cpp"
     )
-target_include_directories(testCommandLineParser PUBLIC "${SRC_DIR}")
-target_link_libraries(testCommandLineParser LINK_PUBLIC Boost::program_options Boost::log doctest::doctest)
+target_include_directories(testCommandLineParser PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testCommandLineParser PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testConfigurator
     "Configurator_test.cpp"
     "ArgV.cpp"
-    "${SRC_DIR}/Configurator.cpp"
     )
-target_include_directories(testConfigurator PUBLIC "${SRC_DIR}")
-target_link_libraries(testConfigurator LINK_PUBLIC Boost::program_options Boost::log doctest::doctest)
+target_include_directories(testConfigurator PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testConfigurator PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testConfiguredModule
     "ConfiguredModule_test.cpp"
     "ArgV.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    "${SRC_DIR}/ConfiguredModule.cpp"
 )
-target_include_directories(testConfiguredModule PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}" "${SRC_DIR}")
-target_link_libraries(testConfiguredModule PRIVATE doctest::doctest Boost::program_options Boost::log)
+target_include_directories(testConfiguredModule PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testConfiguredModule PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testTimer
     "Timer_test.cpp"
-    "${SRC_DIR}/Timer.cpp"
     )
-target_link_libraries(testTimer PRIVATE doctest::doctest)
-target_include_directories(testTimer PRIVATE "${SRC_DIR}")
+target_include_directories(testTimer PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testTimer PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testScopedTimer
     "ScopedTimer_test.cpp"
-    "${SRC_DIR}/Timer.cpp"
-    "${SRC_DIR}/ScopedTimer.cpp"
+    "../src/ScopedTimer.cpp"
     )
-target_link_libraries(testScopedTimer PRIVATE doctest::doctest)
-target_include_directories(testScopedTimer PRIVATE "${SRC_DIR}")
+target_include_directories(testScopedTimer PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testScopedTimer PRIVATE nextsimlib doctest::doctest)
+
+set(INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    "../src/include"
+    "../../core/src"
+    "../../core/src/modules"
+    "./testmodelarraydetails/"
+    # "../../core/src/include"
+    )
 
 add_executable(testModelArray
     "ModelArray_test.cpp"
-    "${CoreSrc}/ModelArray.cpp"
-    "${ModelArrayDetails}/ModelArrayDetails.cpp"
+    "testmodelarraydetails/ModelArrayDetails.cpp"
     )
 
-target_include_directories(testModelArray PRIVATE "${CoreSrc}" "${ModelArrayDetails}")
-target_link_libraries(testModelArray PRIVATE doctest::doctest Eigen3::Eigen)
+target_include_directories(testModelArray PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testModelArray PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testDevGrid
     "DevGrid_test.cpp"
-    "${CoreModulesDir}/DevGrid.cpp"
-    "${CoreModulesDir}/IStructureModule.cpp"
-    "${CoreModulesDir}/RectangularGrid.cpp"
-    "${CoreModulesDir}/ParametricGrid.cpp"
-    "${SRC_DIR}/CommonRestartMetadata.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    "${SRC_DIR}/ConfiguredModule.cpp"
-    "${SRC_DIR}/DevGridIO.cpp"
-    "${SRC_DIR}/MissingData.cpp"
-    "${SRC_DIR}/ModelArray.cpp"
-    "${SRC_DIR}/ModelMetadata.cpp"
-    "${SRC_DIR}/NZLevels.cpp"
-    "${SRC_DIR}/Time.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
     )
 
-target_include_directories(testDevGrid PUBLIC "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}" "${CoreSrc}/${ModelArrayStructure}")
+set(INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    "../src/include"
+    "../../core/src"
+    "../../core/src/modules"
+    "../../core/src/discontinuousgalerkin"
+    "${netCDF_INCLUDE_DIR}"
+    # "../../core/src/include"
+    )
+
+target_include_directories(testDevGrid PRIVATE ${INCLUDE_DIRS})
 target_link_directories(testDevGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testDevGrid LINK_PUBLIC Boost::program_options Boost::log doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_libraries(testDevGrid PRIVATE nextsimlib doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+
+set(INCLUDE_DIRS
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    "../src/include"
+    "../../core/src"
+    "../../core/src/modules"
+    "../../core/src/finitevolume"
+    "${netCDF_INCLUDE_DIR}"
+    # "../../core/src/include"
+    )
 
 add_executable(testRectGrid
     "RectGrid_test.cpp"
-    "${CoreModulesDir}/RectangularGrid.cpp"
-    "${CoreModulesDir}/DevGrid.cpp"
-    "${CoreModulesDir}/ParametricGrid.cpp"
-    "${CoreModulesDir}/IStructureModule.cpp"
-    "${SRC_DIR}/CommonRestartMetadata.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    "${SRC_DIR}/ConfiguredModule.cpp"
-    "${SRC_DIR}/RectGridIO.cpp"
-    "${SRC_DIR}/MissingData.cpp"
-    "${SRC_DIR}/ModelArray.cpp"
-    "${SRC_DIR}/ModelMetadata.cpp"
-    "${SRC_DIR}/NZLevels.cpp"
-    "${SRC_DIR}/Time.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
     )
 
-target_include_directories(testRectGrid PUBLIC "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}" "${CoreSrc}/${ModelArrayStructure}")
+target_include_directories(testRectGrid PRIVATE ${INCLUDE_DIRS})
 target_link_directories(testRectGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testRectGrid LINK_PUBLIC Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_libraries(testRectGrid PRIVATE Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
 add_executable(testParaGrid
     "ParaGrid_test.cpp"
-    "${CoreModulesDir}/ParametricGrid.cpp"
-    "${CoreModulesDir}/RectangularGrid.cpp"
-    "${CoreModulesDir}/DevGrid.cpp"
-    "${CoreModulesDir}/IStructureModule.cpp"
-    "${SRC_DIR}/CommonRestartMetadata.cpp"
-    "${SRC_DIR}/Configurator.cpp"
-    "${SRC_DIR}/ConfiguredModule.cpp"
-    "${SRC_DIR}/ParaGridIO.cpp"
-    "${SRC_DIR}/MissingData.cpp"
-    "${SRC_DIR}/ModelArray.cpp"
-    "${SRC_DIR}/ModelMetadata.cpp"
-    "${SRC_DIR}/NZLevels.cpp"
-    "${SRC_DIR}/Time.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
     )
 
-target_include_directories(testParaGrid PUBLIC "${SRC_DIR}" "${CoreModulesDir}" "${PhysicsDir}" "${PhysicsModulesDir}" "${netCDF_INCLUDE_DIR}" "${CoreSrc}/${ModelArrayStructure}")
+target_include_directories(testParaGrid PRIVATE ${INCLUDE_DIRS})
 target_link_directories(testParaGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testParaGrid LINK_PUBLIC Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_libraries(testParaGrid PRIVATE Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
 add_executable(testModelComponent
     "ModelComponent_test.cpp"
-    "${CoreSrc}/ModelComponent.cpp"
-    "${CoreSrc}/MissingData.cpp"
-    "${CoreSrc}/Configurator.cpp"
-    "${CoreSrc}/ModelArray.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
 )
 
-target_include_directories(testModelComponent PRIVATE "${CoreSrc}" "${CoreSrc}/${ModelArrayStructure}")
-target_link_libraries(testModelComponent PRIVATE Boost::program_options doctest::doctest Eigen3::Eigen)
+target_include_directories(testModelComponent PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testModelComponent PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testTime
     "Time_test.cpp"
-    "${CoreSrc}/Time.cpp"
 )
-target_include_directories(testTime PRIVATE "${CoreSrc}")
-target_link_libraries(testTime PRIVATE doctest::doctest)
+target_include_directories(testTime PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testTime PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testNewModelArrayRef
     "NewModelArrayRef_test.cpp"
-    "${CoreSrc}/ModelArray.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
 )
 
-target_include_directories(testNewModelArrayRef PRIVATE "${CoreSrc}" "${CoreSrc}/${ModelArrayStructure}")
-target_link_libraries(testNewModelArrayRef PRIVATE doctest::doctest Eigen3::Eigen)
-
-# PrognosticData (and hopefully that alone) requires code from the physics tree
-set(PhysSourceDir "${CoreSrc}/../../physics/src/")
-set(PhysModulesDir "${CoreSrc}/../../physics/src/modules")
+target_include_directories(testNewModelArrayRef PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testNewModelArrayRef PRIVATE nextsimlib doctest::doctest)
 
 add_executable(testPrognosticData
     "PrognosticData_test.cpp"
-    "${CoreSrc}/PrognosticData.cpp"
-    "${CoreSrc}/Configurator.cpp"
-    "${CoreSrc}/ConfiguredModule.cpp"
-    "${CoreSrc}/ModelArray.cpp"
-    "${CoreSrc}/ModelComponent.cpp"
-    "${CoreSrc}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSrc}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${CoreSrc}/NZLevels.cpp"
-    "${PhysSourceDir}/IceGrowth.cpp"
-    "${PhysSourceDir}/IceMinima.cpp"
-    "${PhysSourceDir}/SlabOcean.cpp"
-    "${PhysModulesDir}/FiniteElementFluxes.cpp"
-    "${PhysModulesDir}/FiniteElementSpecHum.cpp"
-    "${PhysModulesDir}/FluxCalculationModule.cpp"
-    "${PhysModulesDir}/OceanBoundaryModule.cpp"
-    "${PhysModulesDir}/ConstantOceanBoundary.cpp"
-    "${PhysModulesDir}/ConfiguredOcean.cpp"
-    "${PhysModulesDir}/FluxConfiguredOcean.cpp"
-    "${PhysModulesDir}/AtmosphereBoundaryModule.cpp"
-    "${PhysModulesDir}/ConstantAtmosphereBoundary.cpp"
-    "${PhysModulesDir}/ConfiguredAtmosphere.cpp"
-    "${PhysModulesDir}/FluxConfiguredAtmosphere.cpp"
-    "${PhysModulesDir}/LateralIceSpreadModule.cpp"
-    "${PhysModulesDir}/HiblerSpread.cpp"
-    "${PhysModulesDir}/IceThermodynamicsModule.cpp"
-    "${PhysModulesDir}/ThermoIce0.cpp"
-    "${PhysModulesDir}/ThermoWinton.cpp"
-    "${PhysModulesDir}/IceOceanHeatFluxModule.cpp"
-    "${PhysModulesDir}/BasicIceOceanHeatFlux.cpp"
-    "${PhysModulesDir}/IIceAlbedoModule.cpp"
-    "${PhysModulesDir}/SMUIceAlbedo.cpp"
-    "${PhysModulesDir}/CCSMIceAlbedo.cpp"
-    "${PhysModulesDir}/SMU2IceAlbedo.cpp"
-    "${CoreSrc}/Time.cpp"
     )
-target_include_directories(testPrognosticData PRIVATE
-    "${CoreSrc}"
-    "${CoreSrc}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${PhysSourceDir}"
-    "${PhysModulesDir}"
-    )
-target_link_libraries(testPrognosticData PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
+target_include_directories(testPrognosticData PRIVATE ${INCLUDE_DIRS})
+target_link_libraries(testPrognosticData PRIVATE nextsimlib doctest::doctest)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -84,6 +84,14 @@ target_include_directories(testDevGrid PRIVATE ${INCLUDE_DIRS})
 target_link_directories(testDevGrid PUBLIC "${netCDF_LIB_DIR}")
 target_link_libraries(testDevGrid PRIVATE nextsimlib doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
+add_executable(testParaGrid
+    "ParaGrid_test.cpp"
+    )
+
+target_include_directories(testParaGrid PRIVATE ${INCLUDE_DIRS})
+target_link_directories(testParaGrid PUBLIC "${netCDF_LIB_DIR}")
+target_link_libraries(testParaGrid PRIVATE nextsimlib Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+
 set(INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}
     "../src/include"
@@ -101,14 +109,6 @@ add_executable(testRectGrid
 target_include_directories(testRectGrid PRIVATE ${INCLUDE_DIRS})
 target_link_directories(testRectGrid PUBLIC "${netCDF_LIB_DIR}")
 target_link_libraries(testRectGrid PRIVATE nextsimlib Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
-
-add_executable(testParaGrid
-    "ParaGrid_test.cpp"
-    )
-
-target_include_directories(testParaGrid PRIVATE ${INCLUDE_DIRS})
-target_link_directories(testParaGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testParaGrid PRIVATE nextsimlib Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
 add_executable(testModelComponent
     "ModelComponent_test.cpp"

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -100,7 +100,7 @@ add_executable(testRectGrid
 
 target_include_directories(testRectGrid PRIVATE ${INCLUDE_DIRS})
 target_link_directories(testRectGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testRectGrid PRIVATE Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_libraries(testRectGrid PRIVATE nextsimlib Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
 add_executable(testParaGrid
     "ParaGrid_test.cpp"
@@ -108,7 +108,7 @@ add_executable(testParaGrid
 
 target_include_directories(testParaGrid PRIVATE ${INCLUDE_DIRS})
 target_link_directories(testParaGrid PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(testParaGrid PRIVATE Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
+target_link_libraries(testParaGrid PRIVATE nextsimlib Boost::program_options doctest::doctest "${NSDG_NetCDF_Library}" Eigen3::Eigen)
 
 add_executable(testModelComponent
     "ModelComponent_test.cpp"
@@ -130,8 +130,13 @@ add_executable(testNewModelArrayRef
 target_include_directories(testNewModelArrayRef PRIVATE ${INCLUDE_DIRS})
 target_link_libraries(testNewModelArrayRef PRIVATE nextsimlib doctest::doctest)
 
+set(PHYSICS_INCLUDE_DIRS
+    "../../physics/src"
+    "../../physics/src/modules"
+    )
+
 add_executable(testPrognosticData
     "PrognosticData_test.cpp"
     )
-target_include_directories(testPrognosticData PRIVATE ${INCLUDE_DIRS})
+target_include_directories(testPrognosticData PRIVATE ${INCLUDE_DIRS} ${PHYSICS_INCLUDE_DIRS})
 target_link_libraries(testPrognosticData PRIVATE nextsimlib doctest::doctest)

--- a/dynamics/applications/CMakeLists.txt
+++ b/dynamics/applications/CMakeLists.txt
@@ -1,110 +1,49 @@
-# Include dynamics headers
-set(DynamicsSrc "../src")
-set(SRC_DIR "${DynamicsSrc}")
-set(INCLUDE_DIR "${DynamicsSrc}/include")
-
-set(CoreDir "../../core/src/")
-
-include_directories(${INCLUDE_DIR})
-
-add_executable(createNextsimMeshData createNextsimMeshData.cpp
-    "${CoreDir}/modules/ParametricGrid.cpp"
-    "${CoreDir}/modules/RectangularGrid.cpp"
-    "${CoreDir}/modules/DevGrid.cpp"
-    "${CoreDir}/modules/IStructureModule.cpp"
-    "${CoreDir}/CommonRestartMetadata.cpp"
-    "${CoreDir}/Configurator.cpp"
-    "${CoreDir}/ParaGridIO.cpp"
-    "${CoreDir}/MissingData.cpp"
-    "${CoreDir}/ModelArray.cpp"
-    "${CoreDir}/ModelMetadata.cpp"
-    "${CoreDir}/NZLevels.cpp"
-    "${CoreDir}/Time.cpp"
-    "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    )
-target_link_libraries(createNextsimMeshData LINK_PUBLIC Eigen3::Eigen Boost::program_options "${NSDG_NetCDF_Library}")
-target_link_directories(createNextsimMeshData PUBLIC "${netCDF_LIB_DIR}")
-target_include_directories(createNextsimMeshData PRIVATE "${CoreDir}" "${CoreDir}/modules" "${CoreDir}/${ModelArrayStructure}" "${netCDF_INCLUDE_DIR}")
-
-
-add_executable(benchmark_mehlmann_sasip_mevp benchmark_mehlmann_sasip_mevp.cpp
-    "${SRC_DIR}/stopwatch.cpp"
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/Interpolations.cpp"
-    "${SRC_DIR}/ParametricMesh.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
-    "${SRC_DIR}/cgParametricMomentum.cpp"
-    "${SRC_DIR}/VectorManipulations.cpp"
-    )
-add_executable(benchmark_mehlmann_orcamesh_mevp benchmark_mehlmann_orcamesh_mevp.cpp
-    "${SRC_DIR}/stopwatch.cpp"
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/Interpolations.cpp"
-    "${SRC_DIR}/ParametricMesh.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
-    "${SRC_DIR}/cgParametricMomentum.cpp"
-    "${SRC_DIR}/VectorManipulations.cpp"
-    )
-add_executable(benchmark_mehlmann_orcamesh_mevp_spherical benchmark_mehlmann_orcamesh_mevp_spherical.cpp
-    "${SRC_DIR}/stopwatch.cpp"
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/Interpolations.cpp"
-    "${SRC_DIR}/ParametricMesh.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
-    "${SRC_DIR}/cgParametricMomentum.cpp"
-    "${SRC_DIR}/VectorManipulations.cpp"
-    )
-add_executable(benchmark_cartesian_globe benchmark_cartesian_globe.cpp
-    "${SRC_DIR}/stopwatch.cpp"
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/Interpolations.cpp"
-    "${SRC_DIR}/ParametricMesh.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
-    "${SRC_DIR}/cgParametricMomentum.cpp"
-    "${SRC_DIR}/VectorManipulations.cpp"
-    )
-add_executable(benchmark_spherical_globe benchmark_spherical_globe.cpp
-    "${SRC_DIR}/stopwatch.cpp"
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/Interpolations.cpp"
-    "${SRC_DIR}/ParametricMesh.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
-    "${SRC_DIR}/cgParametricMomentum.cpp"
-    "${SRC_DIR}/VectorManipulations.cpp"
-    )
-add_executable(test_spherical_globe test_spherical_globe.cpp
-    "${SRC_DIR}/stopwatch.cpp"
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/Interpolations.cpp"
-    "${SRC_DIR}/ParametricMesh.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
-    "${SRC_DIR}/cgParametricMomentum.cpp"
-    "${SRC_DIR}/VectorManipulations.cpp"
-    )
-add_executable(benchmark_mehlmann_sasip_meb benchmark_mehlmann_sasip_meb.cpp
-    "${SRC_DIR}/stopwatch.cpp"
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/Interpolations.cpp"
-    "${SRC_DIR}/ParametricMesh.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
-    "${SRC_DIR}/cgParametricMomentum.cpp"
-    "${SRC_DIR}/VectorManipulations.cpp"
-    )
-add_executable(benchmark_box_sasip_mevp benchmark_box_sasip_mevp.cpp
-    "${SRC_DIR}/stopwatch.cpp"
-    "${SRC_DIR}/DGTransport.cpp"
-    "${SRC_DIR}/Interpolations.cpp"
-    "${SRC_DIR}/ParametricMesh.cpp"
-    "${SRC_DIR}/ParametricMap.cpp"
-    "${SRC_DIR}/cgParametricMomentum.cpp"
-    "${SRC_DIR}/VectorManipulations.cpp"
+set(COMMON_INCLUDE_DIRS
+    "../../core/src/discontinuousgalerkin"
+    "../../core/src"
+    "../../core/src/modules"
+    "../src"
+    "../src/include"
     )
 
-target_link_libraries(benchmark_mehlmann_sasip_mevp LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(benchmark_cartesian_globe LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(benchmark_spherical_globe LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(test_spherical_globe LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(benchmark_mehlmann_orcamesh_mevp LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(benchmark_mehlmann_orcamesh_mevp_spherical LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(benchmark_mehlmann_sasip_meb LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(benchmark_box_sasip_mevp LINK_PUBLIC Eigen3::Eigen)
+add_executable(createNextsimMeshData "createNextsimMeshData.cpp")
+target_include_directories(createNextsimMeshData PRIVATE ${COMMON_INCLUDE_DIRS} ${netCDF_INCLUDE_DIR})
+target_link_libraries(createNextsimMeshData LINK_PUBLIC nextsimlib)
+
+set(sources
+    "../src/stopwatch.cpp"
+    "../src/DGTransport.cpp"
+    "../src/Interpolations.cpp"
+    "../src/ParametricMesh.cpp"
+    "../src/ParametricMap.cpp"
+    "../src/cgParametricMomentum.cpp"
+    "../src/VectorManipulations.cpp"
+    )
+
+include_directories("../src/include")
+
+add_library(dynamicslib SHARED ${sources})
+
+add_executable(benchmark_mehlmann_sasip_mevp "benchmark_mehlmann_sasip_mevp.cpp")
+target_link_libraries(benchmark_mehlmann_sasip_mevp PRIVATE dynamicslib)
+
+add_executable(benchmark_mehlmann_orcamesh_mevp "benchmark_mehlmann_orcamesh_mevp.cpp")
+target_link_libraries(benchmark_mehlmann_orcamesh_mevp PRIVATE dynamicslib)
+
+add_executable(benchmark_mehlmann_orcamesh_mevp_spherical "benchmark_mehlmann_orcamesh_mevp_spherical.cpp")
+target_link_libraries(benchmark_mehlmann_orcamesh_mevp_spherical PRIVATE dynamicslib)
+
+add_executable(benchmark_cartesian_globe "benchmark_cartesian_globe.cpp")
+target_link_libraries(benchmark_cartesian_globe PRIVATE dynamicslib)
+
+add_executable(benchmark_spherical_globe "benchmark_spherical_globe.cpp")
+target_link_libraries(benchmark_spherical_globe PRIVATE dynamicslib)
+
+add_executable(test_spherical_globe "test_spherical_globe.cpp")
+target_link_libraries(test_spherical_globe PRIVATE dynamicslib)
+
+add_executable(benchmark_mehlmann_sasip_meb "benchmark_mehlmann_sasip_meb.cpp")
+target_link_libraries(benchmark_mehlmann_sasip_meb PRIVATE dynamicslib)
+
+add_executable(benchmark_box_sasip_mevp "benchmark_box_sasip_mevp.cpp")
+target_link_libraries(benchmark_box_sasip_mevp PRIVATE dynamicslib)

--- a/dynamics/tests/CMakeLists.txt
+++ b/dynamics/tests/CMakeLists.txt
@@ -1,80 +1,32 @@
-# Include dynamics headers
-set(DynamicsSrc "../src")
-set(SRC_DIR "${DynamicsSrc}")
-set(INCLUDE_DIR "${DynamicsSrc}/include")
-set(CoreDir "../../core/src/")
-
-include_directories(${INCLUDE_DIR})
-
-add_executable(example1-sasipmesh example1-sasipmesh.cpp
- "${SRC_DIR}/stopwatch.cpp"
- "${SRC_DIR}/Interpolations.cpp"
- "${SRC_DIR}/ParametricMesh.cpp"
- "${SRC_DIR}/DGTransport.cpp"
- "${SRC_DIR}/ParametricMap.cpp"
- "${SRC_DIR}/cgParametricMomentum.cpp"
- )
-target_include_directories(example1-sasipmesh PRIVATE "${CoreDir}")
-target_link_libraries(example1-sasipmesh LINK_PUBLIC Eigen3::Eigen)
-
-add_executable(example2-sasipmesh example2-sasipmesh.cpp
- "${SRC_DIR}/stopwatch.cpp"
- "${SRC_DIR}/DGTransport.cpp"
- "${SRC_DIR}/ParametricMap.cpp"
- "${SRC_DIR}/Interpolations.cpp"
- "${SRC_DIR}/ParametricMesh.cpp"
- "${SRC_DIR}/cgParametricMomentum.cpp"
- )
-target_include_directories(example2-sasipmesh PRIVATE "${CoreDir}")
-target_link_libraries(example2-sasipmesh LINK_PUBLIC Eigen3::Eigen)
-
-add_executable(example3-orcamesh example3-orcamesh.cpp
-"${SRC_DIR}/stopwatch.cpp"
- "${SRC_DIR}/DGTransport.cpp"
- "${SRC_DIR}/ParametricMap.cpp"
-"${SRC_DIR}/Interpolations.cpp"
-"${SRC_DIR}/ParametricMesh.cpp"
-"${SRC_DIR}/cgParametricMomentum.cpp"
-)
-target_include_directories(example3-orcamesh PRIVATE "${CoreDir}")
-target_link_libraries(example3-orcamesh LINK_PUBLIC Eigen3::Eigen)
-
-add_executable(dgma_test
-    "DGModelArray_test.cpp"
-    "${CoreDir}/ModelArray.cpp"
-    "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
+set(COMMON_INCLUDE_DIRS
+    "../../core/src/discontinuousgalerkin"
+    "../../core/src"
+    "../../core/src/modules"
+    "../src"
+    "../src/include"
     )
-target_include_directories(dgma_test PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}")
-target_link_libraries(dgma_test LINK_PUBLIC doctest::doctest Eigen3::Eigen)
 
-add_executable(cgma_test
-    "CGModelArray_test.cpp"
-    "${CoreDir}/ModelArray.cpp"
-    "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    )
-target_include_directories(cgma_test PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}")
-target_link_libraries(cgma_test LINK_PUBLIC doctest::doctest Eigen3::Eigen)
+add_executable(dgma_test "DGModelArray_test.cpp")
+target_include_directories(dgma_test PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(dgma_test PRIVATE nextsimlib doctest::doctest)
 
-add_executable(example4-orcamesh-spherical example4-orcamesh-spherical.cpp
-"${SRC_DIR}/stopwatch.cpp"
-"${SRC_DIR}/DGTransport.cpp"
-"${SRC_DIR}/Interpolations.cpp"
-"${SRC_DIR}/ParametricMesh.cpp"
-"${SRC_DIR}/ParametricMap.cpp"
-"${SRC_DIR}/cgParametricMomentum.cpp"
-)
+add_executable(cgma_test "CGModelArray_test.cpp")
+target_include_directories(cgma_test PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(cgma_test PRIVATE nextsimlib doctest::doctest)
 
-add_executable(example4-orcamesh-spherical-greenland example4-orcamesh-spherical-greenland.cpp
-"${SRC_DIR}/stopwatch.cpp"
-"${SRC_DIR}/DGTransport.cpp"
-"${SRC_DIR}/Interpolations.cpp"
-"${SRC_DIR}/ParametricMesh.cpp"
-"${SRC_DIR}/ParametricMap.cpp"
-"${SRC_DIR}/cgParametricMomentum.cpp"
-)
+include_directories("../src/include")
 
-target_link_libraries(example1-sasipmesh LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(example2-sasipmesh LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(example3-orcamesh  LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(example4-orcamesh-spherical  LINK_PUBLIC Eigen3::Eigen)
-target_link_libraries(example4-orcamesh-spherical-greenland  LINK_PUBLIC Eigen3::Eigen)
+add_executable(example1-sasipmesh "example1-sasipmesh.cpp")
+target_link_libraries(example1-sasipmesh PRIVATE dynamicslib)
+
+add_executable(example2-sasipmesh "example2-sasipmesh.cpp")
+target_link_libraries(example2-sasipmesh PRIVATE dynamicslib)
+
+add_executable(example3-orcamesh "example3-orcamesh.cpp")
+target_link_libraries(example3-orcamesh  PRIVATE dynamicslib)
+
+add_executable(example4-orcamesh-spherical "example4-orcamesh-spherical.cpp")
+target_link_libraries(example4-orcamesh-spherical  PRIVATE dynamicslib)
+
+add_executable(example4-orcamesh-spherical-greenland "example4-orcamesh-spherical-greenland.cpp")
+target_link_libraries(example4-orcamesh-spherical-greenland  PRIVATE dynamicslib)

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -1,206 +1,45 @@
 # Build the unit, integration and model tests for neXtSIM
 
-set(CoreSourceDir "${PROJECT_SOURCE_DIR}/core/src")
-set(CoreModulesDir "${CoreSourceDir}/modules")
-set(SourceDir "../src")
-set(ModulesDir "${SourceDir}/modules")
+set(COMMON_INCLUDE_DIRS
+    "../../core/src/discontinuousgalerkin"
+    "../../core/src"
+    "../../core/src/modules"
+    "../src"
+    "../src/modules"
+    )
 
-# add_executable(testexe
-#   test/TestSrc.cpp
-#   otherSource.cpp)
-#target_link_libraries(testexe PRIVATE doctest::doctest)
+add_executable(testIceGrowth "IceGrowth_test.cpp")
+target_include_directories(testIceGrowth PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testIceGrowth PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testIceGrowth
-    "IceGrowth_test.cpp"
-    "${SourceDir}/IceGrowth.cpp"
-    "${SourceDir}/IceMinima.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${CoreSourceDir}/NZLevels.cpp"
-    "${ModulesDir}/IceThermodynamicsModule.cpp"
-    "${ModulesDir}/LateralIceSpreadModule.cpp"
-    "${ModulesDir}/HiblerSpread.cpp"
-    "${ModulesDir}/ThermoIce0.cpp"
-    "${ModulesDir}/ThermoWinton.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testIceGrowth PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testIceGrowth PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
+add_executable(testThermoWinton "ThermoWintonTemperature_test.cpp")
+target_include_directories(testThermoWinton PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testThermoWinton PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testThermoWinton
-    "ThermoWintonTemperature_test.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreSourceDir}/NZLevels.cpp"
-    "${SourceDir}/IceMinima.cpp"
-    "${ModulesDir}/LateralIceSpreadModule.cpp"
-    "${ModulesDir}/HiblerSpread.cpp"
-    "${ModulesDir}/ThermoWinton.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testThermoWinton PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testThermoWinton PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
+add_executable(testFEFluxes "FiniteElementFluxes_test.cpp")
+target_include_directories(testFEFluxes PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testFEFluxes PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testFEFluxes
-    "FiniteElementFluxes_test.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${ModulesDir}/FiniteElementFluxes.cpp"
-    "${ModulesDir}/FiniteElementSpecHum.cpp"
-    "${ModulesDir}/IIceAlbedoModule.cpp"
-    "${ModulesDir}/SMUIceAlbedo.cpp"
-    "${ModulesDir}/CCSMIceAlbedo.cpp"
-    "${ModulesDir}/SMU2IceAlbedo.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testFEFluxes PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testFEFluxes PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
+add_executable(testConfiguredAtm "ConfiguredAtmosphere_test.cpp")
+target_include_directories(testConfiguredAtm PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testConfiguredAtm PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testConfiguredAtm
-    "ConfiguredAtmosphere_test.cpp"
-    "${ModulesDir}/ConfiguredAtmosphere.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${ModulesDir}/FiniteElementFluxes.cpp"
-    "${ModulesDir}/FiniteElementSpecHum.cpp"
-    "${ModulesDir}/FluxCalculationModule.cpp"
-    "${ModulesDir}/IIceAlbedoModule.cpp"
-    "${ModulesDir}/SMUIceAlbedo.cpp"
-    "${ModulesDir}/CCSMIceAlbedo.cpp"
-    "${ModulesDir}/SMU2IceAlbedo.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testConfiguredAtm PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testConfiguredAtm PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
+add_executable(testBIOHFluxes "BasicIceOceanFlux_test.cpp")
+target_include_directories(testBIOHFluxes PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testBIOHFluxes PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testBIOHFluxes
-    "BasicIceOceanFlux_test.cpp"
-    "${ModulesDir}/BasicIceOceanHeatFlux.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    )
-target_include_directories(testBIOHFluxes PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testBIOHFluxes PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
+add_executable(testSpecHum "SpecificHumidity_test.cpp")
+target_include_directories(testSpecHum PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testSpecHum PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testSpecHum
-    "SpecificHumidity_test.cpp"
-    "${ModulesDir}/FiniteElementSpecHum.cpp"
-    )
-target_include_directories(testSpecHum PRIVATE
-    "${ModulesDir}"
-    )
-target_link_libraries(testSpecHum PRIVATE doctest::doctest)
+add_executable(testConstantOcn "ConstantOceanBoundary_test.cpp")
+target_include_directories(testConstantOcn PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testConstantOcn PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testConstantOcn
-    "ConstantOceanBoundary_test.cpp"
-    "${ModulesDir}/ConstantOceanBoundary.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${ModulesDir}/FiniteElementFluxes.cpp"
-    "${ModulesDir}/FiniteElementSpecHum.cpp"
-    "${ModulesDir}/FluxCalculationModule.cpp"
-    "${ModulesDir}/IceOceanHeatFluxModule.cpp"
-    "${ModulesDir}/BasicIceOceanHeatFlux.cpp"
-    "${ModulesDir}/IIceAlbedoModule.cpp"
-    "${ModulesDir}/SMUIceAlbedo.cpp"
-    "${ModulesDir}/CCSMIceAlbedo.cpp"
-    "${ModulesDir}/SMU2IceAlbedo.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testConstantOcn PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testConstantOcn PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
+add_executable(testSlabOcn "SlabOcean_test.cpp")
+target_include_directories(testSlabOcn PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testSlabOcn PRIVATE nextsimlib doctest::doctest)
 
-add_executable(testSlabOcn
-    "SlabOcean_test.cpp"
-    "${SourceDir}/SlabOcean.cpp"
-    "${CoreSourceDir}/Configurator.cpp"
-    "${CoreSourceDir}/ConfiguredModule.cpp"
-    "${CoreSourceDir}/ModelArray.cpp"
-    "${CoreSourceDir}/ModelComponent.cpp"
-    "${CoreSourceDir}/MissingData.cpp"
-    "${CoreModulesDir}/IFreezingPointModule.cpp"
-    "${CoreSourceDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
-    "${CoreSourceDir}/Time.cpp"
-    )
-target_include_directories(testSlabOcn PRIVATE
-    "${CoreSourceDir}"
-    "${CoreSourceDir}/${ModelArrayStructure}"
-    "${CoreModulesDir}"
-    "${SourceDir}"
-    "${ModulesDir}"
-    )
-target_link_libraries(testSlabOcn PRIVATE Boost::program_options Boost::log doctest::doctest Eigen3::Eigen)
-
-add_executable(testIceMinima
-    "IceMinima_test.cpp"
-    "${SourceDir}/IceMinima.cpp"
-    )
-target_include_directories(testIceMinima PRIVATE "${SourceDir}")
-target_link_libraries(testIceMinima PRIVATE doctest::doctest)
+add_executable(testIceMinima "IceMinima_test.cpp")
+target_include_directories(testIceMinima PRIVATE ${COMMON_INCLUDE_DIRS})
+target_link_libraries(testIceMinima PRIVATE nextsimlib doctest::doctest)


### PR DESCRIPTION
# Pull Request Title

## Fixes \#347 and fixes \#210

---
# Change Description

* Previous build of code base took ~45 mins (e.g. see [github actions](https://github.com/nextsimdg/nextsimdg/actions/runs/5855514762)
* I have modified the following `CMakeLists.txt` files:
  * `core/test/CMakeLists.txt`
  * `dynamics/applications/CMakeLists.txt`
  * `dynamics/tests/CMakeLists.txt`
  * `physics/test/CMakeLists.txt`
* They should be a lot simpler to read and should be faster to compile.
* I have removed build duplication by linking against a compiled lib rather than rebuilding every cpp file for each executable (there are many tests, each are separate exe's)
* In my first attempt I have created two libraries:
  * the main library containing the majority of nextsimdg code (`nextsimlib`)
  * a smaller library containing code for dynamics (`dynamicslib`)
* These libraries can be merged or split further depending on use-case in future

* **My primary goal was to improve build time not necessarily thinking about how best to structure the code into libraries. This can be discussed at a later stage.**

---
# Documentation Impact

* shouldn't need any changes to docs but I might update the build instructions anyway as they are a bit out of date e.g., they still refer to `Catch2` which is no longer used.