### PR TITLE
Only override the restart coords in case of a spherical grid.

### DIFF
--- a/core/src/modules/DynamicsModule/MEVPDynamics.cpp
+++ b/core/src/modules/DynamicsModule/MEVPDynamics.cpp
@@ -43,21 +43,24 @@ void MEVPDynamics::setData(const ModelState::DataMap& ms)
     }
 
     // TODO: Remove this when spherical coordinates are fully implemented
-    if (isSpherical) std::cout << "Spherical coordinates are not yet implemented. Reverting to Cartesian." << std::endl;
-    isSpherical = false;
-    ModelArray fake25kmCoords(ModelArray::Type::VERTEX);
-    double d = 25000; // 25 km in metres
-    // Fill the fake coordinate array
-    for (size_t j = 0; j < ModelArray::size(ModelArray::Dimension::YVERTEX); ++j) {
-        for (size_t i = 0; i < ModelArray::size(ModelArray::Dimension::XVERTEX); ++i) {
-            fake25kmCoords.components({i, j})[0] = d * i;
-            fake25kmCoords.components({i, j})[1] = d * j;
+    ModelArray coords;
+    if (isSpherical) {
+        std::cout << "Spherical coordinates are not yet implemented. Reverting to Cartesian." << std::endl;
+        isSpherical = false;
+        ModelArray fake25kmCoords(ModelArray::Type::VERTEX);
+        double d = 25000; // 25 km in metres
+        // Fill the fake coordinate array
+        for (size_t j = 0; j < ModelArray::size(ModelArray::Dimension::YVERTEX); ++j) {
+            for (size_t i = 0; i < ModelArray::size(ModelArray::Dimension::XVERTEX); ++i) {
+                fake25kmCoords.components({i, j})[0] = d * i;
+                fake25kmCoords.components({i, j})[1] = d * j;
+            }
         }
+        coords = fake25kmCoords;
+        // End of code to be removed
+    } else {
+        coords = ms.at(coordsName);
     }
-    ModelArray& coords = fake25kmCoords;
-    // End of code to be removed
-
-    // ModelArray& coords = ms.at(coordsName);
     // TODO: Some encoding of the periodic edge boundary conditions
     kernel.initialisation(coords, isSpherical, ms.at(maskName));
 


### PR DESCRIPTION
# Pull Request Title
## Fixes \#503

Makes the coordinates work again for non-spherical grids.

Until issue #463 is complete, the dynamics do not work with spherical coordinates. In order to be able to continue using the `init_25kn_NH.nc` restart file, the coordinates are replaced in the initialization of the `DynamicsKernel` class with the Cartesian coordinates with a 25 km spacing that the corresponding `.smesh` file used to provide. However, when running from a file containing a Cartesian grid, the coordinates should not be replaced. This PR ensures that only `SPHERICAL` grids have their coordinates replaced by the 25 km grid.