### PR TITLE
Add explicit specialization of the base class to module.cpp

### DIFF
--- a/scripts/module_builder.py
+++ b/scripts/module_builder.py
@@ -101,6 +101,8 @@ template <> std::unique_ptr<{strings[class_name]}> getInstance()
 {{
     addToConfiguredModules<{strings[class_name]}, {strings[module_class_name]}>();
 }}
+
+template class {module_templ};
 """)
     source.write("""
 } /* namespace Module */


### PR DESCRIPTION
# Explicit specialization of the base class in `module.cpp`

Fixes #657

# Change Description

Add a line to `module_builder.py` to explicitly instantiate the templated `Module` class within the `module.cpp` source file.

---
# Test Description

The Release build successfully links all tests on MacOS/clang++.
