### PR TITLE
tidy github ci workflow

### DIFF
--- a/.github/workflows/clang-compile-tests.yml
+++ b/.github/workflows/clang-compile-tests.yml
@@ -39,24 +39,16 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install netcdf-bin libnetcdf-c++4-dev libboost-all-dev libeigen3-dev cmake
-        git clone -b v2.x https://github.com/catchorg/Catch2.git
-        cd Catch2
-        cmake -Bbuild -H. -DBUILD_TESTING=OFF
-        sudo cmake --build build/ --target install
-        cd ..
     - name: make
       run: |
         cmake .
         make
     - name: run tests
       run: |
-        cd core/test
-        for file in $(find test* -maxdepth 0 -type f); do ./$file; done
-        cd -
-        for component in physics
+        for component in core physics
         do
             cd $component/test
-            for file in $(find test* -maxdepth 0 -type f); do ./$file; done
+            for file in $(find test* -maxdepth 0 -type f); do echo $file; ./$file; done
             cd -
         done
 
@@ -80,12 +72,9 @@ jobs:
         make
     - name: run tests
       run: |
-        cd core/test
-        for file in $(find test* -maxdepth 0 -type f); do ./$file; done
-        cd -
-        for component in physics
+        for component in core physics
         do
             cd $component/test
-            for file in $(find test* -maxdepth 0 -type f); do ./$file; done
+            for file in $(find test* -maxdepth 0 -type f); do echo $file; ./$file; done
             cd -
         done


### PR DESCRIPTION
# Improve CI Workflow
## Fixes \#371
---
# Change Description

currently test names are not printed when run (see e.g., [this failed job](https://github.com/nextsimdg/nextsimdg/actions/runs/5950366565/job/16138001232)).

If a test fails you have no way of knowing which one has failed (see output below).

```
Run cd core/test
...
[doctest] doctest version is "2.4.10"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:  7 |  7 passed | 0 failed | 0 skipped
[doctest] assertions: 68 | 68 passed | 0 failed |
[doctest] Status: SUCCESS!
libc++abi: terminating with uncaught exception of type std::out_of_range: map::at:  key not found
/Users/runner/work/_temp/1b1cdd50-e257-4534-a07b-fe9f8070ad92.sh: line 2:  4039 Abort trap: 6           ./$file
Error: Process completed with exit code 134.
```

This PR fixes #371 and removes some unnecessary building of catch2 in the ubuntu build (`build-and-tests-on-ubuntu`). 