### PR TITLE
WIP: MPI-ify the dynamics

### DIFF
--- a/core/src/ModelArraySlice.cpp
+++ b/core/src/ModelArraySlice.cpp
@@ -49,6 +49,39 @@ ModelArraySlice& ModelArraySlice::operator=(ModelArray& ma)
     return *this;
 }
 
+ModelArraySlice& ModelArraySlice::operator=(const ModelArray::DataType& buffer)
+{
+    SliceIter thisIter(slice, data.dimensions());
+    // The iterator for the buffer must have the same dimensions as the target slice.
+    Slice::VBounds bufferBounds(data.nDimensions(), Slice::Bounds());
+    ModelArray::MultiDim bufferDims(data.nDimensions());
+    for (size_t dim = 0; dim < data.nDimensions(); ++dim) {
+        bufferDims[dim] = thisIter.nElements(dim);
+    }
+    SliceIter bufferIter(bufferBounds, bufferDims);
+    copySliceWithIters(buffer, bufferIter, data.m_data, thisIter);
+
+    return *this;
+}
+
+ModelArraySlice::operator ModelArray::DataType()
+{
+    SliceIter thisIter(slice, data.dimensions());
+    Slice::VBounds bufferBounds(data.nDimensions(), Slice::Bounds());
+    ModelArray::MultiDim bufferDims(data.nDimensions());
+    size_t nElements = 1;
+    for (size_t dim = 0; dim < data.nDimensions(); ++dim) {
+        bufferDims[dim] = thisIter.nElements(dim);
+        nElements *= bufferDims[dim];
+    }
+    SliceIter bufferIter(bufferBounds, bufferDims);
+    ModelArray::DataType buffer;
+    buffer.resize(nElements, data.nComponents());
+    copySliceWithIters(data.m_data, thisIter, buffer, bufferIter);
+
+    return buffer;
+}
+
 ModelArray& ModelArraySlice::copyToModelArray(ModelArray& target) const
 {
     copyBetweenMAandMASlice(target, *this, false, "ModelArraySlice::copyToModelArray(ModelArray)");

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -1,8 +1,9 @@
 /*!
  * @file ModelMetadata.cpp
  *
- * @date 21 August 2024
+ * @date 17 Jan 2025
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Tom Meltzer <tdm39@cam.ac.uk>
  */
 
 #include "include/ModelMetadata.hpp"
@@ -47,8 +48,8 @@ void ModelMetadata::readNeighbourData(netCDF::NcFile& ncFile)
     netCDF::NcGroup neighbourGroup(ncFile.getGroup(neighbourName));
     std::string varName {};
     for (auto edge : edges) {
-        size_t nStart {}; // start point in metadata arrays
-        size_t count {}; // number of elements to read from metadata arrays
+        size_t nStart = 0; // start point in metadata arrays
+        size_t count = 0; // number of elements to read from metadata arrays
         std::vector<int> numNeighbours = std::vector<int>(mpiSize, 0);
         std::vector<int> offsets = std::vector<int>(mpiSize, 0);
 
@@ -66,7 +67,8 @@ void ModelMetadata::readNeighbourData(netCDF::NcFile& ncFile)
             // initialize neighbour info to zero and correct size
             neighbourRanks[edge].resize(count, 0);
             neighbourExtents[edge].resize(count, 0);
-            neighbourHaloStarts[edge].resize(count, 0);
+            neighbourHaloSend[edge].resize(count, 0);
+            neighbourHaloRecv[edge].resize(count, 0);
 
             varName = edgeNames[edge] + "_neighbour_ids";
             neighbourGroup.getVar(varName).getVar({ nStart }, { count }, &neighbourRanks[edge][0]);
@@ -75,9 +77,13 @@ void ModelMetadata::readNeighbourData(netCDF::NcFile& ncFile)
             neighbourGroup.getVar(varName).getVar(
                 { nStart }, { count }, &neighbourExtents[edge][0]);
 
-            varName = edgeNames[edge] + "_neighbour_halo_starts";
+            varName = edgeNames[edge] + "_neighbour_halo_send";
             neighbourGroup.getVar(varName).getVar(
-                { nStart }, { count }, &neighbourHaloStarts[edge][0]);
+                { nStart }, { count }, &neighbourHaloSend[edge][0]);
+
+            varName = edgeNames[edge] + "_neighbour_halo_recv";
+            neighbourGroup.getVar(varName).getVar(
+                { nStart }, { count }, &neighbourHaloRecv[edge][0]);
         }
 
         // periodic neighbours
@@ -94,7 +100,8 @@ void ModelMetadata::readNeighbourData(netCDF::NcFile& ncFile)
             // initialize neighbour info to zero and correct size
             neighbourRanksPeriodic[edge].resize(count, 0);
             neighbourExtentsPeriodic[edge].resize(count, 0);
-            neighbourHaloStartsPeriodic[edge].resize(count, 0);
+            neighbourHaloSendPeriodic[edge].resize(count, 0);
+            neighbourHaloRecvPeriodic[edge].resize(count, 0);
 
             varName = edgeNames[edge] + "_neighbour_ids_periodic";
             neighbourGroup.getVar(varName).getVar(
@@ -104,9 +111,13 @@ void ModelMetadata::readNeighbourData(netCDF::NcFile& ncFile)
             neighbourGroup.getVar(varName).getVar(
                 { nStart }, { count }, &neighbourExtentsPeriodic[edge][0]);
 
-            varName = edgeNames[edge] + "_neighbour_halo_starts_periodic";
+            varName = edgeNames[edge] + "_neighbour_halo_send_periodic";
             neighbourGroup.getVar(varName).getVar(
-                { nStart }, { count }, &neighbourHaloStartsPeriodic[edge][0]);
+                { nStart }, { count }, &neighbourHaloSendPeriodic[edge][0]);
+
+            varName = edgeNames[edge] + "_neighbour_halo_recv_periodic";
+            neighbourGroup.getVar(varName).getVar(
+                { nStart }, { count }, &neighbourHaloRecvPeriodic[edge][0]);
         }
     }
 }

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -11,11 +11,11 @@
 #include "include/IStructure.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/gridNames.hpp"
-#include "mpi.h"
 #include <cstddef>
 #include <vector>
 
 #ifdef USE_MPI
+#include "mpi.h"
 #include <ncDim.h>
 #include <ncFile.h>
 #include <ncGroup.h>

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -10,6 +10,9 @@
 #include "include/IStructure.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/gridNames.hpp"
+#include "mpi.h"
+#include <cstddef>
+#include <vector>
 
 #ifdef USE_MPI
 #include <ncDim.h>
@@ -39,6 +42,75 @@ void ModelMetadata::setMpiMetadata(MPI_Comm comm)
     MPI_Comm_rank(mpiComm, &mpiMyRank);
 }
 
+void ModelMetadata::readNeighbourData(netCDF::NcFile& ncFile)
+{
+    netCDF::NcGroup neighbourGroup(ncFile.getGroup(neighbourName));
+    std::string varName {};
+    for (auto edge : edges) {
+        size_t nStart {}; // start point in metadata arrays
+        size_t count {}; // number of elements to read from metadata arrays
+        std::vector<int> numNeighbours = std::vector<int>(mpiSize, 0);
+        std::vector<int> offsets = std::vector<int>(mpiSize, 0);
+
+        // non-periodic neighbours
+        varName = edgeNames[edge] + "_neighbours";
+        neighbourGroup.getVar(varName).getVar(
+            { 0 }, { static_cast<size_t>(mpiSize) }, &numNeighbours[0]);
+
+        // compute start index for each process
+        MPI_Exscan(&numNeighbours[mpiMyRank], &nStart, 1, MPI_INT, MPI_SUM, mpiComm);
+        // how many elements to read for each process
+        count = numNeighbours[mpiMyRank];
+
+        if (count) {
+            // initialize neighbour info to zero and correct size
+            neighbourRanks[edge].resize(count, 0);
+            neighbourExtents[edge].resize(count, 0);
+            neighbourHaloStarts[edge].resize(count, 0);
+
+            varName = edgeNames[edge] + "_neighbour_ids";
+            neighbourGroup.getVar(varName).getVar({ nStart }, { count }, &neighbourRanks[edge][0]);
+
+            varName = edgeNames[edge] + "_neighbour_halos";
+            neighbourGroup.getVar(varName).getVar(
+                { nStart }, { count }, &neighbourExtents[edge][0]);
+
+            varName = edgeNames[edge] + "_neighbour_halo_starts";
+            neighbourGroup.getVar(varName).getVar(
+                { nStart }, { count }, &neighbourHaloStarts[edge][0]);
+        }
+
+        // periodic neighbours
+        varName = edgeNames[edge] + "_neighbours_periodic";
+        neighbourGroup.getVar(varName).getVar(
+            { 0 }, { static_cast<size_t>(mpiSize) }, &numNeighbours[0]);
+
+        // compute start index for each process
+        MPI_Exscan(&numNeighbours[mpiMyRank], &nStart, 1, MPI_INT, MPI_SUM, mpiComm);
+        // how many elements to read for each process
+        count = numNeighbours[mpiMyRank];
+
+        if (count) {
+            // initialize neighbour info to zero and correct size
+            neighbourRanksPeriodic[edge].resize(count, 0);
+            neighbourExtentsPeriodic[edge].resize(count, 0);
+            neighbourHaloStartsPeriodic[edge].resize(count, 0);
+
+            varName = edgeNames[edge] + "_neighbour_ids_periodic";
+            neighbourGroup.getVar(varName).getVar(
+                { nStart }, { count }, &neighbourRanksPeriodic[edge][0]);
+
+            varName = edgeNames[edge] + "_neighbour_halos_periodic";
+            neighbourGroup.getVar(varName).getVar(
+                { nStart }, { count }, &neighbourExtentsPeriodic[edge][0]);
+
+            varName = edgeNames[edge] + "_neighbour_halo_starts_periodic";
+            neighbourGroup.getVar(varName).getVar(
+                { nStart }, { count }, &neighbourHaloStartsPeriodic[edge][0]);
+        }
+    }
+}
+
 void ModelMetadata::getPartitionMetadata(std::string partitionFile)
 {
     // TODO: Move the reading of the partition file to its own class
@@ -53,11 +125,15 @@ void ModelMetadata::getPartitionMetadata(std::string partitionFile)
     globalExtentX = ncFile.getDim("NX").getSize();
     globalExtentY = ncFile.getDim("NY").getSize();
     netCDF::NcGroup bboxGroup(ncFile.getGroup(bboxName));
-    std::vector<size_t> index(1, mpiMyRank);
-    bboxGroup.getVar("domain_x").getVar(index, &localCornerX);
-    bboxGroup.getVar("domain_y").getVar(index, &localCornerY);
-    bboxGroup.getVar("domain_extent_x").getVar(index, &localExtentX);
-    bboxGroup.getVar("domain_extent_y").getVar(index, &localExtentY);
+
+    std::vector<size_t> rank(1, mpiMyRank);
+    bboxGroup.getVar("domain_x").getVar(rank, &localCornerX);
+    bboxGroup.getVar("domain_y").getVar(rank, &localCornerY);
+    bboxGroup.getVar("domain_extent_x").getVar(rank, &localExtentX);
+    bboxGroup.getVar("domain_extent_y").getVar(rank, &localExtentY);
+
+    readNeighbourData(ncFile);
+
     ncFile.close();
 }
 

--- a/core/src/include/ModelArraySlice.hpp
+++ b/core/src/include/ModelArraySlice.hpp
@@ -152,6 +152,32 @@ public:
     }
 
     /*!
+     * @brief Assigns to a slice from a instance of ModelArray::DataType.
+     *
+     * @details Fills the slice with data from an instance of ModelArray::DataType. The data source
+     * should be sufficiently sized that the data is copied without being indexed out-of-bounds.
+     * The number of components of the slice ModelArray and the size of the second dimension of the
+     * source array should match. The spatial dimensions of the slice will copy from the first
+     * dimension of the source array, treating it as a flattened one-dimensional version of the
+     * slice, with the first spatial dimension of the slice varying fastest.
+     *
+     * @params dataBuffer The source of the data to be copied into the slice.
+     */
+    ModelArraySlice& operator=(const ModelArray::DataType& dataBuffer);
+
+    /*!
+     * @brief Returns the contents of this slice as an instance of ModelArray::DataType.
+     *
+     * @details Creates an instance of ModelArray::DataType with the contents of the slice,
+     * including all components. Current ModelArray::DataType is Eigen::Array. In this case all
+     * spatial dimensions are flattened to one dimension, as they are internally in ModelArray,
+     * and occupy the first dimension of the Eigen::Array. Any components of the sliced array take
+     * up the second dimension. That is, a 4 x 5 slice with 3 components will create a (20, 3)
+     * Eigen::Array.
+     */
+    operator ModelArray::DataType();
+
+    /*!
      * Copies the contents of a slice to a ModelArray with an equal number of elements.
      * @param target The ModelArray object to copy the contents of the slice to.
      * @return A reference to the updated ModelArray object.

--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -13,7 +13,9 @@
 #include "include/ModelState.hpp"
 #include "include/Time.hpp"
 
+#include <ncFile.h>
 #include <string>
+#include <vector>
 
 #ifdef USE_MPI
 #include <mpi.h>
@@ -93,13 +95,34 @@ public:
      */
     void getPartitionMetadata(std::string partitionFile);
 
+    enum Edge { BOTTOM, RIGHT, TOP, LEFT, N_EDGE };
+    // An array to allow the edges to be accessed in the correct order.
+    static constexpr std::array<Edge, N_EDGE> edges = { BOTTOM, RIGHT, TOP, LEFT };
+    std::array<std::string, N_EDGE> edgeNames = { "bottom", "right", "top", "left" };
+
     MPI_Comm mpiComm;
     int mpiSize = 0;
     int mpiMyRank = -1;
-    int localCornerX, localCornerY, localExtentX, localExtentY, globalExtentX, globalExtentY;
+    int localCornerX, localCornerY;
+    int localExtentX, localExtentY;
+    int globalExtentX, globalExtentY;
+    // mpi rank ID and extent for each edge direction
+    std::array<std::vector<int>, N_EDGE> neighbourRanks;
+    std::array<std::vector<int>, N_EDGE> neighbourExtents;
+    std::array<std::vector<int>, N_EDGE> neighbourHaloStarts;
+    std::array<std::vector<int>, N_EDGE> neighbourRanksPeriodic;
+    std::array<std::vector<int>, N_EDGE> neighbourExtentsPeriodic;
+    std::array<std::vector<int>, N_EDGE> neighbourHaloStartsPeriodic;
 #endif
 
 private:
+    /*!
+     * @brief Read neighbour metadata from netCDF file
+     *
+     * @param netCDF file with partition metadata
+     */
+    void readNeighbourData(netCDF::NcFile& ncFile);
+
     TimePoint m_time;
     ConfigMap m_config;
 
@@ -116,6 +139,7 @@ private:
     bool hasParameters;
 #ifdef USE_MPI
     const std::string bboxName = "bounding_boxes";
+    const std::string neighbourName = "connectivity";
 #endif
 };
 

--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -1,8 +1,9 @@
 /*!
  * @file ModelMetadata.hpp
  *
- * @date Jun 29, 2022
+ * @date 17 Jan 2025
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Tom Meltzer <tdm39@cam.ac.uk>
  */
 
 #ifndef MODELMETADATA_HPP
@@ -109,10 +110,12 @@ public:
     // mpi rank ID and extent for each edge direction
     std::array<std::vector<int>, N_EDGE> neighbourRanks;
     std::array<std::vector<int>, N_EDGE> neighbourExtents;
-    std::array<std::vector<int>, N_EDGE> neighbourHaloStarts;
+    std::array<std::vector<int>, N_EDGE> neighbourHaloSend;
+    std::array<std::vector<int>, N_EDGE> neighbourHaloRecv;
     std::array<std::vector<int>, N_EDGE> neighbourRanksPeriodic;
     std::array<std::vector<int>, N_EDGE> neighbourExtentsPeriodic;
-    std::array<std::vector<int>, N_EDGE> neighbourHaloStartsPeriodic;
+    std::array<std::vector<int>, N_EDGE> neighbourHaloSendPeriodic;
+    std::array<std::vector<int>, N_EDGE> neighbourHaloRecvPeriodic;
 #endif
 
 private:

--- a/core/src/include/Slice.hpp
+++ b/core/src/include/Slice.hpp
@@ -122,7 +122,7 @@ public:
         Index stop;
         Int step;
         Bounds()
-            : Bounds(0, {}, 1)
+            : Bounds(0, Index(), 1)
         {
         }
         Bounds(Index i)
@@ -144,7 +144,10 @@ public:
         }
         std::ostream& print(std::ostream& os) const
         {
-            return os << start << ":" << stop << ":" << step;
+            start.print(os);
+            os << ":";
+            stop.print(os);
+            return os << ":" << step;
         }
         friend SliceIter;
     };

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -35,9 +35,11 @@ if(ENABLE_MPI)
     add_custom_command(
         OUTPUT partition_metadata_3_cb.nc partition_metadata_3_pb.nc
         COMMAND
-            ncgen -b -o partition_metadata_3_cb.nc ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_cb.cdl
+            ncgen -b -o partition_metadata_3_cb.nc
+            ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_cb.cdl
         COMMAND
-            ncgen -b -o partition_metadata_3_pb.nc ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_pb.cdl
+            ncgen -b -o partition_metadata_3_pb.nc
+            ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_pb.cdl
         DEPENDS
             ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_cb.cdl
             ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_pb.cdl

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -32,10 +32,24 @@ if(ENABLE_MPI)
             ncgen -b -o partition_metadata_2.nc ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_2.cdl
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_2.cdl
     )
+    add_custom_command(
+        OUTPUT partition_metadata_3_cb.nc partition_metadata_3_pb.nc
+        COMMAND
+            ncgen -b -o partition_metadata_3_cb.nc ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_cb.cdl
+        COMMAND
+            ncgen -b -o partition_metadata_3_pb.nc ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_pb.cdl
+        DEPENDS
+            ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_cb.cdl
+            ${CMAKE_CURRENT_SOURCE_DIR}/partition_metadata_3_pb.cdl
+    )
     add_custom_target(
         generate_partition_files
         ALL
-        DEPENDS partition_metadata_3.nc partition_metadata_2.nc
+        DEPENDS
+            partition_metadata_3.nc
+            partition_metadata_2.nc
+            partition_metadata_3_cb.nc
+            partition_metadata_3_pb.nc
     )
 
     add_executable(testRectGrid_MPI3 "RectGrid_test.cpp" "MainMPI.cpp")
@@ -48,6 +62,20 @@ if(ENABLE_MPI)
         PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule"
     )
     target_link_libraries(testRectGrid_MPI3 PRIVATE nextsimlib doctest::doctest)
+
+    add_executable(testModelMetadata_MPI3 "ModelMetadata_test.cpp" "MainMPI.cpp")
+    target_compile_definitions(
+        testModelMetadata_MPI3
+        PRIVATE
+            USE_MPI
+            TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"
+            TEST_FILE_SOURCE=\"${CMAKE_CURRENT_SOURCE_DIR}\"
+    )
+    target_include_directories(
+        testModelMetadata_MPI3
+        PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule"
+    )
+    target_link_libraries(testModelMetadata_MPI3 PRIVATE nextsimlib doctest::doctest)
 
     add_executable(testParaGrid_MPI2 "ParaGrid_test.cpp" "MainMPI.cpp")
     target_compile_definitions(

--- a/core/test/ModelArraySlice_test.cpp
+++ b/core/test/ModelArraySlice_test.cpp
@@ -21,7 +21,6 @@ const auto nz = 5;
 
 namespace Nextsim {
 TEST_SUITE_BEGIN("ModelArraySlice");
-#if false
 TEST_CASE("Assign scalar to slice")
 {
     ModelArray::setDimension(ModelArray::Dimension::X, nx);
@@ -500,7 +499,7 @@ TEST_CASE("Eigen copying")
     // Check the copied values
     REQUIRE(eig1(Indexer::indexer(eig1Dim, {iTest + oneWrap, 0}), 0) == source(iTest, ny-1));
 }
-#endif
+
 TEST_CASE("Eigen (ModelArray::DataType) buffers")
 {
     ModelArray::setDimension(ModelArray::Dimension::X, nx);
@@ -551,8 +550,6 @@ TEST_CASE("Eigen (ModelArray::DataType) buffers")
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 0) == 0);
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 5) == 5);
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {3, 5}), 2) == 2 + xMul * (3 + yMul * 5));
-
-
 }
 TEST_SUITE_END();
 } // namespace Nextsim

--- a/core/test/ModelArraySlice_test.cpp
+++ b/core/test/ModelArraySlice_test.cpp
@@ -551,5 +551,88 @@ TEST_CASE("Eigen (ModelArray::DataType) buffers")
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 5) == 5);
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {3, 5}), 2) == 2 + xMul * (3 + yMul * 5));
 }
+
+TEST_CASE("Eigen (ModelArray::DataType) subscripted buffers")
+{
+    ModelArray::setDimension(ModelArray::Dimension::X, nx);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny);
+
+    const size_t DG = 6;
+    ModelArray::setDimension(ModelArray::Dimension::COMP, DG);
+
+    double xMul = 100;
+    double yMul = 100;
+
+    // Buffer of the array perimeter
+    ModelArray maSrc(ModelArray::Type::TWOCOMP);
+    maSrc.resize();
+
+    for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+            double spatial = xMul * (i + yMul * j);
+            for (size_t c = 0; c < DG; ++c) {
+                maSrc.components({i, j})[c] = spatial + c;
+            }
+        }
+    }
+    REQUIRE(maSrc.components({2, 3})[4] == 4 + xMul * (2 + yMul * 3));
+
+    ModelArray::DataType perimeterBuffer;
+    perimeterBuffer.resize(2*nx + 2*ny, DG);
+    Slice left {{{0}, {}}};
+    Slice right {{{nx-1},{}}};
+    Slice bottom {{{},{0}}};
+    Slice top {{{}, {ny-1}}};
+    // bottom 0, nx points
+    perimeterBuffer(Eigen::seqN(0, nx), Eigen::all) = static_cast<ModelArray::DataType>(maSrc[bottom]);
+    // right nx, ny points
+    perimeterBuffer(Eigen::seqN(nx, ny), Eigen::all) = static_cast<ModelArray::DataType>(maSrc[right]);
+    // top nx + ny, nx points
+    perimeterBuffer(Eigen::seqN(nx+ny, nx), Eigen::all) = static_cast<ModelArray::DataType>(maSrc[top]);
+    // left 2nx + ny, ny points
+    perimeterBuffer(Eigen::seqN(2*nx+ny, ny), Eigen::all) = static_cast<ModelArray::DataType>(maSrc[left]);
+
+    // bottom check
+    for (size_t i = 0; i < nx; ++i) {
+        REQUIRE(perimeterBuffer(i, i % DG) == (i % DG) + xMul * i);
+    }
+    // right check
+    for (size_t j = 0; j < ny; ++j) {
+        REQUIRE(perimeterBuffer(j + nx, j % DG) == (j % DG) + xMul * (nx-1 + yMul * j));
+    }
+    // top check
+    for (size_t i = 0; i < nx; ++i) {
+        REQUIRE(perimeterBuffer(i + nx + ny, i % DG) == (i % DG) + xMul * (i + yMul * (ny -1)));
+    }
+    // left check
+    for (size_t j = 0; j < ny; ++j) {
+        REQUIRE(perimeterBuffer(j + 2 * nx + ny, j % DG) == (j % DG) + xMul * (0 + yMul * j));
+    }
+
+    ModelArray maSnk(ModelArray::Type::TWOCOMP);
+    maSnk.resize();
+    maSnk[bottom] = ModelArray::DataType(perimeterBuffer(Eigen::seqN(0, nx), Eigen::all));
+    maSnk[right] = ModelArray::DataType(perimeterBuffer(Eigen::seqN(nx, ny), Eigen::all));
+    maSnk[top] = ModelArray::DataType(perimeterBuffer(Eigen::seqN(nx + ny, nx), Eigen::all));
+    maSnk[left] = ModelArray::DataType(perimeterBuffer(Eigen::seqN(2*nx + ny, ny), Eigen::all));
+
+    // bottom check
+    for (size_t i = 0; i < nx; ++i) {
+        REQUIRE(maSnk.components({i, 0})[i % DG] == (i % DG) + xMul * i);
+    }
+    // right check
+    for (size_t j = 0; j < ny; ++j) {
+        REQUIRE(maSnk.components({nx-1, j})[j % DG] == (j % DG) + xMul * (nx-1 + yMul * j));
+    }
+    // top check
+    for (size_t i = 0; i < nx; ++i) {
+        REQUIRE(maSnk.components({i, ny-1})[i % DG] == (i % DG) + xMul * (i + yMul * (ny -1)));
+    }
+    // left check
+    for (size_t j = 0; j < ny; ++j) {
+        REQUIRE(maSnk.components({0, j})[j % DG] == (j % DG) + xMul * (0 + yMul * j));
+    }
+
+}
 TEST_SUITE_END();
 } // namespace Nextsim

--- a/core/test/ModelArraySlice_test.cpp
+++ b/core/test/ModelArraySlice_test.cpp
@@ -21,6 +21,7 @@ const auto nz = 5;
 
 namespace Nextsim {
 TEST_SUITE_BEGIN("ModelArraySlice");
+#if false
 TEST_CASE("Assign scalar to slice")
 {
     ModelArray::setDimension(ModelArray::Dimension::X, nx);
@@ -498,6 +499,60 @@ TEST_CASE("Eigen copying")
     source[topRow2].copyToSlicedBuffer(eig1_0, eig1BottomRowBlock);
     // Check the copied values
     REQUIRE(eig1(Indexer::indexer(eig1Dim, {iTest + oneWrap, 0}), 0) == source(iTest, ny-1));
+}
+#endif
+TEST_CASE("Eigen (ModelArray::DataType) buffers")
+{
+    ModelArray::setDimension(ModelArray::Dimension::X, nx);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny);
+
+    const size_t DG = 6;
+    ModelArray::setDimension(ModelArray::Dimension::COMP, DG);
+
+    size_t sliceNx = 7;
+    size_t sliceNy = 11;
+    size_t sliceX0 = 3;
+    size_t sliceY0 = 5;
+
+    double xMul = 100;
+    double yMul = 100;
+    ModelArray::DataType eaSrc;
+    eaSrc.resize(sliceNx * sliceNy, DG);
+    for (size_t j = 0; j < sliceNy; ++j) {
+        for (size_t i = 0; i < sliceNx; ++i) {
+            size_t ii = Indexer::indexer({sliceNx, sliceNy}, {i, j});
+            for (size_t c = 0; c < DG; ++c) {
+                eaSrc(ii, c) = c + xMul * (i + yMul * j);
+            }
+        }
+    }
+    REQUIRE(eaSrc(Indexer::indexer({sliceNx, sliceNy}, {2, 3}), 4) == 4 + xMul*(2 + yMul * 3));
+
+    ModelArray maInter(ModelArray::Type::TWOCOMP);
+    maInter = -1.;
+    REQUIRE(maInter.components({sliceX0+2, sliceY0+3})[4] == -1.);
+    Slice maSlice {{{sliceX0, sliceX0 + sliceNx}, {sliceY0, sliceY0 + sliceNy}}};
+    maInter[maSlice] = eaSrc;
+    REQUIRE(maInter.components({sliceX0-1, sliceY0-1})[0] == -1.);
+    REQUIRE(maInter.components({sliceX0-1, sliceY0-1})[DG-1] == -1.);
+    REQUIRE(maInter.components({sliceX0+0, sliceY0+0})[0] == 0.);
+    REQUIRE(maInter.components({sliceX0+0, sliceY0+0})[DG-1] == DG-1);
+    REQUIRE(maInter.components({sliceX0+1, sliceY0+0})[0] == xMul);
+    REQUIRE(maInter.components({sliceX0+1, sliceY0+0})[DG-1] == xMul + DG-1);
+    REQUIRE(maInter.components({sliceX0+0, sliceY0+1})[0] == xMul * yMul);
+    REQUIRE(maInter.components({sliceX0+0, sliceY0+1})[DG-1] == xMul  * yMul + DG-1);
+
+    REQUIRE(maInter.components({sliceX0+2, sliceY0+3})[4] == 4 + xMul*(2 + yMul * 3));
+
+    ModelArray::DataType eaSink;
+    eaSink.resize(sliceNx * sliceNy, DG);
+    eaSink = -1;
+    eaSink = maInter[maSlice];
+    REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 0) == 0);
+    REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 5) == 5);
+    REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {3, 5}), 2) == 2 + xMul * (3 + yMul * 5));
+
+
 }
 TEST_SUITE_END();
 } // namespace Nextsim

--- a/core/test/ModelMetadata_test.cpp
+++ b/core/test/ModelMetadata_test.cpp
@@ -1,0 +1,149 @@
+/*!
+ * @file ModelMetadata_test.cpp
+ *
+ * @date 18 Nov 2024
+ * @author Tom Meltzer <tdm39@cam.ac.uk>
+ */
+
+#include <doctest/extensions/doctest_mpi.h>
+#include <iostream>
+
+#include "ModelMetadata.hpp"
+
+const std::string testFilesDir = TEST_FILES_DIR;
+const std::string filename = testFilesDir + "/paraGrid_test.nc";
+const std::string diagFile = "paraGrid_diag.nc";
+const std::string dateString = "2000-01-01T00:00:00Z";
+const std::string partitionFilenameCB = testFilesDir + "/partition_metadata_3_cb.nc";
+const std::string partitionFilenamePB = testFilesDir + "/partition_metadata_3_pb.nc";
+
+namespace Nextsim {
+
+TEST_SUITE_BEGIN("ModelMetadata");
+MPI_TEST_CASE("Test getPartitionMetadata closed boundary", 3)
+{
+    ModelMetadata metadata(partitionFilenameCB, test_comm);
+    REQUIRE(metadata.mpiComm == test_comm);
+    // this metadata is specific to the non-periodic boundary conditions
+    if (test_rank == 0) {
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT] == std::vector<int> { 2 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::RIGHT] == std::vector<int> { 4 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::RIGHT] == std::vector<int> { 0 });
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP] == std::vector<int> { 1 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::TOP] == std::vector<int> { 7 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::TOP] == std::vector<int> { 0 });
+    } else if (test_rank == 1) {
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT] == std::vector<int> { 2 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::RIGHT] == std::vector<int> { 5 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::RIGHT] == std::vector<int> { 12 });
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM] == std::vector<int> { 0 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::BOTTOM] == std::vector<int> { 7 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::BOTTOM] == std::vector<int> { 21 });
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP].size() == 0);
+    } else if (test_rank == 2) {
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT] == std::vector<int> { 0, 1 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::LEFT] == std::vector<int> { 4, 5 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::LEFT] == std::vector<int> { 6, 6 });
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP].size() == 0);
+    } else {
+        std::cerr << "only valid for 3 ranks" << std::endl;
+        exit(1);
+    }
+
+    // This metadata is specific to the periodic boundary conditions.
+    // They are all zero because the input metadata file `partitionFilenameCB` does not use periodic
+    // boundary conditions.
+    REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::LEFT].size() == 0);
+    REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::RIGHT].size() == 0);
+    REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::BOTTOM].size() == 0);
+    REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::TOP].size() == 0);
+}
+
+MPI_TEST_CASE("Test getPartitionMetadata periodic boundary", 3)
+{
+    ModelMetadata metadata(partitionFilenamePB, test_comm);
+    REQUIRE(metadata.mpiComm == test_comm);
+    // this metadata should be identical to the Closed Boundary version so we check it again
+    if (test_rank == 0) {
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT] == std::vector<int> { 2 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::RIGHT] == std::vector<int> { 4 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::RIGHT] == std::vector<int> { 0 });
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP] == std::vector<int> { 1 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::TOP] == std::vector<int> { 7 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::TOP] == std::vector<int> { 0 });
+    } else if (test_rank == 1) {
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT] == std::vector<int> { 2 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::RIGHT] == std::vector<int> { 5 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::RIGHT] == std::vector<int> { 12 });
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM] == std::vector<int> { 0 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::BOTTOM] == std::vector<int> { 7 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::BOTTOM] == std::vector<int> { 21 });
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP].size() == 0);
+    } else if (test_rank == 2) {
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT] == std::vector<int> { 0, 1 });
+        REQUIRE(metadata.neighbourExtents[ModelMetadata::LEFT] == std::vector<int> { 4, 5 });
+        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::LEFT] == std::vector<int> { 6, 6 });
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM].size() == 0);
+        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP].size() == 0);
+    } else {
+        std::cerr << "only valid for 3 ranks" << std::endl;
+        exit(1);
+    }
+
+    // this metadata is specific to the periodic boundary conditions
+    if (test_rank == 0) {
+        // clang-format off
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::LEFT] == std::vector<int> { 2 });
+        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::LEFT] == std::vector<int> { 4 });
+        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::LEFT] == std::vector<int> { 2 });
+
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::RIGHT].size() == 0);
+
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 1 });
+        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 7 });
+        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 28 });
+
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::TOP].size() == 0);
+    } else if (test_rank == 1) {
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::LEFT] == std::vector<int> { 2 });
+        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::LEFT] == std::vector<int> { 5 });
+        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::LEFT] == std::vector<int> { 14 });
+
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::RIGHT].size() == 0);
+
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::BOTTOM].size() == 0);
+
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::TOP] == std::vector<int> { 0 });
+        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::TOP] == std::vector<int> { 7 });
+        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::TOP] == std::vector<int> { 0 });
+    } else if (test_rank == 2) {
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::LEFT].size() == 0);
+
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::RIGHT] == std::vector<int> { 0, 1 });
+        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::RIGHT] == std::vector<int> { 4, 5 });
+        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::RIGHT] == std::vector<int> { 0, 0 });
+
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 2 });
+        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 3 });
+        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 24 });
+
+        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::TOP] == std::vector<int> { 2 });
+        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::TOP] == std::vector<int> { 3 });
+        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::TOP] == std::vector<int> { 0 });
+        // clang-format on
+    } else {
+        std::cerr << "only valid for 3 ranks" << std::endl;
+        exit(1);
+    }
+}
+
+}

--- a/core/test/ModelMetadata_test.cpp
+++ b/core/test/ModelMetadata_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ModelMetadata_test.cpp
  *
- * @date 18 Nov 2024
+ * @date 17 Jan 2025
  * @author Tom Meltzer <tdm39@cam.ac.uk>
  */
 
@@ -11,138 +11,115 @@
 #include "ModelMetadata.hpp"
 
 const std::string testFilesDir = TEST_FILES_DIR;
-const std::string filename = testFilesDir + "/paraGrid_test.nc";
-const std::string diagFile = "paraGrid_diag.nc";
-const std::string dateString = "2000-01-01T00:00:00Z";
 const std::string partitionFilenameCB = testFilesDir + "/partition_metadata_3_cb.nc";
 const std::string partitionFilenamePB = testFilesDir + "/partition_metadata_3_pb.nc";
 
 namespace Nextsim {
 
+constexpr ModelMetadata::Edge BOTTOM = ModelMetadata::Edge::BOTTOM;
+constexpr ModelMetadata::Edge RIGHT = ModelMetadata::Edge::RIGHT;
+constexpr ModelMetadata::Edge TOP = ModelMetadata::Edge::TOP;
+constexpr ModelMetadata::Edge LEFT = ModelMetadata::Edge::LEFT;
+
+typedef std::vector<int> vec;
+
+// these tests are the same for closed boundary conditions (BC) and peridic BC
+static void testNonPeriodicBC(ModelMetadata meta, int test_rank)
+{
+    if (test_rank == 0) {
+        REQUIRE(meta.neighbourRanks[LEFT].size() == 0);
+        REQUIRE(meta.neighbourRanks[RIGHT] == vec { 2 });
+        REQUIRE(meta.neighbourExtents[RIGHT] == vec { 4 });
+        REQUIRE(meta.neighbourHaloSend[RIGHT] == vec { 15 });
+        REQUIRE(meta.neighbourHaloRecv[RIGHT] == vec { 7 });
+        REQUIRE(meta.neighbourRanks[BOTTOM].size() == 0);
+        REQUIRE(meta.neighbourRanks[TOP] == vec { 1 });
+        REQUIRE(meta.neighbourExtents[TOP] == vec { 7 });
+        REQUIRE(meta.neighbourHaloSend[TOP] == vec { 0 });
+        REQUIRE(meta.neighbourHaloRecv[TOP] == vec { 11 });
+    } else if (test_rank == 1) {
+        REQUIRE(meta.neighbourRanks[LEFT].size() == 0);
+        REQUIRE(meta.neighbourRanks[RIGHT] == vec { 2 });
+        REQUIRE(meta.neighbourExtents[RIGHT] == vec { 5 });
+        REQUIRE(meta.neighbourHaloSend[RIGHT] == vec { 19 });
+        REQUIRE(meta.neighbourHaloRecv[RIGHT] == vec { 7 });
+        REQUIRE(meta.neighbourRanks[BOTTOM] == vec { 0 });
+        REQUIRE(meta.neighbourExtents[BOTTOM] == vec { 7 });
+        REQUIRE(meta.neighbourHaloSend[BOTTOM] == vec { 11 });
+        REQUIRE(meta.neighbourHaloRecv[BOTTOM] == vec { 0 });
+        REQUIRE(meta.neighbourRanks[TOP].size() == 0);
+    } else if (test_rank == 2) {
+        REQUIRE(meta.neighbourRanks[LEFT] == vec { 0, 1 });
+        REQUIRE(meta.neighbourExtents[LEFT] == vec { 4, 5 });
+        REQUIRE(meta.neighbourHaloSend[LEFT] == vec { 7, 7 });
+        REQUIRE(meta.neighbourHaloRecv[LEFT] == vec { 15, 19 });
+        REQUIRE(meta.neighbourRanks[RIGHT].size() == 0);
+        REQUIRE(meta.neighbourRanks[BOTTOM].size() == 0);
+        REQUIRE(meta.neighbourRanks[TOP].size() == 0);
+    }
+}
+
 TEST_SUITE_BEGIN("ModelMetadata");
 MPI_TEST_CASE("Test getPartitionMetadata closed boundary", 3)
 {
-    ModelMetadata metadata(partitionFilenameCB, test_comm);
-    REQUIRE(metadata.mpiComm == test_comm);
+    ModelMetadata meta(partitionFilenameCB, test_comm);
+    REQUIRE(meta.mpiComm == test_comm);
     // this metadata is specific to the non-periodic boundary conditions
-    if (test_rank == 0) {
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT] == std::vector<int> { 2 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::RIGHT] == std::vector<int> { 4 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::RIGHT] == std::vector<int> { 0 });
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP] == std::vector<int> { 1 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::TOP] == std::vector<int> { 7 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::TOP] == std::vector<int> { 0 });
-    } else if (test_rank == 1) {
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT] == std::vector<int> { 2 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::RIGHT] == std::vector<int> { 5 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::RIGHT] == std::vector<int> { 12 });
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM] == std::vector<int> { 0 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::BOTTOM] == std::vector<int> { 7 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::BOTTOM] == std::vector<int> { 21 });
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP].size() == 0);
-    } else if (test_rank == 2) {
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT] == std::vector<int> { 0, 1 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::LEFT] == std::vector<int> { 4, 5 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::LEFT] == std::vector<int> { 6, 6 });
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP].size() == 0);
-    } else {
-        std::cerr << "only valid for 3 ranks" << std::endl;
-        exit(1);
-    }
+    testNonPeriodicBC(meta, test_rank);
 
     // This metadata is specific to the periodic boundary conditions.
     // They are all zero because the input metadata file `partitionFilenameCB` does not use periodic
     // boundary conditions.
-    REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::LEFT].size() == 0);
-    REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::RIGHT].size() == 0);
-    REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::BOTTOM].size() == 0);
-    REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::TOP].size() == 0);
+    REQUIRE(meta.neighbourRanksPeriodic[LEFT].size() == 0);
+    REQUIRE(meta.neighbourRanksPeriodic[RIGHT].size() == 0);
+    REQUIRE(meta.neighbourRanksPeriodic[BOTTOM].size() == 0);
+    REQUIRE(meta.neighbourRanksPeriodic[TOP].size() == 0);
 }
 
 MPI_TEST_CASE("Test getPartitionMetadata periodic boundary", 3)
 {
-    ModelMetadata metadata(partitionFilenamePB, test_comm);
-    REQUIRE(metadata.mpiComm == test_comm);
+    ModelMetadata meta(partitionFilenamePB, test_comm);
+    REQUIRE(meta.mpiComm == test_comm);
     // this metadata should be identical to the Closed Boundary version so we check it again
-    if (test_rank == 0) {
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT] == std::vector<int> { 2 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::RIGHT] == std::vector<int> { 4 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::RIGHT] == std::vector<int> { 0 });
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP] == std::vector<int> { 1 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::TOP] == std::vector<int> { 7 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::TOP] == std::vector<int> { 0 });
-    } else if (test_rank == 1) {
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT] == std::vector<int> { 2 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::RIGHT] == std::vector<int> { 5 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::RIGHT] == std::vector<int> { 12 });
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM] == std::vector<int> { 0 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::BOTTOM] == std::vector<int> { 7 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::BOTTOM] == std::vector<int> { 21 });
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP].size() == 0);
-    } else if (test_rank == 2) {
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::LEFT] == std::vector<int> { 0, 1 });
-        REQUIRE(metadata.neighbourExtents[ModelMetadata::LEFT] == std::vector<int> { 4, 5 });
-        REQUIRE(metadata.neighbourHaloStarts[ModelMetadata::LEFT] == std::vector<int> { 6, 6 });
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::RIGHT].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::BOTTOM].size() == 0);
-        REQUIRE(metadata.neighbourRanks[ModelMetadata::TOP].size() == 0);
-    } else {
-        std::cerr << "only valid for 3 ranks" << std::endl;
-        exit(1);
-    }
+    testNonPeriodicBC(meta, test_rank);
 
     // this metadata is specific to the periodic boundary conditions
     if (test_rank == 0) {
-        // clang-format off
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::LEFT] == std::vector<int> { 2 });
-        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::LEFT] == std::vector<int> { 4 });
-        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::LEFT] == std::vector<int> { 2 });
-
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::RIGHT].size() == 0);
-
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 1 });
-        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 7 });
-        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 28 });
-
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::TOP].size() == 0);
+        REQUIRE(meta.neighbourRanksPeriodic[LEFT] == vec { 2 });
+        REQUIRE(meta.neighbourExtentsPeriodic[LEFT] == vec { 4 });
+        REQUIRE(meta.neighbourHaloSendPeriodic[LEFT] == vec { 3 });
+        REQUIRE(meta.neighbourHaloRecvPeriodic[LEFT] == vec { 18 });
+        REQUIRE(meta.neighbourRanksPeriodic[RIGHT].size() == 0);
+        REQUIRE(meta.neighbourRanksPeriodic[BOTTOM] == vec { 1 });
+        REQUIRE(meta.neighbourExtentsPeriodic[BOTTOM] == vec { 7 });
+        REQUIRE(meta.neighbourHaloSendPeriodic[BOTTOM] == vec { 12 });
+        REQUIRE(meta.neighbourHaloRecvPeriodic[BOTTOM] == vec { 0 });
+        REQUIRE(meta.neighbourRanksPeriodic[TOP].size() == 0);
     } else if (test_rank == 1) {
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::LEFT] == std::vector<int> { 2 });
-        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::LEFT] == std::vector<int> { 5 });
-        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::LEFT] == std::vector<int> { 14 });
-
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::RIGHT].size() == 0);
-
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::BOTTOM].size() == 0);
-
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::TOP] == std::vector<int> { 0 });
-        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::TOP] == std::vector<int> { 7 });
-        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::TOP] == std::vector<int> { 0 });
+        REQUIRE(meta.neighbourRanksPeriodic[LEFT] == vec { 2 });
+        REQUIRE(meta.neighbourExtentsPeriodic[LEFT] == vec { 5 });
+        REQUIRE(meta.neighbourHaloSendPeriodic[LEFT] == vec { 7 });
+        REQUIRE(meta.neighbourHaloRecvPeriodic[LEFT] == vec { 19 });
+        REQUIRE(meta.neighbourRanksPeriodic[RIGHT].size() == 0);
+        REQUIRE(meta.neighbourRanksPeriodic[BOTTOM].size() == 0);
+        REQUIRE(meta.neighbourRanksPeriodic[TOP] == vec { 0 });
+        REQUIRE(meta.neighbourExtentsPeriodic[TOP] == vec { 7 });
+        REQUIRE(meta.neighbourHaloSendPeriodic[TOP] == vec { 0 });
+        REQUIRE(meta.neighbourHaloRecvPeriodic[TOP] == vec { 12 });
     } else if (test_rank == 2) {
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::LEFT].size() == 0);
-
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::RIGHT] == std::vector<int> { 0, 1 });
-        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::RIGHT] == std::vector<int> { 4, 5 });
-        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::RIGHT] == std::vector<int> { 0, 0 });
-
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 2 });
-        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 3 });
-        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::BOTTOM] == std::vector<int> { 24 });
-
-        REQUIRE(metadata.neighbourRanksPeriodic[ModelMetadata::TOP] == std::vector<int> { 2 });
-        REQUIRE(metadata.neighbourExtentsPeriodic[ModelMetadata::TOP] == std::vector<int> { 3 });
-        REQUIRE(metadata.neighbourHaloStartsPeriodic[ModelMetadata::TOP] == std::vector<int> { 0 });
-        // clang-format on
-    } else {
-        std::cerr << "only valid for 3 ranks" << std::endl;
-        exit(1);
+        REQUIRE(meta.neighbourRanksPeriodic[LEFT].size() == 0);
+        REQUIRE(meta.neighbourRanksPeriodic[RIGHT] == vec { 0, 1 });
+        REQUIRE(meta.neighbourExtentsPeriodic[RIGHT] == vec { 4, 5 });
+        REQUIRE(meta.neighbourHaloSendPeriodic[RIGHT] == vec { 18, 19 });
+        REQUIRE(meta.neighbourHaloRecvPeriodic[RIGHT] == vec { 3, 7 });
+        REQUIRE(meta.neighbourRanksPeriodic[BOTTOM] == vec { 2 });
+        REQUIRE(meta.neighbourExtentsPeriodic[BOTTOM] == vec { 3 });
+        REQUIRE(meta.neighbourHaloSendPeriodic[BOTTOM] == vec { 12 });
+        REQUIRE(meta.neighbourHaloRecvPeriodic[BOTTOM] == vec { 0 });
+        REQUIRE(meta.neighbourRanksPeriodic[TOP] == vec { 2 });
+        REQUIRE(meta.neighbourExtentsPeriodic[TOP] == vec { 3 });
+        REQUIRE(meta.neighbourHaloSendPeriodic[TOP] == vec { 0 });
+        REQUIRE(meta.neighbourHaloRecvPeriodic[TOP] == vec { 12 });
     }
 }
 

--- a/core/test/ParaGrid_test.cpp
+++ b/core/test/ParaGrid_test.cpp
@@ -1,8 +1,9 @@
 /*!
  * @file ParaGrid_test.cpp
  *
- * @date 24 Sep 2024
+ * @date 17 Jan 2025
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Tom Meltzer <tdm39@cam.ac.uk>
  */
 
 #include "ModelArray.hpp"
@@ -16,11 +17,11 @@
 
 #include "include/Configurator.hpp"
 #include "include/ConfiguredModule.hpp"
+#include "include/IStructure.hpp"
 #include "include/NZLevels.hpp"
+#include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
 #include "include/ParametricGrid.hpp"
-#include "include/IStructure.hpp"
-#include "include/NextsimModule.hpp"
 #include "include/gridNames.hpp"
 
 #include <cmath>
@@ -114,12 +115,12 @@ TEST_CASE("Write and read a ModelState-based ParaGrid restart file")
 
 #ifdef USE_MPI
     if (test_rank == 0) {
-        ModelArray::setDimension(ModelArray::Dimension::X, nx, 4, 0);
-        ModelArray::setDimension(ModelArray::Dimension::XVERTEX, nx + 1, 4 + 1, 0);
+        ModelArray::setDimension(ModelArray::Dimension::X, nx, 5, 0);
+        ModelArray::setDimension(ModelArray::Dimension::XVERTEX, nx + 1, 5 + 1, 0);
     }
     if (test_rank == 1) {
-        ModelArray::setDimension(ModelArray::Dimension::X, nx, 6, 4);
-        ModelArray::setDimension(ModelArray::Dimension::XVERTEX, nx + 1, 6 + 1, 4);
+        ModelArray::setDimension(ModelArray::Dimension::X, nx, 5, 5);
+        ModelArray::setDimension(ModelArray::Dimension::XVERTEX, nx + 1, 5 + 1, 5);
     }
     ModelArray::setDimension(ModelArray::Dimension::Y, ny, ny, 0);
     ModelArray::setDimension(ModelArray::Dimension::Z, NZLevels::get(), NZLevels::get(), 0);

--- a/core/test/partition_metadata_2.cdl
+++ b/core/test/partition_metadata_2.cdl
@@ -3,58 +3,106 @@ dimensions:
 	NX = 10 ;
 	NY = 9 ;
 	P = 2 ;
-	T = 1 ;
-	B = 1 ;
-	L = UNLIMITED ; // (0 currently)
-	R = UNLIMITED ; // (0 currently)
+	L = 1 ;
+	R = 1 ;
+	B = UNLIMITED ; // (0 currently)
+	T = UNLIMITED ; // (0 currently)
+	L_periodic = UNLIMITED ; // (0 currently)
+	R_periodic = UNLIMITED ; // (0 currently)
+	B_periodic = UNLIMITED ; // (0 currently)
+	T_periodic = UNLIMITED ; // (0 currently)
 
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;
-  	int domain_y(P) ;
   	int domain_extent_x(P) ;
+  	int domain_y(P) ;
   	int domain_extent_y(P) ;
   data:
 
-   domain_x = 0, 4 ;
+   domain_x = 0, 5 ;
+
+   domain_extent_x = 5, 5 ;
 
    domain_y = 0, 0 ;
-
-   domain_extent_x = 4, 6 ;
 
    domain_extent_y = 9, 9 ;
   } // group bounding_boxes
 
 group: connectivity {
   variables:
-  	int top_neighbors(P) ;
-  	int top_neighbor_ids(T) ;
-  	int top_neighbor_halos(T) ;
-  	int bottom_neighbors(P) ;
-  	int bottom_neighbor_ids(B) ;
-  	int bottom_neighbor_halos(B) ;
-  	int left_neighbors(P) ;
-  	int left_neighbor_ids(L) ;
-  	int left_neighbor_halos(L) ;
-  	int right_neighbors(P) ;
-  	int right_neighbor_ids(R) ;
-  	int right_neighbor_halos(R) ;
+  	int left_neighbours(P) ;
+  	int left_neighbour_ids(L) ;
+  	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
+  	int right_neighbours(P) ;
+  	int right_neighbour_ids(R) ;
+  	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
+  	int bottom_neighbours(P) ;
+  	int bottom_neighbour_ids(B) ;
+  	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
+  	int top_neighbours(P) ;
+  	int top_neighbour_ids(T) ;
+  	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
+  	int left_neighbours_periodic(P) ;
+  	int left_neighbour_ids_periodic(L_periodic) ;
+  	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
+  	int right_neighbours_periodic(P) ;
+  	int right_neighbour_ids_periodic(R_periodic) ;
+  	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
+  	int bottom_neighbours_periodic(P) ;
+  	int bottom_neighbour_ids_periodic(B_periodic) ;
+  	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
+  	int top_neighbours_periodic(P) ;
+  	int top_neighbour_ids_periodic(T_periodic) ;
+  	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
   data:
 
-   top_neighbors = 0, 1 ;
+   left_neighbours = 0, 1 ;
 
-   top_neighbor_ids = 0 ;
+   left_neighbour_ids = 0 ;
 
-   top_neighbor_halos = 9 ;
+   left_neighbour_halos = 9 ;
 
-   bottom_neighbors = 1, 0 ;
+   left_neighbour_halo_send = 5 ;
 
-   bottom_neighbor_ids = 1 ;
+   left_neighbour_halo_recv = 19 ;
 
-   bottom_neighbor_halos = 9 ;
+   right_neighbours = 1, 0 ;
 
-   left_neighbors = 0, 0 ;
+   right_neighbour_ids = 1 ;
 
-   right_neighbors = 0, 0 ;
+   right_neighbour_halos = 9 ;
+
+   right_neighbour_halo_send = 19 ;
+
+   right_neighbour_halo_recv = 5 ;
+
+   bottom_neighbours = 0, 0 ;
+
+   top_neighbours = 0, 0 ;
+
+   left_neighbours_periodic = 0, 0 ;
+
+   right_neighbours_periodic = 0, 0 ;
+
+   bottom_neighbours_periodic = 0, 0 ;
+
+   top_neighbours_periodic = 0, 0 ;
   } // group connectivity
 }

--- a/core/test/partition_metadata_3.cdl
+++ b/core/test/partition_metadata_3.cdl
@@ -3,66 +3,122 @@ dimensions:
 	NX = 5 ;
 	NY = 7 ;
 	P = 3 ;
-	T = 2 ;
-	B = 2 ;
-	L = 1 ;
-	R = 1 ;
+	L = 2 ;
+	R = 2 ;
+	B = 1 ;
+	T = 1 ;
+	L_periodic = UNLIMITED ; // (0 currently)
+	R_periodic = UNLIMITED ; // (0 currently)
+	B_periodic = UNLIMITED ; // (0 currently)
+	T_periodic = UNLIMITED ; // (0 currently)
 
 group: bounding_boxes {
   variables:
   	int domain_x(P) ;
-  	int domain_y(P) ;
   	int domain_extent_x(P) ;
+  	int domain_y(P) ;
   	int domain_extent_y(P) ;
   data:
 
    domain_x = 0, 0, 3 ;
 
-   domain_y = 0, 3, 0 ;
-
    domain_extent_x = 3, 3, 2 ;
+
+   domain_y = 0, 3, 0 ;
 
    domain_extent_y = 3, 4, 7 ;
   } // group bounding_boxes
 
 group: connectivity {
   variables:
-  	int top_neighbors(P) ;
-  	int top_neighbor_ids(T) ;
-  	int top_neighbor_halos(T) ;
-  	int bottom_neighbors(P) ;
-  	int bottom_neighbor_ids(B) ;
-  	int bottom_neighbor_halos(B) ;
-  	int left_neighbors(P) ;
-  	int left_neighbor_ids(L) ;
-  	int left_neighbor_halos(L) ;
-  	int right_neighbors(P) ;
-  	int right_neighbor_ids(R) ;
-  	int right_neighbor_halos(R) ;
+  	int left_neighbours(P) ;
+  	int left_neighbour_ids(L) ;
+  	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
+  	int right_neighbours(P) ;
+  	int right_neighbour_ids(R) ;
+  	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
+  	int bottom_neighbours(P) ;
+  	int bottom_neighbour_ids(B) ;
+  	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
+  	int top_neighbours(P) ;
+  	int top_neighbour_ids(T) ;
+  	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
+  	int left_neighbours_periodic(P) ;
+  	int left_neighbour_ids_periodic(L_periodic) ;
+  	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
+  	int right_neighbours_periodic(P) ;
+  	int right_neighbour_ids_periodic(R_periodic) ;
+  	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
+  	int bottom_neighbours_periodic(P) ;
+  	int bottom_neighbour_ids_periodic(B_periodic) ;
+  	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
+  	int top_neighbours_periodic(P) ;
+  	int top_neighbour_ids_periodic(T_periodic) ;
+  	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
   data:
 
-   top_neighbors = 0, 0, 2 ;
+   left_neighbours = 0, 0, 2 ;
 
-   top_neighbor_ids = 0, 1 ;
+   left_neighbour_ids = 0, 1 ;
 
-   top_neighbor_halos = 3, 4 ;
+   left_neighbour_halos = 3, 4 ;
 
-   bottom_neighbors = 1, 1, 0 ;
+   left_neighbour_halo_send = 3, 3 ;
 
-   bottom_neighbor_ids = 2, 2 ;
+   left_neighbour_halo_recv = 11, 14 ;
 
-   bottom_neighbor_halos = 3, 4 ;
+   right_neighbours = 1, 1, 0 ;
 
-   left_neighbors = 0, 1, 0 ;
+   right_neighbour_ids = 2, 2 ;
 
-   left_neighbor_ids = 0 ;
+   right_neighbour_halos = 3, 4 ;
 
-   left_neighbor_halos = 3 ;
+   right_neighbour_halo_send = 11, 14 ;
 
-   right_neighbors = 1, 0, 0 ;
+   right_neighbour_halo_recv = 3, 3 ;
 
-   right_neighbor_ids = 1 ;
+   bottom_neighbours = 0, 1, 0 ;
 
-   right_neighbor_halos = 3 ;
+   bottom_neighbour_ids = 0 ;
+
+   bottom_neighbour_halos = 3 ;
+
+   bottom_neighbour_halo_send = 6 ;
+
+   bottom_neighbour_halo_recv = 0 ;
+
+   top_neighbours = 1, 0, 0 ;
+
+   top_neighbour_ids = 1 ;
+
+   top_neighbour_halos = 3 ;
+
+   top_neighbour_halo_send = 0 ;
+
+   top_neighbour_halo_recv = 6 ;
+
+   left_neighbours_periodic = 0, 0, 0 ;
+
+   right_neighbours_periodic = 0, 0, 0 ;
+
+   bottom_neighbours_periodic = 0, 0, 0 ;
+
+   top_neighbours_periodic = 0, 0, 0 ;
   } // group connectivity
 }

--- a/core/test/partition_metadata_3_cb.cdl
+++ b/core/test/partition_metadata_3_cb.cdl
@@ -1,4 +1,4 @@
-netcdf partition_metadata_3 {
+netcdf partition_metadata_3_cb {
 dimensions:
 	NX = 10 ;
 	NY = 9 ;
@@ -34,35 +34,43 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
-  	int left_neighbour_halo_starts(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
-  	int right_neighbour_halo_starts(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
-  	int bottom_neighbour_halo_starts(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
-  	int top_neighbour_halo_starts(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_starts_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_starts_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_starts_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -71,7 +79,9 @@ group: connectivity {
 
    left_neighbour_halos = 4, 5 ;
 
-   left_neighbour_halo_starts = 6, 6 ;
+   left_neighbour_halo_send = 7, 7 ;
+
+   left_neighbour_halo_recv = 15, 19 ;
 
    right_neighbours = 1, 1, 0 ;
 
@@ -79,7 +89,9 @@ group: connectivity {
 
    right_neighbour_halos = 4, 5 ;
 
-   right_neighbour_halo_starts = 0, 12 ;
+   right_neighbour_halo_send = 15, 19 ;
+
+   right_neighbour_halo_recv = 7, 7 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -87,7 +99,9 @@ group: connectivity {
 
    bottom_neighbour_halos = 7 ;
 
-   bottom_neighbour_halo_starts = 21 ;
+   bottom_neighbour_halo_send = 11 ;
+
+   bottom_neighbour_halo_recv = 0 ;
 
    top_neighbours = 1, 0, 0 ;
 
@@ -95,7 +109,9 @@ group: connectivity {
 
    top_neighbour_halos = 7 ;
 
-   top_neighbour_halo_starts = 0 ;
+   top_neighbour_halo_send = 0 ;
+
+   top_neighbour_halo_recv = 11 ;
 
    left_neighbours_periodic = 0, 0, 0 ;
 

--- a/core/test/partition_metadata_3_cb.cdl
+++ b/core/test/partition_metadata_3_cb.cdl
@@ -1,0 +1,108 @@
+netcdf partition_metadata_3 {
+dimensions:
+	NX = 10 ;
+	NY = 9 ;
+	P = 3 ;
+	L = 2 ;
+	R = 2 ;
+	B = 1 ;
+	T = 1 ;
+	L_periodic = UNLIMITED ; // (0 currently)
+	R_periodic = UNLIMITED ; // (0 currently)
+	B_periodic = UNLIMITED ; // (0 currently)
+	T_periodic = UNLIMITED ; // (0 currently)
+
+group: bounding_boxes {
+  variables:
+  	int domain_x(P) ;
+  	int domain_extent_x(P) ;
+  	int domain_y(P) ;
+  	int domain_extent_y(P) ;
+  data:
+
+   domain_x = 0, 0, 7 ;
+
+   domain_extent_x = 7, 7, 3 ;
+
+   domain_y = 0, 4, 0 ;
+
+   domain_extent_y = 4, 5, 9 ;
+  } // group bounding_boxes
+
+group: connectivity {
+  variables:
+  	int left_neighbours(P) ;
+  	int left_neighbour_ids(L) ;
+  	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_starts(L) ;
+  	int right_neighbours(P) ;
+  	int right_neighbour_ids(R) ;
+  	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_starts(R) ;
+  	int bottom_neighbours(P) ;
+  	int bottom_neighbour_ids(B) ;
+  	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_starts(B) ;
+  	int top_neighbours(P) ;
+  	int top_neighbour_ids(T) ;
+  	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_starts(T) ;
+  	int left_neighbours_periodic(P) ;
+  	int left_neighbour_ids_periodic(L_periodic) ;
+  	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_starts_periodic(L_periodic) ;
+  	int right_neighbours_periodic(P) ;
+  	int right_neighbour_ids_periodic(R_periodic) ;
+  	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_starts_periodic(R_periodic) ;
+  	int bottom_neighbours_periodic(P) ;
+  	int bottom_neighbour_ids_periodic(B_periodic) ;
+  	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
+  	int top_neighbours_periodic(P) ;
+  	int top_neighbour_ids_periodic(T_periodic) ;
+  	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_starts_periodic(T_periodic) ;
+  data:
+
+   left_neighbours = 0, 0, 2 ;
+
+   left_neighbour_ids = 0, 1 ;
+
+   left_neighbour_halos = 4, 5 ;
+
+   left_neighbour_halo_starts = 6, 6 ;
+
+   right_neighbours = 1, 1, 0 ;
+
+   right_neighbour_ids = 2, 2 ;
+
+   right_neighbour_halos = 4, 5 ;
+
+   right_neighbour_halo_starts = 0, 12 ;
+
+   bottom_neighbours = 0, 1, 0 ;
+
+   bottom_neighbour_ids = 0 ;
+
+   bottom_neighbour_halos = 7 ;
+
+   bottom_neighbour_halo_starts = 21 ;
+
+   top_neighbours = 1, 0, 0 ;
+
+   top_neighbour_ids = 1 ;
+
+   top_neighbour_halos = 7 ;
+
+   top_neighbour_halo_starts = 0 ;
+
+   left_neighbours_periodic = 0, 0, 0 ;
+
+   right_neighbours_periodic = 0, 0, 0 ;
+
+   bottom_neighbours_periodic = 0, 0, 0 ;
+
+   top_neighbours_periodic = 0, 0, 0 ;
+  } // group connectivity
+}

--- a/core/test/partition_metadata_3_pb.cdl
+++ b/core/test/partition_metadata_3_pb.cdl
@@ -1,0 +1,132 @@
+netcdf partition_metadata_3 {
+dimensions:
+	NX = 10 ;
+	NY = 9 ;
+	P = 3 ;
+	L = 2 ;
+	R = 2 ;
+	B = 1 ;
+	T = 1 ;
+	L_periodic = 2 ;
+	R_periodic = 2 ;
+	B_periodic = 2 ;
+	T_periodic = 2 ;
+
+group: bounding_boxes {
+  variables:
+  	int domain_x(P) ;
+  	int domain_extent_x(P) ;
+  	int domain_y(P) ;
+  	int domain_extent_y(P) ;
+  data:
+
+   domain_x = 0, 0, 7 ;
+
+   domain_extent_x = 7, 7, 3 ;
+
+   domain_y = 0, 4, 0 ;
+
+   domain_extent_y = 4, 5, 9 ;
+  } // group bounding_boxes
+
+group: connectivity {
+  variables:
+  	int left_neighbours(P) ;
+  	int left_neighbour_ids(L) ;
+  	int left_neighbour_halos(L) ;
+  	int left_neighbour_halo_starts(L) ;
+  	int right_neighbours(P) ;
+  	int right_neighbour_ids(R) ;
+  	int right_neighbour_halos(R) ;
+  	int right_neighbour_halo_starts(R) ;
+  	int bottom_neighbours(P) ;
+  	int bottom_neighbour_ids(B) ;
+  	int bottom_neighbour_halos(B) ;
+  	int bottom_neighbour_halo_starts(B) ;
+  	int top_neighbours(P) ;
+  	int top_neighbour_ids(T) ;
+  	int top_neighbour_halos(T) ;
+  	int top_neighbour_halo_starts(T) ;
+  	int left_neighbours_periodic(P) ;
+  	int left_neighbour_ids_periodic(L_periodic) ;
+  	int left_neighbour_halos_periodic(L_periodic) ;
+  	int left_neighbour_halo_starts_periodic(L_periodic) ;
+  	int right_neighbours_periodic(P) ;
+  	int right_neighbour_ids_periodic(R_periodic) ;
+  	int right_neighbour_halos_periodic(R_periodic) ;
+  	int right_neighbour_halo_starts_periodic(R_periodic) ;
+  	int bottom_neighbours_periodic(P) ;
+  	int bottom_neighbour_ids_periodic(B_periodic) ;
+  	int bottom_neighbour_halos_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
+  	int top_neighbours_periodic(P) ;
+  	int top_neighbour_ids_periodic(T_periodic) ;
+  	int top_neighbour_halos_periodic(T_periodic) ;
+  	int top_neighbour_halo_starts_periodic(T_periodic) ;
+  data:
+
+   left_neighbours = 0, 0, 2 ;
+
+   left_neighbour_ids = 0, 1 ;
+
+   left_neighbour_halos = 4, 5 ;
+
+   left_neighbour_halo_starts = 6, 6 ;
+
+   right_neighbours = 1, 1, 0 ;
+
+   right_neighbour_ids = 2, 2 ;
+
+   right_neighbour_halos = 4, 5 ;
+
+   right_neighbour_halo_starts = 0, 12 ;
+
+   bottom_neighbours = 0, 1, 0 ;
+
+   bottom_neighbour_ids = 0 ;
+
+   bottom_neighbour_halos = 7 ;
+
+   bottom_neighbour_halo_starts = 21 ;
+
+   top_neighbours = 1, 0, 0 ;
+
+   top_neighbour_ids = 1 ;
+
+   top_neighbour_halos = 7 ;
+
+   top_neighbour_halo_starts = 0 ;
+
+   left_neighbours_periodic = 1, 1, 0 ;
+
+   left_neighbour_ids_periodic = 2, 2 ;
+
+   left_neighbour_halos_periodic = 4, 5 ;
+
+   left_neighbour_halo_starts_periodic = 2, 14 ;
+
+   right_neighbours_periodic = 0, 0, 2 ;
+
+   right_neighbour_ids_periodic = 0, 1 ;
+
+   right_neighbour_halos_periodic = 4, 5 ;
+
+   right_neighbour_halo_starts_periodic = 0, 0 ;
+
+   bottom_neighbours_periodic = 1, 0, 1 ;
+
+   bottom_neighbour_ids_periodic = 1, 2 ;
+
+   bottom_neighbour_halos_periodic = 7, 3 ;
+
+   bottom_neighbour_halo_starts_periodic = 28, 24 ;
+
+   top_neighbours_periodic = 0, 1, 1 ;
+
+   top_neighbour_ids_periodic = 0, 2 ;
+
+   top_neighbour_halos_periodic = 7, 3 ;
+
+   top_neighbour_halo_starts_periodic = 0, 0 ;
+  } // group connectivity
+}

--- a/core/test/partition_metadata_3_pb.cdl
+++ b/core/test/partition_metadata_3_pb.cdl
@@ -1,4 +1,4 @@
-netcdf partition_metadata_3 {
+netcdf partition_metadata_3_pb {
 dimensions:
 	NX = 10 ;
 	NY = 9 ;
@@ -34,35 +34,43 @@ group: connectivity {
   	int left_neighbours(P) ;
   	int left_neighbour_ids(L) ;
   	int left_neighbour_halos(L) ;
-  	int left_neighbour_halo_starts(L) ;
+  	int left_neighbour_halo_send(L) ;
+  	int left_neighbour_halo_recv(L) ;
   	int right_neighbours(P) ;
   	int right_neighbour_ids(R) ;
   	int right_neighbour_halos(R) ;
-  	int right_neighbour_halo_starts(R) ;
+  	int right_neighbour_halo_send(R) ;
+  	int right_neighbour_halo_recv(R) ;
   	int bottom_neighbours(P) ;
   	int bottom_neighbour_ids(B) ;
   	int bottom_neighbour_halos(B) ;
-  	int bottom_neighbour_halo_starts(B) ;
+  	int bottom_neighbour_halo_send(B) ;
+  	int bottom_neighbour_halo_recv(B) ;
   	int top_neighbours(P) ;
   	int top_neighbour_ids(T) ;
   	int top_neighbour_halos(T) ;
-  	int top_neighbour_halo_starts(T) ;
+  	int top_neighbour_halo_send(T) ;
+  	int top_neighbour_halo_recv(T) ;
   	int left_neighbours_periodic(P) ;
   	int left_neighbour_ids_periodic(L_periodic) ;
   	int left_neighbour_halos_periodic(L_periodic) ;
-  	int left_neighbour_halo_starts_periodic(L_periodic) ;
+  	int left_neighbour_halo_send_periodic(L_periodic) ;
+  	int left_neighbour_halo_recv_periodic(L_periodic) ;
   	int right_neighbours_periodic(P) ;
   	int right_neighbour_ids_periodic(R_periodic) ;
   	int right_neighbour_halos_periodic(R_periodic) ;
-  	int right_neighbour_halo_starts_periodic(R_periodic) ;
+  	int right_neighbour_halo_send_periodic(R_periodic) ;
+  	int right_neighbour_halo_recv_periodic(R_periodic) ;
   	int bottom_neighbours_periodic(P) ;
   	int bottom_neighbour_ids_periodic(B_periodic) ;
   	int bottom_neighbour_halos_periodic(B_periodic) ;
-  	int bottom_neighbour_halo_starts_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_send_periodic(B_periodic) ;
+  	int bottom_neighbour_halo_recv_periodic(B_periodic) ;
   	int top_neighbours_periodic(P) ;
   	int top_neighbour_ids_periodic(T_periodic) ;
   	int top_neighbour_halos_periodic(T_periodic) ;
-  	int top_neighbour_halo_starts_periodic(T_periodic) ;
+  	int top_neighbour_halo_send_periodic(T_periodic) ;
+  	int top_neighbour_halo_recv_periodic(T_periodic) ;
   data:
 
    left_neighbours = 0, 0, 2 ;
@@ -71,7 +79,9 @@ group: connectivity {
 
    left_neighbour_halos = 4, 5 ;
 
-   left_neighbour_halo_starts = 6, 6 ;
+   left_neighbour_halo_send = 7, 7 ;
+
+   left_neighbour_halo_recv = 15, 19 ;
 
    right_neighbours = 1, 1, 0 ;
 
@@ -79,7 +89,9 @@ group: connectivity {
 
    right_neighbour_halos = 4, 5 ;
 
-   right_neighbour_halo_starts = 0, 12 ;
+   right_neighbour_halo_send = 15, 19 ;
+
+   right_neighbour_halo_recv = 7, 7 ;
 
    bottom_neighbours = 0, 1, 0 ;
 
@@ -87,7 +99,9 @@ group: connectivity {
 
    bottom_neighbour_halos = 7 ;
 
-   bottom_neighbour_halo_starts = 21 ;
+   bottom_neighbour_halo_send = 11 ;
+
+   bottom_neighbour_halo_recv = 0 ;
 
    top_neighbours = 1, 0, 0 ;
 
@@ -95,7 +109,9 @@ group: connectivity {
 
    top_neighbour_halos = 7 ;
 
-   top_neighbour_halo_starts = 0 ;
+   top_neighbour_halo_send = 0 ;
+
+   top_neighbour_halo_recv = 11 ;
 
    left_neighbours_periodic = 1, 1, 0 ;
 
@@ -103,7 +119,9 @@ group: connectivity {
 
    left_neighbour_halos_periodic = 4, 5 ;
 
-   left_neighbour_halo_starts_periodic = 2, 14 ;
+   left_neighbour_halo_send_periodic = 3, 7 ;
+
+   left_neighbour_halo_recv_periodic = 18, 19 ;
 
    right_neighbours_periodic = 0, 0, 2 ;
 
@@ -111,7 +129,9 @@ group: connectivity {
 
    right_neighbour_halos_periodic = 4, 5 ;
 
-   right_neighbour_halo_starts_periodic = 0, 0 ;
+   right_neighbour_halo_send_periodic = 18, 19 ;
+
+   right_neighbour_halo_recv_periodic = 3, 7 ;
 
    bottom_neighbours_periodic = 1, 0, 1 ;
 
@@ -119,7 +139,9 @@ group: connectivity {
 
    bottom_neighbour_halos_periodic = 7, 3 ;
 
-   bottom_neighbour_halo_starts_periodic = 28, 24 ;
+   bottom_neighbour_halo_send_periodic = 12, 12 ;
+
+   bottom_neighbour_halo_recv_periodic = 0, 0 ;
 
    top_neighbours_periodic = 0, 1, 1 ;
 
@@ -127,6 +149,8 @@ group: connectivity {
 
    top_neighbour_halos_periodic = 7, 3 ;
 
-   top_neighbour_halo_starts_periodic = 0, 0 ;
+   top_neighbour_halo_send_periodic = 0, 0 ;
+
+   top_neighbour_halo_recv_periodic = 12, 12 ;
   } // group connectivity
 }


### PR DESCRIPTION
This PR has been superseded by #744


Fixes #120

### Change Description

To parallelize the dynamics we first need the halo region information for each process.

This information is located in the metadata file produced by the domain `decomp` tool.

This PR updates `ModelMetadata::getPartitionMetadata` with all the necessary information on halo regions.

### Test Description

This PR adds two new tests to check the functionality of the `getPartitionMetadata` method and the halo exchange.
- [x] `ModelMetadata_test.cpp` - test `getPartitionMetadata` can correctly load metadata from a partition metadata file into the appropriate data structure e.g., `neighbourExtents`, `neighbourHaloStarts` etc.
- [x] `HaloExchange_test.cpp` - check that we can do basic halo exchange by making use of the new slicing utilities e.g., `ModelArraySlice` #744 
- [ ] add halo exchange logic to nextsim

### Pre-Request Checklist

- [x] Add methods to read halo exchange info into metadata class
- [ ] Add halo exchange info to DGModelArray class
- [ ] Add exchange logic to DGModelArray.hpp
- [ ] Add option of in-/out-flows in the halo? or should this be separate?