### PR TITLE
Issue538 seasurfaceheight

### DIFF
--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file ModelComponent.hpp
  *
- * @date 1 Jul 2024
+ * @date 23 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
@@ -50,7 +50,7 @@ namespace Protected {
         = "EXT_SSS"; // sea surface salinity from coupling or forcing, PSU
     inline constexpr TextTag EXT_SST
         = "EXT_SST"; // sea surface temperature from coupling or forcing, ˚C
-inline constexpr TextTag SSH = "SSH"; // sea surface height, m
+    inline constexpr TextTag SSH = "SSH"; // sea surface height, m
     inline constexpr TextTag EVAP_MINUS_PRECIP
         = "E-P"; // E-P atmospheric freshwater flux, kg s⁻¹ m⁻²
     // Derived fields, calculated once per timestep

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -50,6 +50,7 @@ namespace Protected {
         = "EXT_SSS"; // sea surface salinity from coupling or forcing, PSU
     inline constexpr TextTag EXT_SST
         = "EXT_SST"; // sea surface temperature from coupling or forcing, ˚C
+inline constexpr TextTag SSH = "SSH"; // sea surface height, m
     inline constexpr TextTag EVAP_MINUS_PRECIP
         = "E-P"; // E-P atmospheric freshwater flux, kg s⁻¹ m⁻²
     // Derived fields, calculated once per timestep

--- a/core/src/include/gridNames.hpp
+++ b/core/src/include/gridNames.hpp
@@ -28,6 +28,7 @@ static const std::string uWindName = "uwind";
 static const std::string vWindName = "vwind";
 static const std::string uOceanName = "uocean";
 static const std::string vOceanName = "vocean";
+static const std::string sshName = "ssh";
 
 static const std::string coordsName = "coords";
 static const std::string latitudeName = "latitude";

--- a/core/src/include/gridNames.hpp
+++ b/core/src/include/gridNames.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file gridNames.hpp
  *
- * @date Oct 24, 2022
+ * @date Aug 23, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/src/modules/DynamicsModule/BBMDynamics.cpp
+++ b/core/src/modules/DynamicsModule/BBMDynamics.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file BBMDynamics.cpp
  *
- * @date Jul 1, 2024
+ * @date Aug 23, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */

--- a/core/src/modules/DynamicsModule/BBMDynamics.cpp
+++ b/core/src/modules/DynamicsModule/BBMDynamics.cpp
@@ -80,6 +80,7 @@ void BBMDynamics::update(const TimestepTime& tst)
     kernel.setData(vWindName, vwind.data());
     kernel.setData(uOceanName, uocean.data());
     kernel.setData(vOceanName, vocean.data());
+    kernel.setData(sshName, ssh.data());
 
     /*
      * Ice velocity components are stored in the dynamics, and not changed by the model outside the

--- a/core/src/modules/DynamicsModule/MEVPDynamics.cpp
+++ b/core/src/modules/DynamicsModule/MEVPDynamics.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file MEVPDynamics.cpp
  *
- * @date 18 Jul 2024
+ * @date 23 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Piotr Minakowski <piotr.minakowski@ovgu.de>
  * @author Einar Ólason <einar.olason@nersc.no>

--- a/core/src/modules/DynamicsModule/MEVPDynamics.cpp
+++ b/core/src/modules/DynamicsModule/MEVPDynamics.cpp
@@ -69,6 +69,7 @@ void MEVPDynamics::update(const TimestepTime& tst)
     kernel.setData(vWindName, vwind.data());
     kernel.setData(uOceanName, uocean.data());
     kernel.setData(vOceanName, vocean.data());
+    kernel.setData(sshName, ssh.data());
 
     // kernel.setData(uName, uice);
     // kernel.setData(vName, vice);

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -31,6 +31,7 @@ public:
         , vwind(getStore())
         , uocean(getStore())
         , vocean(getStore())
+        , ssh(getStore())
         , m_usesDamage(usesDamageIn)
     {
         getStore().registerArray(Shared::DAMAGE, &damage, RW);
@@ -88,6 +89,7 @@ protected:
     ModelArrayRef<Protected::WIND_V> vwind;
     ModelArrayRef<Protected::OCEAN_U> uocean;
     ModelArrayRef<Protected::OCEAN_V> vocean;
+    ModelArrayRef<Protected::SSH> ssh;
 
     // Does this implementation of the dynamics use damage?
     bool m_usesDamage;

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IDynamics.hpp
  *
- * @date 7 Sep 2023
+ * @date 23 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/src/modules/include/ProtectedArrayNames.ipp
+++ b/core/src/modules/include/ProtectedArrayNames.ipp
@@ -1,7 +1,7 @@
 /*!
  * @file ProtectedArrayNames.ipp
  *
- * @date 1 Jul 2024
+ * @date 23 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */

--- a/core/src/modules/include/ProtectedArrayNames.ipp
+++ b/core/src/modules/include/ProtectedArrayNames.ipp
@@ -40,4 +40,5 @@
 { "sss_slab", "SLAB_SSS" }, // Slab ocean surface salinity PSU
 { "qdw", "SLAB_QDW" }, // Slab ocean temperature nudging heat flux, W m⁻²
 { "fdw", "SLAB_FDW" }, // Slab ocean salinity nudging water flux, kg s⁻¹ m⁻²
+{ "ssh", "SSH" }, // Slab ocean salinity nudging water flux, kg s⁻¹ m⁻²
 

--- a/core/src/modules/include/ProtectedArrayNames.ipp
+++ b/core/src/modules/include/ProtectedArrayNames.ipp
@@ -8,38 +8,38 @@
 
 // External ProtectedArray names must be unique wrt to the external SharedArray names as well
 { "damage", "DAMAGE0" }, // Ice thickness, cell average, m
-    { "hice", "H_ICE_cell" }, // Ice thickness, cell average, m
-    { "cice", "C_ICE0" }, // Ice concentration
-    { "hsnow", "H_SNOW_cell" }, // Snow depth, cell average, m
-    { "tice", "T_ICE0" }, // Ice temperature, ˚C
-    { "tair", "T_AIR" }, // Air temperature, ˚C
-    { "dew2m", "DEW_2M" }, // Dew point at 2 m, ˚C
-    { "pair", "P_AIR" }, // sea level air pressure, Pa
-    { "mixrat", "MIXRAT" }, // water vapour mass mixing ratio
-    { "sw_in", "SW_IN" }, // incoming shortwave flux, W m⁻²
-    { "lw_in", "LW_IN" }, // incoming longwave flux, W m⁻²
-    { "mld", "MLD" }, // mixed layer depth, m
-    { "snowfall", "SNOWFALL" }, // snow fall, kg m⁻² s⁻¹
-    { "sss", "SSS" }, // sea surface salinity, PSU
-    { "sst", "SST" }, // sea surface temperature ˚C
-    { "sst_ext", "EXT_SST" }, // External sea surface temperature ˚C
-    { "sss_ext", "EXT_SSS" }, // External sea surface salinity PSU
-    { "eminusp", "E-P" }, // E-P atmospheric freshwater flux, kg s⁻¹ m⁻²
-    { "mlcp", "CPML" }, // Mixed layer bulk heat capacity J K⁻¹ m⁻²
-    { "tf", "TF" }, // Ocean freezing temperature, ˚C
-    { "wind_speed", "WIND_SPEED" }, // Wind speed, m s⁻¹
-    { "wind_u", "WIND_U" }, // wind velocity x component, m s⁻¹
-    { "wind_v", "WIND_V" }, // wind velocity y component, m s⁻¹
-    { "hice_true_pro", "HTRUE_ICE" }, // Ice thickness, ice average, m
-    { "hsnow_true_pro", "HTRUE_SNOW" }, // Snow thickness, ice average, m
-    { "ocean_u", "OCEAN_U" }, // x(east)-ward ocean current, m s⁻¹
-    { "ocean_v", "OCEAN_V" }, // y(north)-ward ocean current, m s⁻¹
-    { "u", "ICE_U" }, // x(east)-ward ice velocity, m s⁻¹
-    { "v", "ICE_V" }, // y(north)-ward ice velocity, m s⁻¹
-    { "sst_slab", "SLAB_SST" }, // Slab ocean surface temperature ˚C
-    { "sss_slab", "SLAB_SSS" }, // Slab ocean surface salinity PSU
-    { "qdw", "SLAB_QDW" }, // Slab ocean temperature nudging heat flux, W m⁻²
-    { "fdw", "SLAB_FDW" }, // Slab ocean salinity nudging water flux, kg s⁻¹ m⁻²
+{ "hice", "H_ICE_cell" }, // Ice thickness, cell average, m
+{ "cice", "C_ICE0" }, // Ice concentration
+{ "hsnow", "H_SNOW_cell" }, // Snow depth, cell average, m
+{ "tice", "T_ICE0" }, // Ice temperature, ˚C
+{ "tair", "T_AIR" }, // Air temperature, ˚C
+{ "dew2m", "DEW_2M" }, // Dew point at 2 m, ˚C
+{ "pair", "P_AIR" }, // sea level air pressure, Pa
+{ "mixrat", "MIXRAT" }, // water vapour mass mixing ratio
+{ "sw_in", "SW_IN" }, // incoming shortwave flux, W m⁻²
+{ "lw_in", "LW_IN" }, // incoming longwave flux, W m⁻²
+{ "mld", "MLD" }, // mixed layer depth, m
+{ "snowfall", "SNOWFALL" }, // snow fall, kg m⁻² s⁻¹
+{ "sss", "SSS" }, // sea surface salinity, PSU
+{ "sst", "SST" }, // sea surface temperature ˚C
+{ "sst_ext", "EXT_SST" }, // External sea surface temperature ˚C
+{ "sss_ext", "EXT_SSS" }, // External sea surface salinity PSU
+{ "eminusp", "E-P" }, // E-P atmospheric freshwater flux, kg s⁻¹ m⁻²
+{ "mlcp", "CPML" }, // Mixed layer bulk heat capacity J K⁻¹ m⁻²
+{ "tf", "TF" }, // Ocean freezing temperature, ˚C
+{ "wind_speed", "WIND_SPEED" }, // Wind speed, m s⁻¹
+{ "wind_u", "WIND_U" }, // wind velocity x component, m s⁻¹
+{ "wind_v", "WIND_V" }, // wind velocity y component, m s⁻¹
+{ "hice_true_pro", "HTRUE_ICE" }, // Ice thickness, ice average, m
+{ "hsnow_true_pro", "HTRUE_SNOW" }, // Snow thickness, ice average, m
+{ "ocean_u", "OCEAN_U" }, // x(east)-ward ocean current, m s⁻¹
+{ "ocean_v", "OCEAN_V" }, // y(north)-ward ocean current, m s⁻¹
+{ "u", "ICE_U" }, // x(east)-ward ice velocity, m s⁻¹
+{ "v", "ICE_V" }, // y(north)-ward ice velocity, m s⁻¹
+{ "sst_slab", "SLAB_SST" }, // Slab ocean surface temperature ˚C
+{ "sss_slab", "SLAB_SSS" }, // Slab ocean surface salinity PSU
+{ "qdw", "SLAB_QDW" }, // Slab ocean temperature nudging heat flux, W m⁻²
+{ "fdw", "SLAB_FDW" }, // Slab ocean salinity nudging water flux, kg s⁻¹ m⁻²
 { "ssh", "SSH" }, // Slab ocean salinity nudging water flux, kg s⁻¹ m⁻²
 { "taux", "IO_STRESS_U" }, // Ice-ocean stress x(east) direction, Pa
 { "tauy", "IO_STRESS_V" }, // Ice-ocean stress x(east) direction, Pa

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file CGDynamicsKernel.cpp
  *
- * @date Jan 26, 2024
+ * @date Aug 23, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -113,7 +113,7 @@ void CGDynamicsKernel<DGadvection>::ComputeGradientOfSeaSurfaceHeight(
 {
     // First transform to CG1 Vector and do all computations in CG1
     CGVector<1> cgSeasurfaceHeight(*smesh);
-    Interpolations::DG2CG(*smesh, cgSeasurfaceHeight, SeasurfaceHeight);
+    Interpolations::DG2CG(*smesh, cgSeasurfaceHeight, seaSurfaceHeight);
 
     CGVector<1> uGrad(*smesh);
     CGVector<1> vGrad(*smesh);

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -36,6 +36,9 @@ void CGDynamicsKernel<DGadvection>::initialise(
     cgH.resize_by_mesh(*smesh);
     cgA.resize_by_mesh(*smesh);
 
+    uGradSeasurfaceHeight.resize_by_mesh(*smesh);
+    vGradSeasurfaceHeight.resize_by_mesh(*smesh);
+    
     dStressX.resize_by_mesh(*smesh);
     dStressY.resize_by_mesh(*smesh);
 
@@ -104,6 +107,149 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::prepareAdvection(
     dgtransport->prepareAdvection(u, v);
 }
 
+template <int DGadvection> void CGDynamicsKernel<DGadvection>::ComputeGradientOfSeaSurfaceHeight(const DGVector<1>& SeasurfaceHeight)
+{
+  // First transform to CG1 Vector and do all computations in CG1
+  CGVector<1> cgSeasurfaceHeight(*smesh);
+  Interpolations::DG2CG(*smesh, cgSeasurfaceHeight, SeasurfaceHeight);
+  
+  CGVector<1> uGrad(*smesh);
+  CGVector<1> vGrad(*smesh);
+  uGrad.setZero();
+  vGrad.setZero();
+
+    
+  // parallelization in stripes
+  for (size_t p = 0; p < 2; ++p) {
+#pragma omp parallel for schedule(static)
+    for (size_t cy = 0; cy < smesh->ny; ++cy) {
+      //!< loop over all cells of the mesh
+      if (cy % 2 == p) {
+	size_t eid   = smesh->nx * cy;
+	size_t cg1id = cy*(smesh->nx+1);
+	for (size_t cx = 0; cx < smesh->nx; ++cx, ++eid, ++cg1id)
+	  {
+	    // get local CG nodes
+	    Eigen::Vector<Nextsim::FloatType, 4> loc_cgSSH =
+	      {cgSeasurfaceHeight(cg1id),
+	       cgSeasurfaceHeight(cg1id+1),
+	       cgSeasurfaceHeight(cg1id+smesh->nx+1),
+	       cgSeasurfaceHeight(cg1id+smesh->nx+1+1)};
+	    
+	    // compute grad
+	    Eigen::Vector<Nextsim::FloatType, 4> tx = pmap->dX_SSH[eid] * loc_cgSSH;
+	    Eigen::Vector<Nextsim::FloatType, 4> ty = pmap->dY_SSH[eid] * loc_cgSSH;
+	    
+	    // add global vector
+	    uGrad(cg1id)   -= tx(0);
+	    uGrad(cg1id+1) -= tx(1);
+	    uGrad(cg1id+smesh->nx+1)  -= tx(2);
+	    uGrad(cg1id+smesh->nx+1+1) -= tx(3);
+	    vGrad(cg1id) -= ty(0);
+	    vGrad(cg1id+1) -= ty(1);
+	    vGrad(cg1id+smesh->nx+1) -= ty(2);
+	    vGrad(cg1id+smesh->nx+1+1) -= ty(3);
+	  }
+      }
+    }
+  }
+
+    // scale with mass
+#pragma omp parallel for
+  for (size_t i=0;i<uGrad.rows();++i)
+    {
+      uGrad(i) /= pmap->lumpedcg1mass(i);
+      vGrad(i) /= pmap->lumpedcg1mass(i);
+    }
+  
+  ///// correct boundary (just extend in last elements)
+  size_t cg1row = smesh->nx+1;
+  size_t topleft = smesh->ny*cg1row;
+  for (size_t i=1;i<smesh->nx;++i) // bottom / top
+    {
+      uGrad(i) = uGrad(i+cg1row);
+      vGrad(i) = vGrad(i+cg1row);
+      uGrad(topleft+i) = uGrad(topleft+i-cg1row);
+      vGrad(topleft+i) = vGrad(topleft+i-cg1row);
+    }
+  for (size_t i=1;i<smesh->ny;++i) // left / right
+    {
+      uGrad(i*cg1row) = uGrad(i*cg1row+1);
+      vGrad(i*cg1row) = vGrad(i*cg1row+1);
+	
+      uGrad(i*cg1row+cg1row-1) = uGrad(i*cg1row+cg1row-1-1);
+      vGrad(i*cg1row+cg1row-1) = vGrad(i*cg1row+cg1row-1-1);
+    }
+  // corners
+  uGrad(0) = uGrad(cg1row+1);
+  vGrad(0) = vGrad(cg1row+1);
+  uGrad(smesh->nx) = uGrad(smesh->nx + cg1row - 1);
+  vGrad(smesh->nx) = vGrad(smesh->nx + cg1row - 1);
+  uGrad(smesh->ny*cg1row) = uGrad((smesh->ny-1)*cg1row+1);
+  vGrad(smesh->ny*cg1row) = vGrad((smesh->ny-1)*cg1row+1);
+  uGrad((smesh->ny+1)*cg1row-1) = uGrad((smesh->ny)*cg1row-1-1);
+  vGrad((smesh->ny+1)*cg1row-1) = vGrad((smesh->ny)*cg1row-1-1);
+
+  // Interpolate to CG2 (maybe own function in interpolation?)
+  if (CGDEGREE==1)
+    {
+      uGradSeasurfaceHeight = uGrad;
+      vGradSeasurfaceHeight = vGrad;
+    }
+  else
+    {
+      // outer nodes
+      size_t icg1 = 0;
+#pragma omp parallel for
+      for (size_t iy=0;iy<=smesh->ny;++iy)
+	{
+	  size_t icg2 = (2*smesh->nx+1)*2*iy;
+	  for (size_t ix=0;ix<=smesh->nx;++ix,++icg1,icg2+=2)
+	    {
+	      uGradSeasurfaceHeight(icg2) = uGrad(icg1);
+	      vGradSeasurfaceHeight(icg2) = vGrad(icg1);
+	    }
+	}
+      // along lines
+#pragma omp parallel for
+      for (size_t iy=0;iy<=smesh->ny;++iy) // horizontal
+	{
+	  size_t icg1 = (smesh->nx+1)*iy;
+	  size_t icg2 = (2*smesh->nx+1)*2*iy+1;
+	  for (size_t ix=0;ix<smesh->nx;++ix,++icg1,icg2+=2)
+	    {
+	      uGradSeasurfaceHeight(icg2) = 0.5 * (uGrad(icg1)+uGrad(icg1+1));
+	      vGradSeasurfaceHeight(icg2) = 0.5 * (vGrad(icg1)+vGrad(icg1+1));
+	    }
+	}
+#pragma omp parallel for
+      for (size_t iy=0;iy<smesh->ny;++iy) // vertical 
+	{
+	  size_t icg1 = (smesh->nx+1)*iy;
+	  size_t icg2 = (2*smesh->nx+1)*(2*iy+1);
+	  for (size_t ix=0;ix<=smesh->nx;++ix,++icg1,icg2+=2)
+	    {
+	      uGradSeasurfaceHeight(icg2) = 0.5 * (uGrad(icg1)+uGrad(icg1+cg1row));
+	      vGradSeasurfaceHeight(icg2) = 0.5 * (vGrad(icg1)+vGrad(icg1+cg1row));
+	    }
+	}
+
+      // midpoints
+#pragma omp parallel for
+      for (size_t iy=0;iy<smesh->ny;++iy) // vertical 
+	{
+	  size_t icg1 = (smesh->nx+1)*iy;
+	  size_t icg2 = (2*smesh->nx+1)*(2*iy+1)+1;
+	  for (size_t ix=0;ix<smesh->nx;++ix,++icg1,icg2+=2)
+	    {
+	      uGradSeasurfaceHeight(icg2) = 0.25 * (uGrad(icg1)+uGrad(icg1+1)+uGrad(icg1+cg1row)+uGrad(icg1+cg1row+1));
+	      vGradSeasurfaceHeight(icg2) = 0.25 * (vGrad(icg1)+vGrad(icg1+1)+vGrad(icg1+cg1row)+vGrad(icg1+cg1row+1));
+	    }
+	}	
+    }
+}
+  
+  
 template <int DGadvection> void CGDynamicsKernel<DGadvection>::prepareIteration(const DataMap& data)
 {
     // interpolate ice height and concentration to local cg Variables
@@ -111,6 +257,10 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::prepareIteration(
     VectorManipulations::CGAveragePeriodic(*smesh, cgH);
     Interpolations::DG2CG(*smesh, cgA, data.at(ciceName));
     VectorManipulations::CGAveragePeriodic(*smesh, cgA);
+
+    // Reinit the gradient of the sea surface height. Not done by
+    // DataMap as SeasurfaceHeight is always dG(0)
+    ComputeGradientOfSeaSurfaceHeight(DynamicsKernel<DGadvection, DGstressComp>::SeasurfaceHeight);
 
     // limit A to [0,1] and H to [0, ...)
     cgA = cgA.cwiseMin(1.0);

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -259,8 +259,8 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::prepareIteration(
     VectorManipulations::CGAveragePeriodic(*smesh, cgA);
 
     // Reinit the gradient of the sea surface height. Not done by
-    // DataMap as SeasurfaceHeight is always dG(0)
-    ComputeGradientOfSeaSurfaceHeight(DynamicsKernel<DGadvection, DGstressComp>::SeasurfaceHeight);
+    // DataMap as seaSurfaceHeight is always dG(0)
+    ComputeGradientOfSeaSurfaceHeight(DynamicsKernel<DGadvection, DGstressComp>::seaSurfaceHeight);
 
     // limit A to [0,1] and H to [0, ...)
     cgA = cgA.cwiseMin(1.0);

--- a/dynamics/src/ParametricMap.cpp
+++ b/dynamics/src/ParametricMap.cpp
@@ -1,3 +1,10 @@
+/*!
+ * @file ParametricMap.cpp
+ *
+ * @date Aug 23, 2024
+ * @author Thomas Richter <thomas.richter@ovgu.de>
+ */
+
 #include "ParametricMap.hpp"
 #include "ParametricTools.hpp"
 #include "VectorManipulations.hpp"

--- a/dynamics/src/ParametricMap.cpp
+++ b/dynamics/src/ParametricMap.cpp
@@ -248,7 +248,7 @@ template <int CG> void ParametricMomentumMap<CG>::InitializeDivSMatrices()
             dy_cg2 = PHIy<CG, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fx.row(0).array()
             - PHIx<CG, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fy.row(0).array();
 
-	// same but using CG1 basis functions. Required for SeasurfaceHeight
+	// same but using CG1 basis functions. Required for seaSurfaceHeight
         const Eigen::Matrix<Nextsim::FloatType, 4, GAUSSPOINTS(CG2DGSTRESS(CG))>
             dx_cg1 = PHIx<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fy.row(1).array()
             - PHIy<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fx.row(1).array();

--- a/dynamics/src/ParametricMap.cpp
+++ b/dynamics/src/ParametricMap.cpp
@@ -93,8 +93,8 @@ template <int DG> void ParametricTransportMap<DG>::InitializeInverseDGMassMatrix
 //!
 template <int CG> void ParametricMomentumMap<CG>::InitializeLumpedCGMassMatrix()
 {
-  // Compute lumped mass matric for cG(CG)
-  
+    // Compute lumped mass matric for cG(CG)
+
     lumpedcgmass.resize_by_mesh(smesh);
 
     lumpedcgmass.zero();
@@ -175,21 +175,18 @@ template <int CG> void ParametricMomentumMap<CG>::InitializeLumpedCGMassMatrix()
                 Eigen::Vector<Nextsim::FloatType, 4> Meid;
 
                 if (smesh.CoordinateSystem == CARTESIAN) {
-                    const Eigen::Matrix<Nextsim::FloatType, 1, 2*2> J
-                        = ParametricTools::J<2>(smesh, eid).array()
-                        * GAUSSWEIGHTS<2>.array();
+                    const Eigen::Matrix<Nextsim::FloatType, 1, 2 * 2> J
+                        = ParametricTools::J<2>(smesh, eid).array() * GAUSSWEIGHTS<2>.array();
 
                     Meid = PHI<1, 2> * J.transpose();
                 } else if (smesh.CoordinateSystem == SPHERICAL) {
-                    const Eigen::Matrix<Nextsim::FloatType, 1, 2*2> cos_lat
-                        = (ParametricTools::getGaussPointsInElement<2>(smesh, eid)
-                                .row(1)
-                                .array())
+                    const Eigen::Matrix<Nextsim::FloatType, 1, 2 * 2> cos_lat
+                        = (ParametricTools::getGaussPointsInElement<2>(smesh, eid).row(1).array())
                               .cos();
 
-                    const Eigen::Matrix<Nextsim::FloatType, 1, 2*2> J
-                        = ParametricTools::J<2>(smesh, eid).array()
-                        * GAUSSWEIGHTS<2>.array() * cos_lat.array();
+                    const Eigen::Matrix<Nextsim::FloatType, 1, 2 * 2> J
+                        = ParametricTools::J<2>(smesh, eid).array() * GAUSSWEIGHTS<2>.array()
+                        * cos_lat.array();
 
                     Meid = PHI<1, 2> * J.transpose();
                 } else
@@ -199,11 +196,11 @@ template <int CG> void ParametricMomentumMap<CG>::InitializeLumpedCGMassMatrix()
                 const size_t sy = smesh.nx + 1;
                 const size_t n0 = iy * sy + ix;
 
-		lumpedcg1mass(n0, 0) += Meid(0);
-		lumpedcg1mass(n0 + 1, 0) += Meid(1);
-		
-		lumpedcg1mass(n0 + sy, 0) += Meid(2);
-		lumpedcg1mass(n0 + 1 + sy, 0) += Meid(3);
+                lumpedcg1mass(n0, 0) += Meid(0);
+                lumpedcg1mass(n0 + 1, 0) += Meid(1);
+
+                lumpedcg1mass(n0 + sy, 0) += Meid(2);
+                lumpedcg1mass(n0 + 1 + sy, 0) += Meid(3);
             }
     }
 }
@@ -255,16 +252,15 @@ template <int CG> void ParametricMomentumMap<CG>::InitializeDivSMatrices()
             dy_cg2 = PHIy<CG, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fx.row(0).array()
             - PHIx<CG, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fy.row(0).array();
 
-	// same but using CG1 basis functions. Required for seaSurfaceHeight
-        const Eigen::Matrix<Nextsim::FloatType, 4, GAUSSPOINTS(CG2DGSTRESS(CG))>
-            dx_cg1 = PHIx<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fy.row(1).array()
+        // same but using CG1 basis functions. Required for seaSurfaceHeight
+        const Eigen::Matrix<Nextsim::FloatType, 4, GAUSSPOINTS(CG2DGSTRESS(CG))> dx_cg1
+            = PHIx<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fy.row(1).array()
             - PHIy<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fx.row(1).array();
 
-        const Eigen::Matrix<Nextsim::FloatType, 4, GAUSSPOINTS(CG2DGSTRESS(CG))>
-            dy_cg1 = PHIy<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fx.row(0).array()
+        const Eigen::Matrix<Nextsim::FloatType, 4, GAUSSPOINTS(CG2DGSTRESS(CG))> dy_cg1
+            = PHIy<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fx.row(0).array()
             - PHIx<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise() * Fy.row(0).array();
 
-	
         const Eigen::Matrix<Nextsim::FloatType, 1, GAUSSPOINTS(CG2DGSTRESS(CG))> J
             = ParametricTools::J<GAUSSPOINTS1D(CG2DGSTRESS(CG))>(smesh, eid);
 
@@ -272,12 +268,11 @@ template <int CG> void ParametricMomentumMap<CG>::InitializeDivSMatrices()
             // divS is used for update of stress (S, nabla Phi) in Momentum
             divS1[eid] = dx_cg2 * PSI<CG2DGSTRESS(CG), GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose();
             divS2[eid] = dy_cg2 * PSI<CG2DGSTRESS(CG), GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose();
-	    
-	    // dX_SSH and dY_SSH are used to compute the gradient of the sea surface height
-	    // they store (d_[x/y] PHI_j, PHI_i)
-	    dX_SSH[eid] = dx_cg1 * PHI<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose();
-	    dY_SSH[eid] = dy_cg1 * PHI<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose();
 
+            // dX_SSH and dY_SSH are used to compute the gradient of the sea surface height
+            // they store (d_[x/y] PHI_j, PHI_i)
+            dX_SSH[eid] = dx_cg1 * PHI<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose();
+            dY_SSH[eid] = dy_cg1 * PHI<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose();
 
             // iMgradX/Y (inverse-Mass-gradient X/Y) is used to project strain rate from CG to DG
             const Eigen::Matrix<Nextsim::FloatType, CG2DGSTRESS(CG), CG2DGSTRESS(CG)> imass
@@ -320,12 +315,12 @@ template <int CG> void ParametricMomentumMap<CG>::InitializeDivSMatrices()
                 * PSI<CG2DGSTRESS(CG), GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose()
                 / Nextsim::EarthRadius;
 
-	    // same for CG1 (Sea-Surface Height)
-	    dX_SSH[eid] = dx_cg1 * PHI<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose() / Nextsim::EarthRadius;
-	    dY_SSH[eid] = (dy_cg1.array().rowwise() * cos_lat.array()).matrix()
-	      * PHI<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose() / Nextsim::EarthRadius;
+            // same for CG1 (Sea-Surface Height)
+            dX_SSH[eid] = dx_cg1 * PHI<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose()
+                / Nextsim::EarthRadius;
+            dY_SSH[eid] = (dy_cg1.array().rowwise() * cos_lat.array()).matrix()
+                * PHI<1, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.transpose() / Nextsim::EarthRadius;
 
-	    
             const Eigen::Matrix<Nextsim::FloatType, CG2DGSTRESS(CG), CG2DGSTRESS(CG)> imass
                 = SphericalTools::massMatrix<CG2DGSTRESS(CG)>(smesh, eid).inverse();
             iMgradX[eid] = imass * divS1[eid].transpose();

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -40,6 +40,8 @@ protected:
 
     using CGDynamicsKernel<DGadvection>::u;
     using CGDynamicsKernel<DGadvection>::v;
+    using CGDynamicsKernel<DGadvection>::uGradSeasurfaceHeight;
+    using CGDynamicsKernel<DGadvection>::vGradSeasurfaceHeight;
     using CGDynamicsKernel<DGadvection>::uAtmos;
     using CGDynamicsKernel<DGadvection>::vAtmos;
     using CGDynamicsKernel<DGadvection>::uOcean;
@@ -205,8 +207,10 @@ protected:
                 + cPrime * (vOcean(i) * cosOceanAngle + uOcean(i) * sinOceanAngle);
 
             // Stress gradient
-            const double gradX = dStressX(i) / pmap->lumpedcgmass(i);
-            const double gradY = dStressY(i) / pmap->lumpedcgmass(i);
+            const double gradX = dStressX(i) / pmap->lumpedcgmass(i)
+                - params.rho_ice * cgH(i) * params.gravity * uGradSeasurfaceHeight(i);
+            const double gradY = dStressY(i) / pmap->lumpedcgmass(i)
+                - params.rho_ice * cgH(i) * params.gravity * vGradSeasurfaceHeight(i);
 
             u(i) = alpha * uIce + beta * vIce
                 + dteOverMass * (alpha * (gradX + tauX) + beta * (gradY + tauY));

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -42,8 +42,10 @@ public:
     }
     virtual ~CGDynamicsKernel() = default;
     void initialise(const ModelArray& coords, bool isSpherical, const ModelArray& mask) override;
+  
     void setData(const std::string& name, const ModelArray& data) override;
     ModelArray getDG0Data(const std::string& name) const override;
+    void ComputeGradientOfSeaSurfaceHeight(const DGVector<1>& SeasurfaceHeight);  
     void prepareIteration(const DataMap& data) override;
     void projectVelocityToStrain() override;
     void stressDivergence() override;
@@ -60,6 +62,10 @@ protected:
     // CG ice thickness and concentration
     CGVector<CGdegree> cgA;
     CGVector<CGdegree> cgH;
+
+    // CG gradient of the SeasurfaceHeight
+    CGVector<CGdegree> uGradSeasurfaceHeight;
+    CGVector<CGdegree> vGradSeasurfaceHeight;
 
     // divergence of stress
     CGVector<CGdegree> dStressX;

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -63,7 +63,7 @@ protected:
     CGVector<CGdegree> cgA;
     CGVector<CGdegree> cgH;
 
-    // CG gradient of the SeasurfaceHeight
+    // CG gradient of the seaSurfaceHeight
     CGVector<CGdegree> uGradSeasurfaceHeight;
     CGVector<CGdegree> vGradSeasurfaceHeight;
 

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -42,10 +42,10 @@ public:
     }
     virtual ~CGDynamicsKernel() = default;
     void initialise(const ModelArray& coords, bool isSpherical, const ModelArray& mask) override;
-  
+
     void setData(const std::string& name, const ModelArray& data) override;
     ModelArray getDG0Data(const std::string& name) const override;
-    void ComputeGradientOfSeaSurfaceHeight(const DGVector<1>& SeasurfaceHeight);  
+    void ComputeGradientOfSeaSurfaceHeight(const DGVector<1>& seaSurfaceHeight);
     void prepareIteration(const DataMap& data) override;
     void projectVelocityToStrain() override;
     void stressDivergence() override;

--- a/dynamics/src/include/DynamicsKernel.hpp
+++ b/dynamics/src/include/DynamicsKernel.hpp
@@ -64,7 +64,7 @@ public:
         hice.resize_by_mesh(*smesh);
         cice.resize_by_mesh(*smesh);
 
-	SeasurfaceHeight.resize_by_mesh(*smesh);
+        seaSurfaceHeight.resize_by_mesh(*smesh);
 
         e11.resize_by_mesh(*smesh);
         e12.resize_by_mesh(*smesh);
@@ -99,6 +99,8 @@ public:
             DGModelArray::ma2dg(data, hice);
         } else if (name == ciceName) {
             DGModelArray::ma2dg(data, cice);
+        } else if (name == sshName) {
+            DGModelArray::ma2dg(data, seaSurfaceHeight);
         } else {
             // All other fields get shoved in a (labelled) bucket
             DGModelArray::ma2dg(data, advectedFields[name]);
@@ -173,7 +175,7 @@ protected:
     DGVector<DGadvection> cice;
 
     //! Vector storing the sea surface height (only dG(0) averages)
-    DGVector<1> SeasurfaceHeight;
+    DGVector<1> seaSurfaceHeight;
 
     //! Vectors storing strain and stress components
     DGVector<DGstress> e11, e12, e22;

--- a/dynamics/src/include/DynamicsKernel.hpp
+++ b/dynamics/src/include/DynamicsKernel.hpp
@@ -64,6 +64,8 @@ public:
         hice.resize_by_mesh(*smesh);
         cice.resize_by_mesh(*smesh);
 
+	SeasurfaceHeight.resize_by_mesh(*smesh);
+
         e11.resize_by_mesh(*smesh);
         e12.resize_by_mesh(*smesh);
         e22.resize_by_mesh(*smesh);
@@ -71,6 +73,7 @@ public:
         s12.resize_by_mesh(*smesh);
         s22.resize_by_mesh(*smesh);
     }
+
 
     /*!
      * @brief Sets the data from a provided ModelArray.
@@ -168,6 +171,9 @@ protected:
 
     DGVector<DGadvection> hice;
     DGVector<DGadvection> cice;
+
+    //! Vector storing the sea surface height (only dG(0) averages)
+    DGVector<1> SeasurfaceHeight;
 
     //! Vectors storing strain and stress components
     DGVector<DGstress> e11, e12, e22;

--- a/dynamics/src/include/DynamicsKernel.hpp
+++ b/dynamics/src/include/DynamicsKernel.hpp
@@ -74,7 +74,6 @@ public:
         s22.resize_by_mesh(*smesh);
     }
 
-
     /*!
      * @brief Sets the data from a provided ModelArray.
      *

--- a/dynamics/src/include/DynamicsParameters.hpp
+++ b/dynamics/src/include/DynamicsParameters.hpp
@@ -27,7 +27,7 @@ public:
 
     double ocean_turning_angle; //!< Ocean turning angle
 
-    double gravity;  //!< gravity parameter
+    double gravity; //!< gravity parameter
 
     DynamicsParameters()
     {
@@ -46,7 +46,7 @@ public:
         ocean_turning_angle = 25.; //!< Ocean turning angle
         ocean_turning_angle = 0.0; // FIXME decide between ocean turning angles
 
-	gravity = 9.81; //!< gravity parameter
+        gravity = 9.81; //!< gravity parameter
     }
 };
 }

--- a/dynamics/src/include/DynamicsParameters.hpp
+++ b/dynamics/src/include/DynamicsParameters.hpp
@@ -27,6 +27,8 @@ public:
 
     double ocean_turning_angle; //!< Ocean turning angle
 
+    double gravity;  //!< gravity parameter
+
     DynamicsParameters()
     {
         rho_ice = 900.0; //!< Sea ice density
@@ -43,6 +45,8 @@ public:
 
         ocean_turning_angle = 25.; //!< Ocean turning angle
         ocean_turning_angle = 0.0; // FIXME decide between ocean turning angles
+
+	gravity = 9.81; //!< gravity parameter
     }
 };
 }

--- a/dynamics/src/include/ParametricMap.hpp
+++ b/dynamics/src/include/ParametricMap.hpp
@@ -66,6 +66,8 @@ template <int CG> class ParametricMomentumMap {
 public:
     //! Vector to store the lumpes mass matrix. Is directly initialized when the mesh is known
     CGVector<CG> lumpedcgmass;
+    //! Vector to store the lumpes mass matrix in CG1. Neede to compute SeasurfaceGradient
+    CGVector<1> lumpedcg1mass;
 
     /*!
      * These matrices realize the integration of (-div S, phi) = (S, nabla phi)
@@ -76,6 +78,18 @@ public:
     std::vector<Eigen::Matrix<Nextsim::FloatType, CGDOFS(CG), CG2DGSTRESS(CG)>,
         Eigen::aligned_allocator<Eigen::Matrix<Nextsim::FloatType, CGDOFS(CG), CG2DGSTRESS(CG)>>>
         divS1, divS2, divM;
+
+    /*!
+     * These matrices are used to compute the gradient of the sea surface height via
+     * ( gH, Phi) = ( d_[X/Y] SSH, Phi) 
+     * where SSH is CG1-representation of SeasurfaceHeight
+     * 
+     * Very similar to divS1 and divS2 but working in CG(1) vectors
+     */
+  std::vector<Eigen::Matrix<Nextsim::FloatType, 4, 4>,
+    Eigen::aligned_allocator<Eigen::Matrix<Nextsim::FloatType, 4, 4>>>
+        dX_SSH, dY_SSH;
+  
 
     /*!
      * These matrices realize the integration of (E, \grad phi) scaled with the

--- a/dynamics/src/include/ParametricMap.hpp
+++ b/dynamics/src/include/ParametricMap.hpp
@@ -82,7 +82,7 @@ public:
     /*!
      * These matrices are used to compute the gradient of the sea surface height via
      * ( gH, Phi) = ( d_[X/Y] SSH, Phi) 
-     * where SSH is CG1-representation of SeasurfaceHeight
+     * where SSH is CG1-representation of seaSurfaceHeight
      * 
      * Very similar to divS1 and divS2 but working in CG(1) vectors
      */

--- a/dynamics/src/include/ParametricMap.hpp
+++ b/dynamics/src/include/ParametricMap.hpp
@@ -81,15 +81,14 @@ public:
 
     /*!
      * These matrices are used to compute the gradient of the sea surface height via
-     * ( gH, Phi) = ( d_[X/Y] SSH, Phi) 
+     * ( gH, Phi) = ( d_[X/Y] SSH, Phi)
      * where SSH is CG1-representation of seaSurfaceHeight
-     * 
+     *
      * Very similar to divS1 and divS2 but working in CG(1) vectors
      */
-  std::vector<Eigen::Matrix<Nextsim::FloatType, 4, 4>,
-    Eigen::aligned_allocator<Eigen::Matrix<Nextsim::FloatType, 4, 4>>>
+    std::vector<Eigen::Matrix<Nextsim::FloatType, 4, 4>,
+        Eigen::aligned_allocator<Eigen::Matrix<Nextsim::FloatType, 4, 4>>>
         dX_SSH, dY_SSH;
-  
 
     /*!
      * These matrices realize the integration of (E, \grad phi) scaled with the

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -36,6 +36,8 @@ protected:
 
     using CGDynamicsKernel<DGadvection>::u;
     using CGDynamicsKernel<DGadvection>::v;
+    using CGDynamicsKernel<DGadvection>::uGradSeasurfaceHeight;
+    using CGDynamicsKernel<DGadvection>::vGradSeasurfaceHeight;
     using CGDynamicsKernel<DGadvection>::uAtmos;
     using CGDynamicsKernel<DGadvection>::vAtmos;
     using CGDynamicsKernel<DGadvection>::uOcean;
@@ -122,8 +124,9 @@ protected:
                     + cgA(i)
                         * (params.F_atm * absatm * uAtmos(i) + // atm forcing
                             params.F_ocean * absocn * SC * uOcean(i)) // ocean forcing
-                    + params.rho_ice * cgH(i) * params.fc * vOcnRel // cor + surface
-                    + dStressX(i) / pmap->lumpedcgmass(i)));
+		   - params.rho_ice * cgH(i) * params.fc * u(i) // Coriolis
+		   - params.rho_ice * cgH(i) * params.gravity * uGradSeasurfaceHeight(i) // sea surface
+		   + dStressX(i) / pmap->lumpedcgmass(i)));
             v(i) = (1.0
                 / (params.rho_ice * cgH(i) / deltaT * (1.0 + beta) // implicit parts
                     + cgA(i) * params.F_ocean * absocn) // implicit parts
@@ -131,8 +134,9 @@ protected:
                     + cgA(i)
                         * (params.F_atm * absatm * vAtmos(i) + // atm forcing
                             params.F_ocean * absocn * SC * vOcean(i)) // ocean forcing
-                    + params.rho_ice * cgH(i) * params.fc
-                        * uOcnRel // here the reversed sign of uOcnRel is used
+		   + params.rho_ice * cgH(i) * params.fc * v(i) // Coriolis -  here the reversed sign of uOcnRel is used
+		   - params.rho_ice * cgH(i) * params.gravity * vGradSeasurfaceHeight(i) // sea surface
+		   
                     + dStressY(i) / pmap->lumpedcgmass(i)));
         }
     }

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file VPCGDynamicsKernel.hpp
  *
- * @date Feb 2, 2024
+ * @date Aug 23, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -124,9 +124,10 @@ protected:
                     + cgA(i)
                         * (params.F_atm * absatm * uAtmos(i) + // atm forcing
                             params.F_ocean * absocn * SC * uOcean(i)) // ocean forcing
-		   - params.rho_ice * cgH(i) * params.fc * u(i) // Coriolis
-		   - params.rho_ice * cgH(i) * params.gravity * uGradSeasurfaceHeight(i) // sea surface
-		   + dStressX(i) / pmap->lumpedcgmass(i)));
+                    - params.rho_ice * cgH(i) * params.fc * u(i) // Coriolis
+                    - params.rho_ice * cgH(i) * params.gravity
+                        * uGradSeasurfaceHeight(i) // sea surface
+                    + dStressX(i) / pmap->lumpedcgmass(i)));
             v(i) = (1.0
                 / (params.rho_ice * cgH(i) / deltaT * (1.0 + beta) // implicit parts
                     + cgA(i) * params.F_ocean * absocn) // implicit parts
@@ -134,9 +135,11 @@ protected:
                     + cgA(i)
                         * (params.F_atm * absatm * vAtmos(i) + // atm forcing
                             params.F_ocean * absocn * SC * vOcean(i)) // ocean forcing
-		   + params.rho_ice * cgH(i) * params.fc * v(i) // Coriolis -  here the reversed sign of uOcnRel is used
-		   - params.rho_ice * cgH(i) * params.gravity * vGradSeasurfaceHeight(i) // sea surface
-		   
+                    + params.rho_ice * cgH(i) * params.fc
+                        * v(i) // Coriolis -  here the reversed sign of uOcnRel is used
+                    - params.rho_ice * cgH(i) * params.gravity
+                        * vGradSeasurfaceHeight(i) // sea surface
+
                     + dStressY(i) / pmap->lumpedcgmass(i)));
         }
     }

--- a/physics/src/modules/OceanBoundaryModule/BenchmarkOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/BenchmarkOcean.cpp
@@ -24,6 +24,7 @@ void BenchmarkOcean::setData(const ModelState::DataMap& ms)
     mld = 10.;
     cpml = Water::rho * Water::cp * mld[0];
     qio = 0;
+    ssh = 0.;
 
     // The time and length scales of the current generation function
     constexpr double L = 512000.; // Size of the domain in km

--- a/physics/src/modules/OceanBoundaryModule/BenchmarkOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/BenchmarkOcean.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file BenchmarkOcean.cpp
  *
- * @date 19 Apr 2023
+ * @date 23 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ConfiguredOcean.cpp
  *
- * @date 7 Sep 2023
+ * @date 23 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -117,6 +117,5 @@ void ConfiguredOcean::updateAfter(const TimestepTime& tst)
     slabOcean.update(tst);
     sst = ModelArrayRef<Protected::SLAB_SST, RO>(getStore()).data();
     sss = ModelArrayRef<Protected::SLAB_SSS, RO>(getStore()).data();
-
 }
 } /* namespace Nextsim */

--- a/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
@@ -98,6 +98,10 @@ void ConfiguredOcean::setData(const ModelState::DataMap& ms)
     tf = Module::getImplementation<IFreezingPoint>()(sssExt[0]);
     cpml = Water::rho * Water::cp * mld[0];
 
+    /* It's only the SSH gradient which has an effect, so being able to sett a constant SSH is
+     * useless. */
+    ssh = 0.;
+
     slabOcean.setData(ms);
 
     Module::getImplementation<IIceOceanHeatFlux>().setData(ms);

--- a/physics/src/modules/OceanBoundaryModule/ConstantOceanBoundary.cpp
+++ b/physics/src/modules/OceanBoundaryModule/ConstantOceanBoundary.cpp
@@ -29,6 +29,7 @@ void ConstantOceanBoundary::setData(const ModelState::DataMap& ms)
     sst = tf32; // Tf == SST ensures that there is no ice-ocean heat flux
     cpml = Water::cp * Water::rho * mld;
     qio = 0.;
+    ssh = 0.;
 }
 
 void ConstantOceanBoundary::updateBefore(const TimestepTime& tst)

--- a/physics/src/modules/OceanBoundaryModule/ConstantOceanBoundary.cpp
+++ b/physics/src/modules/OceanBoundaryModule/ConstantOceanBoundary.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ConstantOceanBoundary.cpp
  *
- * @date Sep 26, 2022
+ * @date Aug 23, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
@@ -79,6 +79,10 @@ void FluxConfiguredOcean::setData(const ModelState::DataMap& ms)
     v = v0;
     tf = Module::getImplementation<IFreezingPoint>()(sss[0]);
     cpml = Water::rho * Water::cp * mld[0];
+
+    /* It's only the SSH gradient which has an effect, so being able to sett a constant SSH is
+     * useless. */
+    ssh = 0.;
 }
 
 } /* namespace Nextsim */

--- a/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file FluxConfiguredOcean.cpp
  *
- * @date Sep 29, 2022
+ * @date Aug 23, 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -55,7 +55,7 @@ void TOPAZOcean::configure()
 void TOPAZOcean::updateBefore(const TimestepTime& tst)
 {
     // TODO: Get more authoritative names for the forcings
-    std::set<std::string> forcings = { "sst", "sss", "mld", "u", "v" };
+    std::set<std::string> forcings = { "sst", "sss", "mld", "u", "v", "ssh" };
 
     ModelState state = ParaGridIO::readForcingTimeStatic(forcings, tst.start, filePath);
     sstExt = state.data.at("sst");
@@ -63,6 +63,7 @@ void TOPAZOcean::updateBefore(const TimestepTime& tst)
     mld = state.data.at("mld");
     u = state.data.at("u");
     v = state.data.at("v");
+    ssh = state.data.at("ssh");
 
     cpml = Water::rho * Water::cp * mld;
     overElements(std::bind(&TOPAZOcean::updateTf, this, std::placeholders::_1,

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file TOPAZOcean.cpp
  *
- * @date 7 Sep 2023
+ * @date 23 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/physics/src/modules/OceanBoundaryModule/UniformOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/UniformOcean.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file UniformOcean.cpp
  *
- * @date 30 Mar 2023
+ * @date 23 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/physics/src/modules/OceanBoundaryModule/UniformOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/UniformOcean.cpp
@@ -24,6 +24,10 @@ void UniformOcean::setData(const ModelState::DataMap& ms)
     tf = Module::getImplementation<IFreezingPoint>()(sss[0]);
     cpml = Water::rho * Water::cp * mld[0];
     qio = qio0;
+
+    /* It's only the SSH gradient which has an effect, so being able to sett a constant SSH is
+     * useless. */
+    ssh = 0.;
 }
 
 UniformOcean& UniformOcean::setSST(double sstIn)

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IOceanBoundary.hpp
  *
- * @date Sep 12, 2022
+ * @date Aug 23 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -18,6 +18,7 @@ constexpr TextTag SSS = "SSS"; // sea surface salinity PSU
 constexpr TextTag MLD = "MLD"; // Mixed layer or slab ocean depth m
 constexpr TextTag OCEAN_U = "U"; // x(east)-ward ocean current m s⁻¹
 constexpr TextTag OCEAN_V = "V"; // y(north)-ward ocean current m s⁻¹
+constexpr TextTag SSH = "SSH"; // sea surface height, m
 }
 //! An interface class for the oceanic inputs into the ice physics.
 class IOceanBoundary : public ModelComponent {
@@ -37,6 +38,7 @@ public:
         getStore().registerArray(Protected::TF, &tf, RO);
         getStore().registerArray(Protected::OCEAN_U, &u, RO);
         getStore().registerArray(Protected::OCEAN_V, &v, RO);
+        getStore().registerArray(Protected::SSH, &ssh, RO);
     }
     virtual ~IOceanBoundary() = default;
 
@@ -54,6 +56,7 @@ public:
         tf.resize();
         u.resize();
         v.resize();
+        ssh.resize();
 
         if (ms.count("sst")) {
             sst = ms.at("sst");
@@ -86,6 +89,7 @@ protected:
     HField cpml; // Heat capacity of the mixed layer, J K⁻¹ m²
     UField u; // x(east)-ward ocean current, m s⁻¹
     VField v; // y(north)-ward ocean current, m s⁻¹
+    VField ssh; // sea surface height, m
 
     ModelArrayReferenceStore m_couplingArrays;
 };

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IOceanBoundary.hpp
  *
- * @date Aug 23 2024
+ * @date 07 Oct 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -89,7 +89,7 @@ protected:
     HField cpml; // Heat capacity of the mixed layer, J K⁻¹ m²
     UField u; // x(east)-ward ocean current, m s⁻¹
     VField v; // y(north)-ward ocean current, m s⁻¹
-    VField ssh; // sea surface height, m
+    HField ssh; // sea surface height, m
 
     ModelArrayReferenceStore m_couplingArrays;
 };

--- a/physics/test/TOPAZOcn_test.cpp
+++ b/physics/test/TOPAZOcn_test.cpp
@@ -54,6 +54,7 @@ TEST_CASE("TOPAZOcean test")
     ModelArrayRef<Protected::MLD> mld(ModelComponent::getStore());
     ModelArrayRef<Protected::OCEAN_U> u(ModelComponent::getStore());
     ModelArrayRef<Protected::OCEAN_V> v(ModelComponent::getStore());
+    ModelArrayRef<Protected::SSH> ssh(ModelComponent::getStore());
 
     TimePoint t1("2000-01-01T00:00:00Z");
     TimestepTime tst = { t1, Duration(600) };
@@ -75,6 +76,7 @@ TEST_CASE("TOPAZOcean test")
     REQUIRE(sst(32, 32) == -0.032032);
     REQUIRE(sst(45, 35) == -(0 + targetFrac));
     REQUIRE(mld(45, 35) == (10 + targetFrac));
+    REQUIRE(ssh(45, 35) == (20 + targetFrac));
 
     TimePoint t2("2000-02-01T00:00:00Z");
     topaz.updateBefore({ t2, Duration(600) });
@@ -83,6 +85,7 @@ TEST_CASE("TOPAZOcean test")
     REQUIRE(sst(32, 32) == -0.032032 - 1);
     REQUIRE(sst(45, 35) == -(0 + targetFrac) - 1);
     REQUIRE(mld(45, 35) == (10 + targetFrac) + 1);
+    REQUIRE(ssh(45, 35) == (20 + targetFrac) + 1);
 
     TimePoint t12("2000-12-01T00:00:00Z");
     topaz.updateBefore({ t12, Duration(600) });
@@ -91,6 +94,7 @@ TEST_CASE("TOPAZOcean test")
     REQUIRE(sst(32, 32) == -0.032032 - 11);
     REQUIRE(sst(45, 35) == -(0 + targetFrac) - 11);
     REQUIRE(mld(45, 35) == (10 + targetFrac) + 11);
+    REQUIRE(ssh(45, 35) == (20 + targetFrac) + 11);
 
     // All times after the last time sample should use the last sample's data
     TimePoint t120("2010-01-01T00:00:00Z");
@@ -100,6 +104,7 @@ TEST_CASE("TOPAZOcean test")
     REQUIRE(sst(32, 32) == -0.032032 - 11);
     REQUIRE(sst(45, 35) == -(0 + targetFrac) - 11);
     REQUIRE(mld(45, 35) == (10 + targetFrac) + 11);
+    REQUIRE(ssh(45, 35) == (20 + targetFrac) + 11);
 
     std::filesystem::remove(filePath);
 }

--- a/physics/test/TOPAZOcn_test.cpp
+++ b/physics/test/TOPAZOcn_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ERA5Atm_test.cpp
  *
- * @date 7 Sep 2023
+ * @date 23 Aug 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/physics/test/topaz_test_data.py
+++ b/physics/test/topaz_test_data.py
@@ -122,6 +122,7 @@ sss = datagrp.createVariable("sss", "f8", timefield_dims)
 mld = datagrp.createVariable("mld", "f8", timefield_dims)
 u = datagrp.createVariable("u", "f8", timefield_dims)
 v = datagrp.createVariable("v", "f8", timefield_dims)
+ssh = datagrp.createVariable("ssh", "f8", timefield_dims)
 
 # 12 monthly values
 for t in range(12):
@@ -141,5 +142,8 @@ for t in range(12):
     
     v[t, :, :] = (200 + test_data + 100*t) * mask + mdi * antimask
     v.missing_value = mdi
-    
+
+    ssh[t, :, :] = (test_data + 20 + t) * mask + mdi * antimask
+    ssh.missing_value = mdi
+
 root.close()

--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -58,7 +58,7 @@ def era5_source_file_name(field, unix_time):
 # Returns the file name that holds the TOPAZ data for a given field at a given time
 def topaz4_source_file_name(field, unix_time):
     unix_tm = time.gmtime(unix_time)
-    if field in ("u", "v"):
+    if field in ("u", "v", "ssh"):
         # Ocean currents come from the 30 m files
         return f"TP4DAILY_{unix_tm.tm_year}{unix_tm.tm_mon:02}_30m.nc"
     else:
@@ -326,10 +326,10 @@ if __name__ == "__main__":
                 nc_times[time_index] = unix_times_e[target_t_index]
     era_root.close()
 
-    ocean_fields = ("mld", "sss", "sst")
+    ocean_fields = ("mld", "sss", "sst", "ssh")
     skip_ocean_fields = ()
     topaz_fields = ("mlp", "salinity", "temperature", "u", "v")
-    topaz_translation = {"mld" : "mlp", "sss" : "salinity", "sst" : "temperature"} # wind is special
+    topaz_translation = {"mld" : "mlp", "sss" : "salinity", "sst" : "temperature", "ssh" : "ssh"} # wind is special
 
 
     ###################################################################


### PR DESCRIPTION
# Add sea-surface height
Fixes #538 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [ ] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

This PR adds the contribution of the sea-surface-height gradient to both the mEVP and BBM codes (through VPCGDynamicsKernel and BrittleDynamicsKernel). SSH is read in from IOceanBoundary and passed to the dynamical core. It can also be output through ConfigOutput as "ssh".

---
# Test Description

No unit test was implemented for this feature, and no quantitative test exists. Qualitative testing shows that setting a fixed sea-surface-height gradient gives drift speed close to back-of-the-envelope estimates (13 cm/s modelled, 20 cm/s from back-of-the-envelope).

---
# Documentation Impact

None

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README