### PR TITLE
Reverse the order of dynamics and thermodynamics

### DIFF
--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -81,16 +81,13 @@ void PrognosticData::update(const TimestepTime& tst)
     pOcnBdy->updateBefore(tst);
     pAtmBdy->update(tst);
 
-    // Fill the values of the true ice and snow thicknesses.
-    iceGrowth.initializeThicknesses();
-    // Fill the updated ice temperature array
-    ticeUpd.data().setData(m_tice);
-    pDynamics->update(tst);
-    updatePrognosticFields();
-
     // Take the updated values of the true ice and snow thicknesses, and reset hice0 and hsnow0
     // IceGrowth updates its own fields during update
     iceGrowth.update(tst);
+    updatePrognosticFields();
+
+    pDynamics->update(tst);
+
     updatePrognosticFields();
 
     pOcnBdy->updateAfter(tst);

--- a/scripts/module_builder.py
+++ b/scripts/module_builder.py
@@ -101,6 +101,8 @@ template <> std::unique_ptr<{strings[class_name]}> getInstance()
 {{
     addToConfiguredModules<{strings[class_name]}, {strings[module_class_name]}>();
 }}
+
+template class {module_templ};
 """)
     source.write("""
 } /* namespace Module */


### PR DESCRIPTION
# Reverse the order of dynamics and thermodynamics

Fixes #654

---
# Change Description

Currently, the thermodynamics runs after the dynamics. Since the thermodynamics changes the mean, DG0 value of prognostic fields, this can mean that the higher DG components could be such that the value of the field exceeds its physical limits. To be fully consistent the final state of fields with both DG components and geophysical limits should be immediately after the dynamics, when the limiters have just been applied.

The solution to this is to swap the order of the dynamics and thermodynamics within the `PrognosticData::update()`, as done in the PR.

---
# Test Description

Running the updated model through January 2010 doesn't look any *worse* than before. Arguably it is more realistic.
