### PR TITLE
Improve execution speed of BBM stress update

### DIFF
--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -26,7 +26,7 @@ void CGDynamicsKernel<DGadvection>::initialise(
     DynamicsKernel<DGadvection, DGstressComp>::initialise(coords, isSpherical, mask);
 
     //! Initialize the parametric momentum map
-    pmap = new ParametricMomentumMap<CGdegree>(*smesh);
+    pmap = new ParametricMomentumMap<CGdegree, DGadvection>(*smesh);
     pmap->InitializeLumpedCGMassMatrix();
     pmap->InitializeDivSMatrices();
 

--- a/dynamics/src/ParametricMap.cpp
+++ b/dynamics/src/ParametricMap.cpp
@@ -84,7 +84,7 @@ template <int DG> void ParametricTransportMap<DG>::InitializeInverseDGMassMatrix
 //////////////////////////////////////////////////
 
 //!
-  template <int CG, int DG> void ParametricMomentumMap<CG, DG>::InitializeLumpedCGMassMatrix()
+template <int CG, int DG> void ParametricMomentumMap<CG, DG>::InitializeLumpedCGMassMatrix()
 {
     lumpedcgmass.resize_by_mesh(smesh);
 
@@ -154,7 +154,7 @@ template <int DG> void ParametricTransportMap<DG>::InitializeInverseDGMassMatrix
 }
 
 //!
-  template <int CG, int DG> void ParametricMomentumMap<CG, DG>::InitializeDivSMatrices()
+template <int CG, int DG> void ParametricMomentumMap<CG, DG>::InitializeDivSMatrices()
 {
     divS1.resize(smesh.nelements);
     divS2.resize(smesh.nelements);
@@ -221,14 +221,14 @@ template <int DG> void ParametricTransportMap<DG>::InitializeInverseDGMassMatrix
                 * (PSI<CG2DGSTRESS(CG), GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise()
                     * (GAUSSWEIGHTS<GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array() * J.array()))
                       .matrix();
-	    // same but for the damage. However, we use the same number of Gausspoints as
-	    // for the DG-stress variant above for easier use in BBM Stress update	   
-	    const Eigen::Matrix<Nextsim::FloatType, DG, DG> imass_dam
-	      = ParametricTools::massMatrix<DG>(smesh, eid).inverse();
-	    iMJwPSI_dam[eid] = imass_dam
-	      * (PSI<DG, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise()
-		 * (GAUSSWEIGHTS<GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array() * J.array()))
-	      .matrix();
+            // same but for the damage. However, we use the same number of Gausspoints as
+            // for the DG-stress variant above for easier use in BBM Stress update
+            const Eigen::Matrix<Nextsim::FloatType, DG, DG> imass_dam
+                = ParametricTools::massMatrix<DG>(smesh, eid).inverse();
+            iMJwPSI_dam[eid] = imass_dam
+                * (PSI<DG, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise()
+                    * (GAUSSWEIGHTS<GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array() * J.array()))
+                      .matrix();
 
         } else if (smesh.CoordinateSystem == SPHERICAL) {
             // In spherical coordinates (x,y) coordinates are (lon,lat) coordinates
@@ -271,15 +271,13 @@ template <int DG> void ParametricTransportMap<DG>::InitializeInverseDGMassMatrix
                     * (GAUSSWEIGHTS<GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array() * J.array()))
                       .matrix();
 
-	    // smae for DG advection (damage)
-	    const Eigen::Matrix<Nextsim::FloatType, DG, DG> imass_dam
+            // smae for DG advection (damage)
+            const Eigen::Matrix<Nextsim::FloatType, DG, DG> imass_dam
                 = SphericalTools::massMatrix<DG>(smesh, eid).inverse();
             iMJwPSI_dam[eid] = imass_dam
                 * (PSI<DG, GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array().rowwise()
                     * (GAUSSWEIGHTS<GAUSSPOINTS1D(CG2DGSTRESS(CG))>.array() * J.array()))
                       .matrix();
-
-
 
         } else
             abort();
@@ -291,11 +289,11 @@ template class ParametricTransportMap<3>;
 template class ParametricTransportMap<6>;
 template class ParametricTransportMap<8>;
 
-template class ParametricMomentumMap<1,1>;
-template class ParametricMomentumMap<2,1>;
-template class ParametricMomentumMap<1,3>;
-template class ParametricMomentumMap<2,3>;
-template class ParametricMomentumMap<1,6>;
-template class ParametricMomentumMap<2,6>;
+template class ParametricMomentumMap<1, 1>;
+template class ParametricMomentumMap<2, 1>;
+template class ParametricMomentumMap<1, 3>;
+template class ParametricMomentumMap<2, 3>;
+template class ParametricMomentumMap<1, 6>;
+template class ParametricMomentumMap<2, 6>;
 
 }

--- a/dynamics/src/cgParametricMomentum.cpp
+++ b/dynamics/src/cgParametricMomentum.cpp
@@ -1,6 +1,6 @@
 /*!
  * @file ParametricMomentum.cpp
- * @date 1 Mar 2022
+ * @date 04 Sep 2024
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/src/cgParametricMomentum.cpp
+++ b/dynamics/src/cgParametricMomentum.cpp
@@ -1,6 +1,6 @@
 /*!
  * @file ParametricMomentum.cpp
- * @date 04 Sep 2024
+ * @date 24 Sep 2024
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/src/cgParametricMomentum.cpp
+++ b/dynamics/src/cgParametricMomentum.cpp
@@ -141,7 +141,7 @@ template <int CG> void CGParametricMomentum<CG>::CheckPeriodicity(CGVector<CG>& 
 {
     // the two segments bottom, right, top, left, are each processed in parallel
     for (size_t seg = 0; seg < smesh.periodic.size(); ++seg) {
-        // #pragma omp parallel for
+        //#pragma omp parallel for
         for (size_t i = 0; i < smesh.periodic[seg].size(); ++i) {
 
             const size_t ptype = smesh.periodic[seg][i][0];

--- a/dynamics/src/cgParametricMomentum.cpp
+++ b/dynamics/src/cgParametricMomentum.cpp
@@ -141,7 +141,7 @@ template <int CG> void CGParametricMomentum<CG>::CheckPeriodicity(CGVector<CG>& 
 {
     // the two segments bottom, right, top, left, are each processed in parallel
     for (size_t seg = 0; seg < smesh.periodic.size(); ++seg) {
-        //#pragma omp parallel for
+        // #pragma omp parallel for
         for (size_t i = 0; i < smesh.periodic[seg].size(); ++i) {
 
             const size_t ptype = smesh.periodic[seg][i][0];
@@ -216,7 +216,9 @@ void CGParametricMomentum<CG>::mEVPStep(const VPParameters& params, const size_t
 
     // Update the stresses according to the mEVP model
 
-    std::cerr << "Fatal: Stressupdatehigherorder requires ParametricMomnetumMap with proper template parameter. See headerfile and use Kernel-infrastructure" << std::endl;
+    std::cerr << "Fatal: Stressupdatehigherorder requires ParametricMomnetumMap with proper "
+                 "template parameter. See headerfile and use Kernel-infrastructure"
+              << std::endl;
     abort();
     // Nextsim::mEVP::StressUpdateHighOrder(
     //     params, pmap, smesh, S11, S12, S22, E11, E12, E22, H, A, alpha, beta);

--- a/dynamics/src/cgParametricMomentum.cpp
+++ b/dynamics/src/cgParametricMomentum.cpp
@@ -216,8 +216,10 @@ void CGParametricMomentum<CG>::mEVPStep(const VPParameters& params, const size_t
 
     // Update the stresses according to the mEVP model
 
-    Nextsim::mEVP::StressUpdateHighOrder(
-        params, pmap, smesh, S11, S12, S22, E11, E12, E22, H, A, alpha, beta);
+    std::cerr << "Fatal: Stressupdatehigherorder requires ParametricMomnetumMap with proper template parameter. See headerfile and use Kernel-infrastructure" << std::endl;
+    abort();
+    // Nextsim::mEVP::StressUpdateHighOrder(
+    //     params, pmap, smesh, S11, S12, S22, E11, E12, E22, H, A, alpha, beta);
 
     // Compute the divergence of the stress tensor
 

--- a/dynamics/src/include/BBM.hpp
+++ b/dynamics/src/include/BBM.hpp
@@ -1,6 +1,6 @@
 /*!
  * @file BBM.hpp
- * @date 04 Sep 2024
+ * @date 24 Sep 2024
  * @author Einar Olason <Einar.Olason@nersc.no>
  * @author Piotr Minakowski <piotr.minakowski@ovgu.de>
  */

--- a/dynamics/src/include/BBM.hpp
+++ b/dynamics/src/include/BBM.hpp
@@ -43,7 +43,9 @@ namespace BBM {
      * @param dt_mom timestep for momentum subcycle
      */
     template <int CG, int DGs, int DGa>
-    void StressUpdateHighOrder(const MEBParameters& params, const ParametricMesh& smesh,
+    void StressUpdateHighOrder(const MEBParameters& params,
+			       const ParametricMomentumMap<CG, DGa>& pmap,
+			       const ParametricMesh& smesh,
         DGVector<DGs>& S11, DGVector<DGs>& S12, DGVector<DGs>& S22, const DGVector<DGs>& E11,
         const DGVector<DGs>& E12, const DGVector<DGs>& E22, const DGVector<DGa>& H,
         const DGVector<DGa>& A, DGVector<DGa>& D, const double dt_mom)
@@ -168,19 +170,23 @@ namespace BBM {
             s12_gauss.array() -= s12_gauss.array() * (1. - dcrit.array()) * dt_mom / td.array();
             s22_gauss.array() -= s22_gauss.array() * (1. - dcrit.array()) * dt_mom / td.array();
 
-            // INTEGRATION OF STRESS AND DAMAGE
+            // // INTEGRATION OF STRESS AND DAMAGE
             const Eigen::Matrix<Nextsim::FloatType, 1, NGP* NGP> J
                 = ParametricTools::J<3>(smesh, i);
-            // get the inverse of the mass matrix scaled with the test-functions in the gauss
-            // points, with the gauss weights and with J. This is a 8 x 9 matrix
-            const Eigen::Matrix<Nextsim::FloatType, DGs, NGP* NGP> imass_psi
-                = ParametricTools::massMatrix<DGs>(smesh, i).inverse()
-                * (PSI<DGs, NGP>.array().rowwise() * (GAUSSWEIGHTS<NGP>.array() * J.array()))
-                      .matrix();
+            // // get the inverse of the mass matrix scaled with the test-functions in the gauss
+            // // points, with the gauss weights and with J. This is a 8 x 9 matrix
+            // const Eigen::Matrix<Nextsim::FloatType, DGs, NGP* NGP> imass_psi
+            //     = ParametricTools::massMatrix<DGs>(smesh, i).inverse()
+            //     * (PSI<DGs, NGP>.array().rowwise() * (GAUSSWEIGHTS<NGP>.array() * J.array()))
+            //           .matrix();
 
-            S11.row(i) = imass_psi * s11_gauss.matrix().transpose();
-            S12.row(i) = imass_psi * s12_gauss.matrix().transpose();
-            S22.row(i) = imass_psi * s22_gauss.matrix().transpose();
+            // S11.row(i) = imass_psi * s11_gauss.matrix().transpose();
+            // S12.row(i) = imass_psi * s12_gauss.matrix().transpose();
+            // S22.row(i) = imass_psi * s22_gauss.matrix().transpose();
+
+            S11.row(i) = pmap.iMJwPSI[i] * s11_gauss.matrix().transpose();
+            S12.row(i) = pmap.iMJwPSI[i] * s12_gauss.matrix().transpose();
+            S22.row(i) = pmap.iMJwPSI[i] * s22_gauss.matrix().transpose();
 
             const Eigen::Matrix<Nextsim::FloatType, DGa, NGP* NGP> imass_psi2
                 = ParametricTools::massMatrix<DGa>(smesh, i).inverse()

--- a/dynamics/src/include/BBM.hpp
+++ b/dynamics/src/include/BBM.hpp
@@ -1,6 +1,6 @@
 /*!
  * @file BBM.hpp
- * @date 12 Dec 2022
+ * @date 04 Sep 2024
  * @author Einar Olason <Einar.Olason@nersc.no>
  * @author Piotr Minakowski <piotr.minakowski@ovgu.de>
  */

--- a/dynamics/src/include/BBM.hpp
+++ b/dynamics/src/include/BBM.hpp
@@ -50,7 +50,7 @@ namespace BBM {
         const double dt_mom)
     {
 
-// #define NGP (DGs == 8 ? 3 : (DGs == 3 ? 2 : -1))
+//#define NGP (DGs == 8 ? 3 : (DGs == 3 ? 2 : -1))
 #define NGP 3
 
 //! Stress and Damage Update
@@ -58,53 +58,53 @@ namespace BBM {
         for (size_t i = 0; i < smesh.nelements; ++i) {
 
             //! Evaluate values in Gauss points (3 point Gauss rule in 2d => 9 points)
-            const Eigen::Matrix<double, 1, NGP * NGP> h_gauss
+            const Eigen::Matrix<double, 1, NGP* NGP> h_gauss
                 = (H.row(i) * PSI<DGa, NGP>).array().max(0.0).matrix();
-            const Eigen::Matrix<double, 1, NGP * NGP> a_gauss
+            const Eigen::Matrix<double, 1, NGP* NGP> a_gauss
                 = (A.row(i) * PSI<DGa, NGP>).array().max(0.0).min(1.0).matrix();
-            Eigen::Matrix<double, 1, NGP * NGP> d_gauss
+            Eigen::Matrix<double, 1, NGP* NGP> d_gauss
                 = (D.row(i) * PSI<DGa, NGP>).array().max(1e-12).min(1.0).matrix();
 
-            const Eigen::Matrix<double, 1, NGP * NGP> e11_gauss = E11.row(i) * PSI<DGs, NGP>;
-            const Eigen::Matrix<double, 1, NGP * NGP> e12_gauss = E12.row(i) * PSI<DGs, NGP>;
-            const Eigen::Matrix<double, 1, NGP * NGP> e22_gauss = E22.row(i) * PSI<DGs, NGP>;
+            const Eigen::Matrix<double, 1, NGP* NGP> e11_gauss = E11.row(i) * PSI<DGs, NGP>;
+            const Eigen::Matrix<double, 1, NGP* NGP> e12_gauss = E12.row(i) * PSI<DGs, NGP>;
+            const Eigen::Matrix<double, 1, NGP* NGP> e22_gauss = E22.row(i) * PSI<DGs, NGP>;
 
-            Eigen::Matrix<double, 1, NGP * NGP> s11_gauss = S11.row(i) * PSI<DGs, NGP>;
-            Eigen::Matrix<double, 1, NGP * NGP> s12_gauss = S12.row(i) * PSI<DGs, NGP>;
-            Eigen::Matrix<double, 1, NGP * NGP> s22_gauss = S22.row(i) * PSI<DGs, NGP>;
+            Eigen::Matrix<double, 1, NGP* NGP> s11_gauss = S11.row(i) * PSI<DGs, NGP>;
+            Eigen::Matrix<double, 1, NGP* NGP> s12_gauss = S12.row(i) * PSI<DGs, NGP>;
+            Eigen::Matrix<double, 1, NGP* NGP> s22_gauss = S22.row(i) * PSI<DGs, NGP>;
 
             //! Current normal stress for the evaluation of tildeP (Eqn. 1)
-            Eigen::Matrix<double, 1, NGP * NGP> sigma_n
+            Eigen::Matrix<double, 1, NGP* NGP> sigma_n
                 = 0.5 * (s11_gauss.array() + s22_gauss.array());
 
             //! exp(-C(1-A))
-            const Eigen::Matrix<double, 1, NGP * NGP> expC
+            const Eigen::Matrix<double, 1, NGP* NGP> expC
                 = (params.compaction_param * (1.0 - a_gauss.array())).exp().array();
 
             // Eqn. 25
-            const Eigen::Matrix<double, 1, NGP * NGP> powalphaexpC
+            const Eigen::Matrix<double, 1, NGP* NGP> powalphaexpC
                 = (d_gauss.array() * expC.array()).pow(params.exponent_relaxation_sigma - 1);
-            const Eigen::Matrix<double, 1, NGP * NGP> time_viscous
+            const Eigen::Matrix<double, 1, NGP* NGP> time_viscous
                 = params.undamaged_time_relaxation_sigma * powalphaexpC;
 
             //! BBM  Computing tildeP according to (Eqn. 7b and Eqn. 8)
             // (Eqn. 8)
-            const Eigen::Matrix<double, 1, NGP * NGP> Pmax = params.P0
+            const Eigen::Matrix<double, 1, NGP* NGP> Pmax = params.P0
                 * h_gauss.array().pow(params.exponent_compression_factor) * expC.array();
 
             // (Eqn. 7b) Prepare tildeP
             // tildeP must be capped at 1 to get an elastic response
             // (Eqn. 7b) Select case based on sigma_n
-            const Eigen::Matrix<double, 1, NGP * NGP> tildeP
+            const Eigen::Matrix<double, 1, NGP* NGP> tildeP
                 = (sigma_n.array() < 0.0)
                       .select((-Pmax.array() / sigma_n.array()).min(1.0).matrix(), 0.);
 
             // multiplicator
-            const Eigen::Matrix<double, 1, NGP * NGP> multiplicator
+            const Eigen::Matrix<double, 1, NGP* NGP> multiplicator
                 = time_viscous.array() / (time_viscous.array() + (1. - tildeP.array()) * dt_mom);
 
             //! Eqn. 9
-            const Eigen::Matrix<double, 1, NGP * NGP> elasticity
+            const Eigen::Matrix<double, 1, NGP* NGP> elasticity
                 = h_gauss.array() * params.young * d_gauss.array() * expC.array();
 
             // Eqn. 12: first factor on RHS
@@ -114,7 +114,7 @@ namespace BBM {
              * \ (K:e)12 /    1 - nu^2 \  0   0  1-nu / \ e12 /
              */
 
-            const Eigen::Matrix<double, 1, NGP * NGP> Dunit_factor
+            const Eigen::Matrix<double, 1, NGP* NGP> Dunit_factor
                 = dt_mom * elasticity.array() / (1. - (params.nu0 * params.nu0));
 
             s11_gauss.array()
@@ -129,7 +129,7 @@ namespace BBM {
             s12_gauss.array() *= multiplicator.array();
 
             sigma_n = 0.5 * (s11_gauss.array() + s22_gauss.array());
-            const Eigen::Matrix<double, 1, NGP * NGP> tau
+            const Eigen::Matrix<double, 1, NGP* NGP> tau
                 = (0.25 * (s11_gauss.array() - s22_gauss.array()).square()
                     + s12_gauss.array().square())
                       .sqrt();
@@ -137,15 +137,15 @@ namespace BBM {
             const double scale_coef = std::sqrt(0.1 / smesh.h(i));
 
             //! Eqn. 22
-            const Eigen::Matrix<double, 1, NGP * NGP> cohesion
+            const Eigen::Matrix<double, 1, NGP* NGP> cohesion
                 = params.C_lab * scale_coef * h_gauss.array();
             //! Eqn. 30
-            const Eigen::Matrix<double, 1, NGP * NGP> compr_strength
+            const Eigen::Matrix<double, 1, NGP* NGP> compr_strength
                 = params.compr_strength * scale_coef * h_gauss.array();
 
             // Mohr-Coulomb failure using Mssrs. Plante & Tremblay's formulation
             // sigma_s + tan_phi*sigma_n < 0 is always inside, but gives dcrit < 0
-            Eigen::Matrix<double, 1, NGP * NGP> dcrit
+            Eigen::Matrix<double, 1, NGP* NGP> dcrit
                 = (tau.array() + params.tan_phi * sigma_n.array() > 0.)
                       .select(
                           cohesion.array() / (tau.array() + params.tan_phi * sigma_n.array()), 1.);
@@ -158,7 +158,7 @@ namespace BBM {
             dcrit = dcrit.array().min(1.0);
 
             // Eqn. 29
-            const Eigen::Matrix<double, 1, NGP * NGP> td = smesh.h(i)
+            const Eigen::Matrix<double, 1, NGP* NGP> td = smesh.h(i)
                 * std::sqrt(2. * (1. + params.nu0) * params.rho_ice) / elasticity.array().sqrt();
 
             // Update damage
@@ -170,7 +170,7 @@ namespace BBM {
             s22_gauss.array() -= s22_gauss.array() * (1. - dcrit.array()) * dt_mom / td.array();
 
             // // INTEGRATION OF STRESS AND DAMAGE
-            const Eigen::Matrix<Nextsim::FloatType, 1, NGP * NGP> J
+            const Eigen::Matrix<Nextsim::FloatType, 1, NGP* NGP> J
                 = ParametricTools::J<3>(smesh, i);
             // // get the inverse of the mass matrix scaled with the test-functions in the gauss
             // // points, with the gauss weights and with J. This is a 8 x 9 matrix
@@ -187,7 +187,7 @@ namespace BBM {
             S12.row(i) = pmap.iMJwPSI[i] * s12_gauss.matrix().transpose();
             S22.row(i) = pmap.iMJwPSI[i] * s22_gauss.matrix().transpose();
 
-            const Eigen::Matrix<Nextsim::FloatType, DGa, NGP * NGP> imass_psi2
+            const Eigen::Matrix<Nextsim::FloatType, DGa, NGP* NGP> imass_psi2
                 = ParametricTools::massMatrix<DGa>(smesh, i).inverse()
                 * (PSI<DGa, NGP>.array().rowwise() * (GAUSSWEIGHTS<NGP>.array() * J.array()))
                       .matrix();

--- a/dynamics/src/include/BBM.hpp
+++ b/dynamics/src/include/BBM.hpp
@@ -44,14 +44,13 @@ namespace BBM {
      */
     template <int CG, int DGs, int DGa>
     void StressUpdateHighOrder(const MEBParameters& params,
-			       const ParametricMomentumMap<CG, DGa>& pmap,
-			       const ParametricMesh& smesh,
-        DGVector<DGs>& S11, DGVector<DGs>& S12, DGVector<DGs>& S22, const DGVector<DGs>& E11,
-        const DGVector<DGs>& E12, const DGVector<DGs>& E22, const DGVector<DGa>& H,
-        const DGVector<DGa>& A, DGVector<DGa>& D, const double dt_mom)
+        const ParametricMomentumMap<CG, DGa>& pmap, const ParametricMesh& smesh, DGVector<DGs>& S11,
+        DGVector<DGs>& S12, DGVector<DGs>& S22, const DGVector<DGs>& E11, const DGVector<DGs>& E12,
+        const DGVector<DGs>& E22, const DGVector<DGa>& H, const DGVector<DGa>& A, DGVector<DGa>& D,
+        const double dt_mom)
     {
 
-//#define NGP (DGs == 8 ? 3 : (DGs == 3 ? 2 : -1))
+// #define NGP (DGs == 8 ? 3 : (DGs == 3 ? 2 : -1))
 #define NGP 3
 
 //! Stress and Damage Update
@@ -59,53 +58,53 @@ namespace BBM {
         for (size_t i = 0; i < smesh.nelements; ++i) {
 
             //! Evaluate values in Gauss points (3 point Gauss rule in 2d => 9 points)
-            const Eigen::Matrix<double, 1, NGP* NGP> h_gauss
+            const Eigen::Matrix<double, 1, NGP * NGP> h_gauss
                 = (H.row(i) * PSI<DGa, NGP>).array().max(0.0).matrix();
-            const Eigen::Matrix<double, 1, NGP* NGP> a_gauss
+            const Eigen::Matrix<double, 1, NGP * NGP> a_gauss
                 = (A.row(i) * PSI<DGa, NGP>).array().max(0.0).min(1.0).matrix();
-            Eigen::Matrix<double, 1, NGP* NGP> d_gauss
+            Eigen::Matrix<double, 1, NGP * NGP> d_gauss
                 = (D.row(i) * PSI<DGa, NGP>).array().max(1e-12).min(1.0).matrix();
 
-            const Eigen::Matrix<double, 1, NGP* NGP> e11_gauss = E11.row(i) * PSI<DGs, NGP>;
-            const Eigen::Matrix<double, 1, NGP* NGP> e12_gauss = E12.row(i) * PSI<DGs, NGP>;
-            const Eigen::Matrix<double, 1, NGP* NGP> e22_gauss = E22.row(i) * PSI<DGs, NGP>;
+            const Eigen::Matrix<double, 1, NGP * NGP> e11_gauss = E11.row(i) * PSI<DGs, NGP>;
+            const Eigen::Matrix<double, 1, NGP * NGP> e12_gauss = E12.row(i) * PSI<DGs, NGP>;
+            const Eigen::Matrix<double, 1, NGP * NGP> e22_gauss = E22.row(i) * PSI<DGs, NGP>;
 
-            Eigen::Matrix<double, 1, NGP* NGP> s11_gauss = S11.row(i) * PSI<DGs, NGP>;
-            Eigen::Matrix<double, 1, NGP* NGP> s12_gauss = S12.row(i) * PSI<DGs, NGP>;
-            Eigen::Matrix<double, 1, NGP* NGP> s22_gauss = S22.row(i) * PSI<DGs, NGP>;
+            Eigen::Matrix<double, 1, NGP * NGP> s11_gauss = S11.row(i) * PSI<DGs, NGP>;
+            Eigen::Matrix<double, 1, NGP * NGP> s12_gauss = S12.row(i) * PSI<DGs, NGP>;
+            Eigen::Matrix<double, 1, NGP * NGP> s22_gauss = S22.row(i) * PSI<DGs, NGP>;
 
             //! Current normal stress for the evaluation of tildeP (Eqn. 1)
-            Eigen::Matrix<double, 1, NGP* NGP> sigma_n
+            Eigen::Matrix<double, 1, NGP * NGP> sigma_n
                 = 0.5 * (s11_gauss.array() + s22_gauss.array());
 
             //! exp(-C(1-A))
-            const Eigen::Matrix<double, 1, NGP* NGP> expC
+            const Eigen::Matrix<double, 1, NGP * NGP> expC
                 = (params.compaction_param * (1.0 - a_gauss.array())).exp().array();
 
             // Eqn. 25
-            const Eigen::Matrix<double, 1, NGP* NGP> powalphaexpC
+            const Eigen::Matrix<double, 1, NGP * NGP> powalphaexpC
                 = (d_gauss.array() * expC.array()).pow(params.exponent_relaxation_sigma - 1);
-            const Eigen::Matrix<double, 1, NGP* NGP> time_viscous
+            const Eigen::Matrix<double, 1, NGP * NGP> time_viscous
                 = params.undamaged_time_relaxation_sigma * powalphaexpC;
 
             //! BBM  Computing tildeP according to (Eqn. 7b and Eqn. 8)
             // (Eqn. 8)
-            const Eigen::Matrix<double, 1, NGP* NGP> Pmax = params.P0
+            const Eigen::Matrix<double, 1, NGP * NGP> Pmax = params.P0
                 * h_gauss.array().pow(params.exponent_compression_factor) * expC.array();
 
             // (Eqn. 7b) Prepare tildeP
             // tildeP must be capped at 1 to get an elastic response
             // (Eqn. 7b) Select case based on sigma_n
-            const Eigen::Matrix<double, 1, NGP* NGP> tildeP
+            const Eigen::Matrix<double, 1, NGP * NGP> tildeP
                 = (sigma_n.array() < 0.0)
                       .select((-Pmax.array() / sigma_n.array()).min(1.0).matrix(), 0.);
 
             // multiplicator
-            const Eigen::Matrix<double, 1, NGP* NGP> multiplicator
+            const Eigen::Matrix<double, 1, NGP * NGP> multiplicator
                 = time_viscous.array() / (time_viscous.array() + (1. - tildeP.array()) * dt_mom);
 
             //! Eqn. 9
-            const Eigen::Matrix<double, 1, NGP* NGP> elasticity
+            const Eigen::Matrix<double, 1, NGP * NGP> elasticity
                 = h_gauss.array() * params.young * d_gauss.array() * expC.array();
 
             // Eqn. 12: first factor on RHS
@@ -115,7 +114,7 @@ namespace BBM {
              * \ (K:e)12 /    1 - nu^2 \  0   0  1-nu / \ e12 /
              */
 
-            const Eigen::Matrix<double, 1, NGP* NGP> Dunit_factor
+            const Eigen::Matrix<double, 1, NGP * NGP> Dunit_factor
                 = dt_mom * elasticity.array() / (1. - (params.nu0 * params.nu0));
 
             s11_gauss.array()
@@ -130,7 +129,7 @@ namespace BBM {
             s12_gauss.array() *= multiplicator.array();
 
             sigma_n = 0.5 * (s11_gauss.array() + s22_gauss.array());
-            const Eigen::Matrix<double, 1, NGP* NGP> tau
+            const Eigen::Matrix<double, 1, NGP * NGP> tau
                 = (0.25 * (s11_gauss.array() - s22_gauss.array()).square()
                     + s12_gauss.array().square())
                       .sqrt();
@@ -138,15 +137,15 @@ namespace BBM {
             const double scale_coef = std::sqrt(0.1 / smesh.h(i));
 
             //! Eqn. 22
-            const Eigen::Matrix<double, 1, NGP* NGP> cohesion
+            const Eigen::Matrix<double, 1, NGP * NGP> cohesion
                 = params.C_lab * scale_coef * h_gauss.array();
             //! Eqn. 30
-            const Eigen::Matrix<double, 1, NGP* NGP> compr_strength
+            const Eigen::Matrix<double, 1, NGP * NGP> compr_strength
                 = params.compr_strength * scale_coef * h_gauss.array();
 
             // Mohr-Coulomb failure using Mssrs. Plante & Tremblay's formulation
             // sigma_s + tan_phi*sigma_n < 0 is always inside, but gives dcrit < 0
-            Eigen::Matrix<double, 1, NGP* NGP> dcrit
+            Eigen::Matrix<double, 1, NGP * NGP> dcrit
                 = (tau.array() + params.tan_phi * sigma_n.array() > 0.)
                       .select(
                           cohesion.array() / (tau.array() + params.tan_phi * sigma_n.array()), 1.);
@@ -159,7 +158,7 @@ namespace BBM {
             dcrit = dcrit.array().min(1.0);
 
             // Eqn. 29
-            const Eigen::Matrix<double, 1, NGP* NGP> td = smesh.h(i)
+            const Eigen::Matrix<double, 1, NGP * NGP> td = smesh.h(i)
                 * std::sqrt(2. * (1. + params.nu0) * params.rho_ice) / elasticity.array().sqrt();
 
             // Update damage
@@ -171,7 +170,7 @@ namespace BBM {
             s22_gauss.array() -= s22_gauss.array() * (1. - dcrit.array()) * dt_mom / td.array();
 
             // // INTEGRATION OF STRESS AND DAMAGE
-            const Eigen::Matrix<Nextsim::FloatType, 1, NGP* NGP> J
+            const Eigen::Matrix<Nextsim::FloatType, 1, NGP * NGP> J
                 = ParametricTools::J<3>(smesh, i);
             // // get the inverse of the mass matrix scaled with the test-functions in the gauss
             // // points, with the gauss weights and with J. This is a 8 x 9 matrix
@@ -188,7 +187,7 @@ namespace BBM {
             S12.row(i) = pmap.iMJwPSI[i] * s12_gauss.matrix().transpose();
             S22.row(i) = pmap.iMJwPSI[i] * s22_gauss.matrix().transpose();
 
-            const Eigen::Matrix<Nextsim::FloatType, DGa, NGP* NGP> imass_psi2
+            const Eigen::Matrix<Nextsim::FloatType, DGa, NGP * NGP> imass_psi2
                 = ParametricTools::massMatrix<DGa>(smesh, i).inverse()
                 * (PSI<DGa, NGP>.array().rowwise() * (GAUSSWEIGHTS<NGP>.array() * J.array()))
                       .matrix();

--- a/dynamics/src/include/BBM.hpp
+++ b/dynamics/src/include/BBM.hpp
@@ -170,7 +170,7 @@ namespace BBM {
             s22_gauss.array() -= s22_gauss.array() * (1. - dcrit.array()) * dt_mom / td.array();
 
             // // INTEGRATION OF STRESS AND DAMAGE
-            const Eigen::Matrix<Nextsim::FloatType, 1, NGP* NGP> J
+            const Eigen::Matrix<Nextsim::FloatType, 1, NGP * NGP> J
                 = ParametricTools::J<3>(smesh, i);
             // // get the inverse of the mass matrix scaled with the test-functions in the gauss
             // // points, with the gauss weights and with J. This is a 8 x 9 matrix

--- a/dynamics/src/include/BBMStressUpdateStep.hpp
+++ b/dynamics/src/include/BBMStressUpdateStep.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file BBMStressUpdateStep.hpp
  *
- * @date 04 Sep 2024
+ * @date 24 Sep 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/dynamics/src/include/BBMStressUpdateStep.hpp
+++ b/dynamics/src/include/BBMStressUpdateStep.hpp
@@ -28,14 +28,13 @@ public:
     {
     }
     ~BBMStressUpdateStep() = default;
-    void stressUpdateHighOrder(const DynamicsParameters& dParams,
-			       const ParametricMesh& smesh,
+    void stressUpdateHighOrder(const DynamicsParameters& dParams, const ParametricMesh& smesh,
         SymmetricTensorVector& stress, const SymmetricTensorVector& strain,
         const DGVector<DGadvection>& h, const DGVector<DGadvection>& a,
         const double deltaT) override
     {
-      assert(pmap);
-      
+        assert(pmap);
+
         // Unwrap references
         DGVector<DGstress>& s11 = stress[I11];
         DGVector<DGstress>& s12 = stress[I12];
@@ -53,56 +52,56 @@ public:
         for (size_t i = 0; i < smesh.nelements; ++i) {
 
             //! Evaluate values in Gauss points (3 point Gauss rule in 2d => 9 points)
-            const Eigen::Matrix<double, 1, nGauss* nGauss> hGauss
+            const Eigen::Matrix<double, 1, nGauss * nGauss> hGauss
                 = (h.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).matrix();
-            const Eigen::Matrix<double, 1, nGauss* nGauss> aGauss
+            const Eigen::Matrix<double, 1, nGauss * nGauss> aGauss
                 = (a.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).min(1.0).matrix();
-            Eigen::Matrix<double, 1, nGauss* nGauss> dGauss
+            Eigen::Matrix<double, 1, nGauss * nGauss> dGauss
                 = (p_d->row(i) * PSI<DGadvection, nGauss>).array().max(1e-12).min(1.0).matrix();
 
-            const Eigen::Matrix<double, 1, nGauss* nGauss> e11Gauss
+            const Eigen::Matrix<double, 1, nGauss * nGauss> e11Gauss
                 = e11.row(i) * PSI<DGstress, nGauss>;
-            const Eigen::Matrix<double, 1, nGauss* nGauss> e12Gauss
+            const Eigen::Matrix<double, 1, nGauss * nGauss> e12Gauss
                 = e12.row(i) * PSI<DGstress, nGauss>;
-            const Eigen::Matrix<double, 1, nGauss* nGauss> e22Gauss
+            const Eigen::Matrix<double, 1, nGauss * nGauss> e22Gauss
                 = e22.row(i) * PSI<DGstress, nGauss>;
 
-            Eigen::Matrix<double, 1, nGauss* nGauss> s11Gauss = s11.row(i) * PSI<DGstress, nGauss>;
-            Eigen::Matrix<double, 1, nGauss* nGauss> s12Gauss = s12.row(i) * PSI<DGstress, nGauss>;
-            Eigen::Matrix<double, 1, nGauss* nGauss> s22Gauss = s22.row(i) * PSI<DGstress, nGauss>;
+            Eigen::Matrix<double, 1, nGauss * nGauss> s11Gauss = s11.row(i) * PSI<DGstress, nGauss>;
+            Eigen::Matrix<double, 1, nGauss * nGauss> s12Gauss = s12.row(i) * PSI<DGstress, nGauss>;
+            Eigen::Matrix<double, 1, nGauss * nGauss> s22Gauss = s22.row(i) * PSI<DGstress, nGauss>;
 
             //! Current normal stress for the evaluation of tildeP (Eqn. 1)
-            Eigen::Matrix<double, 1, nGauss* nGauss> sigma_n
+            Eigen::Matrix<double, 1, nGauss * nGauss> sigma_n
                 = 0.5 * (s11Gauss.array() + s22Gauss.array());
 
             //! exp(-C(1-A))
-            const Eigen::Matrix<double, 1, nGauss* nGauss> expC
+            const Eigen::Matrix<double, 1, nGauss * nGauss> expC
                 = (params.compaction_param * (1.0 - aGauss.array())).exp().array();
 
             // Eqn. 25
-            const Eigen::Matrix<double, 1, nGauss* nGauss> powalphaexpC
+            const Eigen::Matrix<double, 1, nGauss * nGauss> powalphaexpC
                 = (dGauss.array() * expC.array()).pow(params.exponent_relaxation_sigma - 1);
-            const Eigen::Matrix<double, 1, nGauss* nGauss> time_viscous
+            const Eigen::Matrix<double, 1, nGauss * nGauss> time_viscous
                 = params.undamaged_time_relaxation_sigma * powalphaexpC;
 
             //! BBM  Computing tildeP according to (Eqn. 7b and Eqn. 8)
             // (Eqn. 8)
-            const Eigen::Matrix<double, 1, nGauss* nGauss> Pmax
+            const Eigen::Matrix<double, 1, nGauss * nGauss> Pmax
                 = params.P0 * hGauss.array().pow(params.exponent_compression_factor) * expC.array();
 
             // (Eqn. 7b) Prepare tildeP
             // tildeP must be capped at 1 to get an elastic response
             // (Eqn. 7b) Select case based on sigma_n
-            const Eigen::Matrix<double, 1, nGauss* nGauss> tildeP
+            const Eigen::Matrix<double, 1, nGauss * nGauss> tildeP
                 = (sigma_n.array() < 0.0)
                       .select((-Pmax.array() / sigma_n.array()).min(1.0).matrix(), 0.);
 
             // multiplicator
-            const Eigen::Matrix<double, 1, nGauss* nGauss> multiplicator
+            const Eigen::Matrix<double, 1, nGauss * nGauss> multiplicator
                 = time_viscous.array() / (time_viscous.array() + (1. - tildeP.array()) * deltaT);
 
             //! Eqn. 9
-            const Eigen::Matrix<double, 1, nGauss* nGauss> elasticity
+            const Eigen::Matrix<double, 1, nGauss * nGauss> elasticity
                 = hGauss.array() * params.young * dGauss.array() * expC.array();
 
             // Eqn. 12: first factor on RHS
@@ -112,7 +111,7 @@ public:
              * \ (K:e)12 /    1 - nu^2 \  0   0  1-nu / \ e12 /
              */
 
-            const Eigen::Matrix<double, 1, nGauss* nGauss> Dunit_factor
+            const Eigen::Matrix<double, 1, nGauss * nGauss> Dunit_factor
                 = deltaT * elasticity.array() / (1. - (params.nu0 * params.nu0));
 
             s11Gauss.array()
@@ -127,7 +126,7 @@ public:
             s12Gauss.array() *= multiplicator.array();
 
             sigma_n = 0.5 * (s11Gauss.array() + s22Gauss.array());
-            const Eigen::Matrix<double, 1, nGauss* nGauss> tau
+            const Eigen::Matrix<double, 1, nGauss * nGauss> tau
                 = (0.25 * (s11Gauss.array() - s22Gauss.array()).square()
                     + s12Gauss.array().square())
                       .sqrt();
@@ -135,15 +134,15 @@ public:
             const double scale_coef = std::sqrt(0.1 / smesh.h(i));
 
             //! Eqn. 22
-            const Eigen::Matrix<double, 1, nGauss* nGauss> cohesion
+            const Eigen::Matrix<double, 1, nGauss * nGauss> cohesion
                 = params.C_lab * scale_coef * hGauss.array();
             //! Eqn. 30
-            const Eigen::Matrix<double, 1, nGauss* nGauss> compr_strength
+            const Eigen::Matrix<double, 1, nGauss * nGauss> compr_strength
                 = params.compr_strength * scale_coef * hGauss.array();
 
             // Mohr-Coulomb failure using Mssrs. Plante & Tremblay's formulation
             // sigma_s + tan_phi*sigma_n < 0 is always inside, but gives dcrit < 0
-            Eigen::Matrix<double, 1, nGauss* nGauss> dcrit
+            Eigen::Matrix<double, 1, nGauss * nGauss> dcrit
                 = (tau.array() + params.tan_phi * sigma_n.array() > 0.)
                       .select(
                           cohesion.array() / (tau.array() + params.tan_phi * sigma_n.array()), 1.);
@@ -156,7 +155,7 @@ public:
             dcrit = dcrit.array().min(1.0);
 
             // Eqn. 29
-            const Eigen::Matrix<double, 1, nGauss* nGauss> td = smesh.h(i)
+            const Eigen::Matrix<double, 1, nGauss * nGauss> td = smesh.h(i)
                 * std::sqrt(2. * (1. + params.nu0) * params.rho_ice) / elasticity.array().sqrt();
 
             // Update damage

--- a/dynamics/src/include/BBMStressUpdateStep.hpp
+++ b/dynamics/src/include/BBMStressUpdateStep.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file BBMStressUpdateStep.hpp
  *
- * @date Mar 1, 2024
+ * @date 04 Sep 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/dynamics/src/include/BBMStressUpdateStep.hpp
+++ b/dynamics/src/include/BBMStressUpdateStep.hpp
@@ -52,56 +52,56 @@ public:
         for (size_t i = 0; i < smesh.nelements; ++i) {
 
             //! Evaluate values in Gauss points (3 point Gauss rule in 2d => 9 points)
-            const Eigen::Matrix<double, 1, nGauss * nGauss> hGauss
+            const Eigen::Matrix<double, 1, nGauss* nGauss> hGauss
                 = (h.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).matrix();
-            const Eigen::Matrix<double, 1, nGauss * nGauss> aGauss
+            const Eigen::Matrix<double, 1, nGauss* nGauss> aGauss
                 = (a.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).min(1.0).matrix();
-            Eigen::Matrix<double, 1, nGauss * nGauss> dGauss
+            Eigen::Matrix<double, 1, nGauss* nGauss> dGauss
                 = (p_d->row(i) * PSI<DGadvection, nGauss>).array().max(1e-12).min(1.0).matrix();
 
-            const Eigen::Matrix<double, 1, nGauss * nGauss> e11Gauss
+            const Eigen::Matrix<double, 1, nGauss* nGauss> e11Gauss
                 = e11.row(i) * PSI<DGstress, nGauss>;
-            const Eigen::Matrix<double, 1, nGauss * nGauss> e12Gauss
+            const Eigen::Matrix<double, 1, nGauss* nGauss> e12Gauss
                 = e12.row(i) * PSI<DGstress, nGauss>;
-            const Eigen::Matrix<double, 1, nGauss * nGauss> e22Gauss
+            const Eigen::Matrix<double, 1, nGauss* nGauss> e22Gauss
                 = e22.row(i) * PSI<DGstress, nGauss>;
 
-            Eigen::Matrix<double, 1, nGauss * nGauss> s11Gauss = s11.row(i) * PSI<DGstress, nGauss>;
-            Eigen::Matrix<double, 1, nGauss * nGauss> s12Gauss = s12.row(i) * PSI<DGstress, nGauss>;
-            Eigen::Matrix<double, 1, nGauss * nGauss> s22Gauss = s22.row(i) * PSI<DGstress, nGauss>;
+            Eigen::Matrix<double, 1, nGauss* nGauss> s11Gauss = s11.row(i) * PSI<DGstress, nGauss>;
+            Eigen::Matrix<double, 1, nGauss* nGauss> s12Gauss = s12.row(i) * PSI<DGstress, nGauss>;
+            Eigen::Matrix<double, 1, nGauss* nGauss> s22Gauss = s22.row(i) * PSI<DGstress, nGauss>;
 
             //! Current normal stress for the evaluation of tildeP (Eqn. 1)
-            Eigen::Matrix<double, 1, nGauss * nGauss> sigma_n
+            Eigen::Matrix<double, 1, nGauss* nGauss> sigma_n
                 = 0.5 * (s11Gauss.array() + s22Gauss.array());
 
             //! exp(-C(1-A))
-            const Eigen::Matrix<double, 1, nGauss * nGauss> expC
+            const Eigen::Matrix<double, 1, nGauss* nGauss> expC
                 = (params.compaction_param * (1.0 - aGauss.array())).exp().array();
 
             // Eqn. 25
-            const Eigen::Matrix<double, 1, nGauss * nGauss> powalphaexpC
+            const Eigen::Matrix<double, 1, nGauss* nGauss> powalphaexpC
                 = (dGauss.array() * expC.array()).pow(params.exponent_relaxation_sigma - 1);
-            const Eigen::Matrix<double, 1, nGauss * nGauss> time_viscous
+            const Eigen::Matrix<double, 1, nGauss* nGauss> time_viscous
                 = params.undamaged_time_relaxation_sigma * powalphaexpC;
 
             //! BBM  Computing tildeP according to (Eqn. 7b and Eqn. 8)
             // (Eqn. 8)
-            const Eigen::Matrix<double, 1, nGauss * nGauss> Pmax
+            const Eigen::Matrix<double, 1, nGauss* nGauss> Pmax
                 = params.P0 * hGauss.array().pow(params.exponent_compression_factor) * expC.array();
 
             // (Eqn. 7b) Prepare tildeP
             // tildeP must be capped at 1 to get an elastic response
             // (Eqn. 7b) Select case based on sigma_n
-            const Eigen::Matrix<double, 1, nGauss * nGauss> tildeP
+            const Eigen::Matrix<double, 1, nGauss* nGauss> tildeP
                 = (sigma_n.array() < 0.0)
                       .select((-Pmax.array() / sigma_n.array()).min(1.0).matrix(), 0.);
 
             // multiplicator
-            const Eigen::Matrix<double, 1, nGauss * nGauss> multiplicator
+            const Eigen::Matrix<double, 1, nGauss* nGauss> multiplicator
                 = time_viscous.array() / (time_viscous.array() + (1. - tildeP.array()) * deltaT);
 
             //! Eqn. 9
-            const Eigen::Matrix<double, 1, nGauss * nGauss> elasticity
+            const Eigen::Matrix<double, 1, nGauss* nGauss> elasticity
                 = hGauss.array() * params.young * dGauss.array() * expC.array();
 
             // Eqn. 12: first factor on RHS
@@ -111,7 +111,7 @@ public:
              * \ (K:e)12 /    1 - nu^2 \  0   0  1-nu / \ e12 /
              */
 
-            const Eigen::Matrix<double, 1, nGauss * nGauss> Dunit_factor
+            const Eigen::Matrix<double, 1, nGauss* nGauss> Dunit_factor
                 = deltaT * elasticity.array() / (1. - (params.nu0 * params.nu0));
 
             s11Gauss.array()
@@ -126,7 +126,7 @@ public:
             s12Gauss.array() *= multiplicator.array();
 
             sigma_n = 0.5 * (s11Gauss.array() + s22Gauss.array());
-            const Eigen::Matrix<double, 1, nGauss * nGauss> tau
+            const Eigen::Matrix<double, 1, nGauss* nGauss> tau
                 = (0.25 * (s11Gauss.array() - s22Gauss.array()).square()
                     + s12Gauss.array().square())
                       .sqrt();
@@ -134,15 +134,15 @@ public:
             const double scale_coef = std::sqrt(0.1 / smesh.h(i));
 
             //! Eqn. 22
-            const Eigen::Matrix<double, 1, nGauss * nGauss> cohesion
+            const Eigen::Matrix<double, 1, nGauss* nGauss> cohesion
                 = params.C_lab * scale_coef * hGauss.array();
             //! Eqn. 30
-            const Eigen::Matrix<double, 1, nGauss * nGauss> compr_strength
+            const Eigen::Matrix<double, 1, nGauss* nGauss> compr_strength
                 = params.compr_strength * scale_coef * hGauss.array();
 
             // Mohr-Coulomb failure using Mssrs. Plante & Tremblay's formulation
             // sigma_s + tan_phi*sigma_n < 0 is always inside, but gives dcrit < 0
-            Eigen::Matrix<double, 1, nGauss * nGauss> dcrit
+            Eigen::Matrix<double, 1, nGauss* nGauss> dcrit
                 = (tau.array() + params.tan_phi * sigma_n.array() > 0.)
                       .select(
                           cohesion.array() / (tau.array() + params.tan_phi * sigma_n.array()), 1.);
@@ -155,7 +155,7 @@ public:
             dcrit = dcrit.array().min(1.0);
 
             // Eqn. 29
-            const Eigen::Matrix<double, 1, nGauss * nGauss> td = smesh.h(i)
+            const Eigen::Matrix<double, 1, nGauss* nGauss> td = smesh.h(i)
                 * std::sqrt(2. * (1. + params.nu0) * params.rho_ice) / elasticity.array().sqrt();
 
             // Update damage

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -73,7 +73,7 @@ protected:
     CGVector<CGdegree> uAtmos;
     CGVector<CGdegree> vAtmos;
 
-    ParametricMomentumMap<CGdegree>* pmap;
+    ParametricMomentumMap<CGdegree, DGadvection>* pmap;
 };
 
 } /* namespace Nextsim */

--- a/dynamics/src/include/MEVPStressUpdateStep.hpp
+++ b/dynamics/src/include/MEVPStressUpdateStep.hpp
@@ -51,20 +51,20 @@ public:
             // Here, one should check if it is enough to use a 2-point Gauss rule.
             // We're dealing with dG2, 3-point Gauss should be required.
 
-            const LocalEdgeVector<nGauss* nGauss> h_gauss
+            const LocalEdgeVector<nGauss * nGauss> h_gauss
                 = (h.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).matrix();
-            const LocalEdgeVector<nGauss* nGauss> a_gauss
+            const LocalEdgeVector<nGauss * nGauss> a_gauss
                 = (a.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).min(1.0).matrix();
 
-            const LocalEdgeVector<nGauss* nGauss> e11_gauss = e11.row(i) * PSI<DGstress, nGauss>;
-            const LocalEdgeVector<nGauss* nGauss> e12_gauss = e12.row(i) * PSI<DGstress, nGauss>;
-            const LocalEdgeVector<nGauss* nGauss> e22_gauss = e22.row(i) * PSI<DGstress, nGauss>;
+            const LocalEdgeVector<nGauss * nGauss> e11_gauss = e11.row(i) * PSI<DGstress, nGauss>;
+            const LocalEdgeVector<nGauss * nGauss> e12_gauss = e12.row(i) * PSI<DGstress, nGauss>;
+            const LocalEdgeVector<nGauss * nGauss> e22_gauss = e22.row(i) * PSI<DGstress, nGauss>;
 
-            const LocalEdgeVector<nGauss* nGauss> DELTA = (SQR(vpParams.DeltaMin)
+            const LocalEdgeVector<nGauss * nGauss> DELTA = (SQR(vpParams.DeltaMin)
                 + 1.25 * (e11_gauss.array().square() + e22_gauss.array().square())
                 + 1.50 * e11_gauss.array() * e22_gauss.array() + e12_gauss.array().square())
-                                                              .sqrt()
-                                                              .matrix();
+                                                               .sqrt()
+                                                               .matrix();
             // double DELTA = sqrt(SQR(vpparameters.DeltaMin) + 1.25 * (SQR(E11(i, 0)) + SQR(E22(i,
             // 0)))
             //       + 1.50 * E11(i, 0) * E22(i, 0) + SQR(E12(i, 0)));
@@ -72,7 +72,7 @@ public:
 
             //   //! Ice strength
             //   double P = vpparameters.Pstar * H(i, 0) * exp(-20.0 * (1.0 - A(i, 0)));
-            const LocalEdgeVector<nGauss* nGauss> P
+            const LocalEdgeVector<nGauss * nGauss> P
                 = (vpParams.Pstar * h_gauss.array() * (-20.0 * (1.0 - a_gauss.array())).exp())
                       .matrix();
 

--- a/dynamics/src/include/MEVPStressUpdateStep.hpp
+++ b/dynamics/src/include/MEVPStressUpdateStep.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file MEVPStressUpdateStep.hpp
  *
- * @date Feb 1, 2024
+ * @date 04 Sep 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/dynamics/src/include/MEVPStressUpdateStep.hpp
+++ b/dynamics/src/include/MEVPStressUpdateStep.hpp
@@ -51,20 +51,20 @@ public:
             // Here, one should check if it is enough to use a 2-point Gauss rule.
             // We're dealing with dG2, 3-point Gauss should be required.
 
-            const LocalEdgeVector<nGauss * nGauss> h_gauss
+            const LocalEdgeVector<nGauss* nGauss> h_gauss
                 = (h.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).matrix();
-            const LocalEdgeVector<nGauss * nGauss> a_gauss
+            const LocalEdgeVector<nGauss* nGauss> a_gauss
                 = (a.row(i) * PSI<DGadvection, nGauss>).array().max(0.0).min(1.0).matrix();
 
-            const LocalEdgeVector<nGauss * nGauss> e11_gauss = e11.row(i) * PSI<DGstress, nGauss>;
-            const LocalEdgeVector<nGauss * nGauss> e12_gauss = e12.row(i) * PSI<DGstress, nGauss>;
-            const LocalEdgeVector<nGauss * nGauss> e22_gauss = e22.row(i) * PSI<DGstress, nGauss>;
+            const LocalEdgeVector<nGauss* nGauss> e11_gauss = e11.row(i) * PSI<DGstress, nGauss>;
+            const LocalEdgeVector<nGauss* nGauss> e12_gauss = e12.row(i) * PSI<DGstress, nGauss>;
+            const LocalEdgeVector<nGauss* nGauss> e22_gauss = e22.row(i) * PSI<DGstress, nGauss>;
 
-            const LocalEdgeVector<nGauss * nGauss> DELTA = (SQR(vpParams.DeltaMin)
+            const LocalEdgeVector<nGauss* nGauss> DELTA = (SQR(vpParams.DeltaMin)
                 + 1.25 * (e11_gauss.array().square() + e22_gauss.array().square())
                 + 1.50 * e11_gauss.array() * e22_gauss.array() + e12_gauss.array().square())
-                                                               .sqrt()
-                                                               .matrix();
+                                                              .sqrt()
+                                                              .matrix();
             // double DELTA = sqrt(SQR(vpparameters.DeltaMin) + 1.25 * (SQR(E11(i, 0)) + SQR(E22(i,
             // 0)))
             //       + 1.50 * E11(i, 0) * E22(i, 0) + SQR(E12(i, 0)));
@@ -72,7 +72,7 @@ public:
 
             //   //! Ice strength
             //   double P = vpparameters.Pstar * H(i, 0) * exp(-20.0 * (1.0 - A(i, 0)));
-            const LocalEdgeVector<nGauss * nGauss> P
+            const LocalEdgeVector<nGauss* nGauss> P
                 = (vpParams.Pstar * h_gauss.array() * (-20.0 * (1.0 - a_gauss.array())).exp())
                       .matrix();
 

--- a/dynamics/src/include/MEVPStressUpdateStep.hpp
+++ b/dynamics/src/include/MEVPStressUpdateStep.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file MEVPStressUpdateStep.hpp
  *
- * @date 04 Sep 2024
+ * @date 24 Sep 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/dynamics/src/include/MEVPStressUpdateStep.hpp
+++ b/dynamics/src/include/MEVPStressUpdateStep.hpp
@@ -116,10 +116,10 @@ public:
                           .transpose());
         }
     }
-    void setPMap(ParametricMomentumMap<CG>* pmapIn) { pmap = pmapIn; }
+    void setPMap(ParametricMomentumMap<CG, DGadvection>* pmapIn) { pmap = pmapIn; }
 
 protected:
-    ParametricMomentumMap<CG>* pmap;
+    ParametricMomentumMap<CG, DGadvection>* pmap;
 
 private:
     //! MEVP parameters

--- a/dynamics/src/include/ParametricMap.hpp
+++ b/dynamics/src/include/ParametricMap.hpp
@@ -1,6 +1,6 @@
 /*!
  * @file    ParametricMap.hpp
- * @date 04 Sep 2024
+ * @date    Dec 13, 2022
  * @author  Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/src/include/ParametricMap.hpp
+++ b/dynamics/src/include/ParametricMap.hpp
@@ -86,9 +86,9 @@ public:
         iMgradX, iMgradY, iMM;
 
     /*!
-     * These matrices are M^-1 J w PSI_i(q), 
-     * inverse of mass matrix (in DGstress-degree) multiplied with map J, weights w and DG Test functions,
-     * all in the GAUSS points, i.e. iMJwPSI \in R^(DGstress x Ngauss)
+     * These matrices are M^-1 J w PSI_i(q),
+     * inverse of mass matrix (in DGstress-degree) multiplied with map J, weights w and DG Test
+     * functions, all in the GAUSS points, i.e. iMJwPSI \in R^(DGstress x Ngauss)
      */
     std::vector<Eigen::Matrix<Nextsim::FloatType, CG2DGSTRESS(CG), GAUSSPOINTS(CG2DGSTRESS(CG))>,
         Eigen::aligned_allocator<
@@ -96,7 +96,7 @@ public:
         iMJwPSI;
 
     /*!
-     * These matrices are M^-1 J w PSI_i(q), 
+     * These matrices are M^-1 J w PSI_i(q),
      * but, instead of DG-stress based on the DGAdvection (used for damage)
      */
     std::vector<Eigen::Matrix<Nextsim::FloatType, DG, GAUSSPOINTS(CG2DGSTRESS(CG))>,

--- a/dynamics/src/include/ParametricMap.hpp
+++ b/dynamics/src/include/ParametricMap.hpp
@@ -1,6 +1,6 @@
 /*!
  * @file    ParametricMap.hpp
- * @date    Dec 13, 2022
+ * @date 04 Sep 2024
  * @author  Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/src/include/ParametricMap.hpp
+++ b/dynamics/src/include/ParametricMap.hpp
@@ -59,7 +59,7 @@ public:
  *
  * The coordiante system is encoded into the matrices
  */
-template <int CG> class ParametricMomentumMap {
+template <int CG, int DG> class ParametricMomentumMap {
     //! Reference to the map. Given with constructor
     const ParametricMesh& smesh;
 
@@ -86,13 +86,23 @@ public:
         iMgradX, iMgradY, iMM;
 
     /*!
-     * These matrices are M^-1 J w PSI_i(q)
-     * Multiplied
+     * These matrices are M^-1 J w PSI_i(q), 
+     * inverse of mass matrix (in DGstress-degree) multiplied with map J, weights w and DG Test functions,
+     * all in the GAUSS points, i.e. iMJwPSI \in R^(DGstress x Ngauss)
      */
     std::vector<Eigen::Matrix<Nextsim::FloatType, CG2DGSTRESS(CG), GAUSSPOINTS(CG2DGSTRESS(CG))>,
         Eigen::aligned_allocator<
             Eigen::Matrix<Nextsim::FloatType, CG2DGSTRESS(CG), GAUSSPOINTS(CG2DGSTRESS(CG))>>>
         iMJwPSI;
+
+    /*!
+     * These matrices are M^-1 J w PSI_i(q), 
+     * but, instead of DG-stress based on the DGAdvection (used for damage)
+     */
+    std::vector<Eigen::Matrix<Nextsim::FloatType, DG, GAUSSPOINTS(CG2DGSTRESS(CG))>,
+        Eigen::aligned_allocator<
+            Eigen::Matrix<Nextsim::FloatType, DG, GAUSSPOINTS(CG2DGSTRESS(CG))>>>
+        iMJwPSI_dam;
 
     ParametricMomentumMap(const ParametricMesh& sm)
         : smesh(sm)

--- a/dynamics/src/include/cgParametricMomentum.hpp
+++ b/dynamics/src/include/cgParametricMomentum.hpp
@@ -1,6 +1,6 @@
 /*!
  * @file cgParametricMomentum.hpp
- * @date 5 August 2022
+ * @date 04 Sep 2024
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/src/include/cgParametricMomentum.hpp
+++ b/dynamics/src/include/cgParametricMomentum.hpp
@@ -32,7 +32,7 @@ private:
 
 public:
     //! CGParametricMomentum should not be used but removed. ParametricMomentumMap needs DGadvection
-    // but this is not provided here.
+    //! but this is not provided here.
     ParametricMomentumMap<CG, 1> pmap;
 
     //! vectors storing the velocity (node-wise)

--- a/dynamics/src/include/cgParametricMomentum.hpp
+++ b/dynamics/src/include/cgParametricMomentum.hpp
@@ -20,7 +20,7 @@
 
 namespace Nextsim {
 
-template <int CG> class CGParametricMomentum {
+  template <int CG> class CGParametricMomentum {
 private:
     const ParametricMesh& smesh; //!< const-reference to the mesh
 
@@ -31,7 +31,8 @@ private:
     static constexpr int precompute_matrices = 1;
 
 public:
-    ParametricMomentumMap<CG> pmap;
+    //! CGParametricMomentum should not be used but removed. ParametricMomentumMap needs DGadvection but this is not provided here.     
+    ParametricMomentumMap<CG,1> pmap;
 
     //! vectors storing the velocity (node-wise)
     CGVector<CG> vx, vy;
@@ -62,6 +63,8 @@ public:
         : smesh(sm)
         , pmap(sm)
     {
+      std::cerr << "CGParametricMomentum can't be used any more. It is replaced by the different Kernels. Reason is that the ParamwetricMomentumMap requires the DGadvection degree as template but this is not provided. It could be easily changed, but instead one should use the Kernel-infrastructure." << std::endl;
+      
         if (!(smesh.nelements > 0)) {
             std::cerr << "CGParametricMomentum: The mesh has to be initialized first!" << std::endl;
             abort();

--- a/dynamics/src/include/cgParametricMomentum.hpp
+++ b/dynamics/src/include/cgParametricMomentum.hpp
@@ -20,7 +20,7 @@
 
 namespace Nextsim {
 
-  template <int CG> class CGParametricMomentum {
+template <int CG> class CGParametricMomentum {
 private:
     const ParametricMesh& smesh; //!< const-reference to the mesh
 
@@ -31,8 +31,9 @@ private:
     static constexpr int precompute_matrices = 1;
 
 public:
-    //! CGParametricMomentum should not be used but removed. ParametricMomentumMap needs DGadvection but this is not provided here.     
-    ParametricMomentumMap<CG,1> pmap;
+    //! CGParametricMomentum should not be used but removed. ParametricMomentumMap needs DGadvection
+    // but this is not provided here.
+    ParametricMomentumMap<CG, 1> pmap;
 
     //! vectors storing the velocity (node-wise)
     CGVector<CG> vx, vy;
@@ -63,8 +64,12 @@ public:
         : smesh(sm)
         , pmap(sm)
     {
-      std::cerr << "CGParametricMomentum can't be used any more. It is replaced by the different Kernels. Reason is that the ParamwetricMomentumMap requires the DGadvection degree as template but this is not provided. It could be easily changed, but instead one should use the Kernel-infrastructure." << std::endl;
-      
+        std::cerr << "CGParametricMomentum can't be used any more. It is replaced by the different "
+                     "Kernels. Reason is that the ParamwetricMomentumMap requires the DGadvection "
+                     "degree as template but this is not provided. It could be easily changed, but "
+                     "instead one should use the Kernel-infrastructure."
+                  << std::endl;
+
         if (!(smesh.nelements > 0)) {
             std::cerr << "CGParametricMomentum: The mesh has to be initialized first!" << std::endl;
             abort();

--- a/dynamics/src/include/cgParametricMomentum.hpp
+++ b/dynamics/src/include/cgParametricMomentum.hpp
@@ -1,6 +1,6 @@
 /*!
  * @file cgParametricMomentum.hpp
- * @date 04 Sep 2024
+ * @date 5 August 2022
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/src/include/mevp.hpp
+++ b/dynamics/src/include/mevp.hpp
@@ -1,6 +1,6 @@
 /*!
  * @file mevp.hpp
- * @date 04 Sep 2024
+ * @date 24 Sep 2024
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/src/include/mevp.hpp
+++ b/dynamics/src/include/mevp.hpp
@@ -1,6 +1,6 @@
 /*!
  * @file mevp.hpp
- * @date 1 Mar 2022
+ * @date 04 Sep 2024
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 

--- a/dynamics/src/include/mevp.hpp
+++ b/dynamics/src/include/mevp.hpp
@@ -24,7 +24,7 @@ namespace mEVP {
 
     template <int CG, int DGstress, int DGadvection>
     void StressUpdateHighOrder(const VPParameters& vpparameters,
-        const ParametricMomentumMap<CG>& pmap, const ParametricMesh& smesh, DGVector<DGstress>& S11,
+			       const ParametricMomentumMap<CG, DGadvection>& pmap, const ParametricMesh& smesh, DGVector<DGstress>& S11,
         DGVector<DGstress>& S12, DGVector<DGstress>& S22, const DGVector<DGstress>& E11,
         const DGVector<DGstress>& E12, const DGVector<DGstress>& E22,
         const DGVector<DGadvection>& H, const DGVector<DGadvection>& A, const double alpha,

--- a/dynamics/src/include/mevp.hpp
+++ b/dynamics/src/include/mevp.hpp
@@ -24,9 +24,9 @@ namespace mEVP {
 
     template <int CG, int DGstress, int DGadvection>
     void StressUpdateHighOrder(const VPParameters& vpparameters,
-			       const ParametricMomentumMap<CG, DGadvection>& pmap, const ParametricMesh& smesh, DGVector<DGstress>& S11,
-        DGVector<DGstress>& S12, DGVector<DGstress>& S22, const DGVector<DGstress>& E11,
-        const DGVector<DGstress>& E12, const DGVector<DGstress>& E22,
+        const ParametricMomentumMap<CG, DGadvection>& pmap, const ParametricMesh& smesh,
+        DGVector<DGstress>& S11, DGVector<DGstress>& S12, DGVector<DGstress>& S22,
+        const DGVector<DGstress>& E11, const DGVector<DGstress>& E12, const DGVector<DGstress>& E22,
         const DGVector<DGadvection>& H, const DGVector<DGadvection>& A, const double alpha,
         const double beta)
     {
@@ -39,20 +39,20 @@ namespace mEVP {
             // Here, one should check if it is enough to use a 2-point Gauss rule.
             // We're dealing with dG2, 3-point Gauss should be required.
 
-            const LocalEdgeVector<NGP* NGP> h_gauss
+            const LocalEdgeVector<NGP * NGP> h_gauss
                 = (H.row(i) * PSI<DGadvection, NGP>).array().max(0.0).matrix();
-            const LocalEdgeVector<NGP* NGP> a_gauss
+            const LocalEdgeVector<NGP * NGP> a_gauss
                 = (A.row(i) * PSI<DGadvection, NGP>).array().max(0.0).min(1.0).matrix();
 
-            const LocalEdgeVector<NGP* NGP> e11_gauss = E11.row(i) * PSI<DGstress, NGP>;
-            const LocalEdgeVector<NGP* NGP> e12_gauss = E12.row(i) * PSI<DGstress, NGP>;
-            const LocalEdgeVector<NGP* NGP> e22_gauss = E22.row(i) * PSI<DGstress, NGP>;
+            const LocalEdgeVector<NGP * NGP> e11_gauss = E11.row(i) * PSI<DGstress, NGP>;
+            const LocalEdgeVector<NGP * NGP> e12_gauss = E12.row(i) * PSI<DGstress, NGP>;
+            const LocalEdgeVector<NGP * NGP> e22_gauss = E22.row(i) * PSI<DGstress, NGP>;
 
-            const LocalEdgeVector<NGP* NGP> DELTA = (SQR(vpparameters.DeltaMin)
+            const LocalEdgeVector<NGP * NGP> DELTA = (SQR(vpparameters.DeltaMin)
                 + 1.25 * (e11_gauss.array().square() + e22_gauss.array().square())
                 + 1.50 * e11_gauss.array() * e22_gauss.array() + e12_gauss.array().square())
-                                                        .sqrt()
-                                                        .matrix();
+                                                         .sqrt()
+                                                         .matrix();
             // double DELTA = sqrt(SQR(vpparameters.DeltaMin) + 1.25 * (SQR(E11(i, 0)) + SQR(E22(i,
             // 0)))
             //       + 1.50 * E11(i, 0) * E22(i, 0) + SQR(E12(i, 0)));
@@ -60,7 +60,7 @@ namespace mEVP {
 
             //   //! Ice strength
             //   double P = vpparameters.Pstar * H(i, 0) * exp(-20.0 * (1.0 - A(i, 0)));
-            const LocalEdgeVector<NGP* NGP> P
+            const LocalEdgeVector<NGP * NGP> P
                 = (vpparameters.Pstar * h_gauss.array() * (-20.0 * (1.0 - a_gauss.array())).exp())
                       .matrix();
 
@@ -145,20 +145,20 @@ namespace mEVP {
             // Here, one should check if it is enough to use a 2-point Gauss rule.
             // We're dealing with dG2, 3-point Gauss should be required.
 
-            const LocalEdgeVector<NGP* NGP> h_gauss
+            const LocalEdgeVector<NGP * NGP> h_gauss
                 = (H.row(i) * PSI<DGa, NGP>).array().max(0.0).matrix();
-            const LocalEdgeVector<NGP* NGP> a_gauss
+            const LocalEdgeVector<NGP * NGP> a_gauss
                 = (A.row(i) * PSI<DGa, NGP>).array().max(0.0).min(1.0).matrix();
 
-            const LocalEdgeVector<NGP* NGP> e11_gauss = E11.row(i) * PSI<DGs, NGP>;
-            const LocalEdgeVector<NGP* NGP> e12_gauss = E12.row(i) * PSI<DGs, NGP>;
-            const LocalEdgeVector<NGP* NGP> e22_gauss = E22.row(i) * PSI<DGs, NGP>;
+            const LocalEdgeVector<NGP * NGP> e11_gauss = E11.row(i) * PSI<DGs, NGP>;
+            const LocalEdgeVector<NGP * NGP> e12_gauss = E12.row(i) * PSI<DGs, NGP>;
+            const LocalEdgeVector<NGP * NGP> e22_gauss = E22.row(i) * PSI<DGs, NGP>;
 
-            const LocalEdgeVector<NGP* NGP> DELTA = (SQR(vpparameters.DeltaMin)
+            const LocalEdgeVector<NGP * NGP> DELTA = (SQR(vpparameters.DeltaMin)
                 + 1.25 * (e11_gauss.array().square() + e22_gauss.array().square())
                 + 1.50 * e11_gauss.array() * e22_gauss.array() + e12_gauss.array().square())
-                                                        .sqrt()
-                                                        .matrix();
+                                                         .sqrt()
+                                                         .matrix();
             // double DELTA = sqrt(SQR(vpparameters.DeltaMin) + 1.25 * (SQR(E11(i, 0)) + SQR(E22(i,
             // 0)))
             //       + 1.50 * E11(i, 0) * E22(i, 0) + SQR(E12(i, 0)));
@@ -166,7 +166,7 @@ namespace mEVP {
 
             //   //! Ice strength
             //   double P = vpparameters.Pstar * H(i, 0) * exp(-20.0 * (1.0 - A(i, 0)));
-            const LocalEdgeVector<NGP* NGP> P
+            const LocalEdgeVector<NGP * NGP> P
                 = (vpparameters.Pstar * h_gauss.array() * (-20.0 * (1.0 - a_gauss.array())).exp())
                       .matrix();
 
@@ -193,11 +193,11 @@ namespace mEVP {
             //       E22.row(i)));
             //   S11(i, 0) -= 1.0 / alpha * 0.5 * P;
 
-            const Eigen::Matrix<Nextsim::FloatType, 1, NGP* NGP> J
+            const Eigen::Matrix<Nextsim::FloatType, 1, NGP * NGP> J
                 = ParametricTools::J<NGP>(smesh, i);
             // get the inverse of the mass matrix scaled with the test-functions in the gauss
             // points, with the gauss weights and with J. This is a 8 x 9 matrix
-            const Eigen::Matrix<Nextsim::FloatType, DGs, NGP* NGP> imass_psi
+            const Eigen::Matrix<Nextsim::FloatType, DGs, NGP * NGP> imass_psi
                 = ParametricTools::massMatrix<DGs>(smesh, i).inverse()
                 * (PSI<DGs, NGP>.array().rowwise() * (GAUSSWEIGHTS<3>.array() * J.array()))
                       .matrix();

--- a/dynamics/src/include/mevp.hpp
+++ b/dynamics/src/include/mevp.hpp
@@ -39,20 +39,20 @@ namespace mEVP {
             // Here, one should check if it is enough to use a 2-point Gauss rule.
             // We're dealing with dG2, 3-point Gauss should be required.
 
-            const LocalEdgeVector<NGP * NGP> h_gauss
+            const LocalEdgeVector<NGP* NGP> h_gauss
                 = (H.row(i) * PSI<DGadvection, NGP>).array().max(0.0).matrix();
-            const LocalEdgeVector<NGP * NGP> a_gauss
+            const LocalEdgeVector<NGP* NGP> a_gauss
                 = (A.row(i) * PSI<DGadvection, NGP>).array().max(0.0).min(1.0).matrix();
 
-            const LocalEdgeVector<NGP * NGP> e11_gauss = E11.row(i) * PSI<DGstress, NGP>;
-            const LocalEdgeVector<NGP * NGP> e12_gauss = E12.row(i) * PSI<DGstress, NGP>;
-            const LocalEdgeVector<NGP * NGP> e22_gauss = E22.row(i) * PSI<DGstress, NGP>;
+            const LocalEdgeVector<NGP* NGP> e11_gauss = E11.row(i) * PSI<DGstress, NGP>;
+            const LocalEdgeVector<NGP* NGP> e12_gauss = E12.row(i) * PSI<DGstress, NGP>;
+            const LocalEdgeVector<NGP* NGP> e22_gauss = E22.row(i) * PSI<DGstress, NGP>;
 
-            const LocalEdgeVector<NGP * NGP> DELTA = (SQR(vpparameters.DeltaMin)
+            const LocalEdgeVector<NGP* NGP> DELTA = (SQR(vpparameters.DeltaMin)
                 + 1.25 * (e11_gauss.array().square() + e22_gauss.array().square())
                 + 1.50 * e11_gauss.array() * e22_gauss.array() + e12_gauss.array().square())
-                                                         .sqrt()
-                                                         .matrix();
+                                                        .sqrt()
+                                                        .matrix();
             // double DELTA = sqrt(SQR(vpparameters.DeltaMin) + 1.25 * (SQR(E11(i, 0)) + SQR(E22(i,
             // 0)))
             //       + 1.50 * E11(i, 0) * E22(i, 0) + SQR(E12(i, 0)));
@@ -60,7 +60,7 @@ namespace mEVP {
 
             //   //! Ice strength
             //   double P = vpparameters.Pstar * H(i, 0) * exp(-20.0 * (1.0 - A(i, 0)));
-            const LocalEdgeVector<NGP * NGP> P
+            const LocalEdgeVector<NGP* NGP> P
                 = (vpparameters.Pstar * h_gauss.array() * (-20.0 * (1.0 - a_gauss.array())).exp())
                       .matrix();
 
@@ -145,20 +145,20 @@ namespace mEVP {
             // Here, one should check if it is enough to use a 2-point Gauss rule.
             // We're dealing with dG2, 3-point Gauss should be required.
 
-            const LocalEdgeVector<NGP * NGP> h_gauss
+            const LocalEdgeVector<NGP* NGP> h_gauss
                 = (H.row(i) * PSI<DGa, NGP>).array().max(0.0).matrix();
-            const LocalEdgeVector<NGP * NGP> a_gauss
+            const LocalEdgeVector<NGP* NGP> a_gauss
                 = (A.row(i) * PSI<DGa, NGP>).array().max(0.0).min(1.0).matrix();
 
-            const LocalEdgeVector<NGP * NGP> e11_gauss = E11.row(i) * PSI<DGs, NGP>;
-            const LocalEdgeVector<NGP * NGP> e12_gauss = E12.row(i) * PSI<DGs, NGP>;
-            const LocalEdgeVector<NGP * NGP> e22_gauss = E22.row(i) * PSI<DGs, NGP>;
+            const LocalEdgeVector<NGP* NGP> e11_gauss = E11.row(i) * PSI<DGs, NGP>;
+            const LocalEdgeVector<NGP* NGP> e12_gauss = E12.row(i) * PSI<DGs, NGP>;
+            const LocalEdgeVector<NGP* NGP> e22_gauss = E22.row(i) * PSI<DGs, NGP>;
 
-            const LocalEdgeVector<NGP * NGP> DELTA = (SQR(vpparameters.DeltaMin)
+            const LocalEdgeVector<NGP* NGP> DELTA = (SQR(vpparameters.DeltaMin)
                 + 1.25 * (e11_gauss.array().square() + e22_gauss.array().square())
                 + 1.50 * e11_gauss.array() * e22_gauss.array() + e12_gauss.array().square())
-                                                         .sqrt()
-                                                         .matrix();
+                                                        .sqrt()
+                                                        .matrix();
             // double DELTA = sqrt(SQR(vpparameters.DeltaMin) + 1.25 * (SQR(E11(i, 0)) + SQR(E22(i,
             // 0)))
             //       + 1.50 * E11(i, 0) * E22(i, 0) + SQR(E12(i, 0)));
@@ -166,7 +166,7 @@ namespace mEVP {
 
             //   //! Ice strength
             //   double P = vpparameters.Pstar * H(i, 0) * exp(-20.0 * (1.0 - A(i, 0)));
-            const LocalEdgeVector<NGP * NGP> P
+            const LocalEdgeVector<NGP* NGP> P
                 = (vpparameters.Pstar * h_gauss.array() * (-20.0 * (1.0 - a_gauss.array())).exp())
                       .matrix();
 
@@ -193,11 +193,11 @@ namespace mEVP {
             //       E22.row(i)));
             //   S11(i, 0) -= 1.0 / alpha * 0.5 * P;
 
-            const Eigen::Matrix<Nextsim::FloatType, 1, NGP * NGP> J
+            const Eigen::Matrix<Nextsim::FloatType, 1, NGP* NGP> J
                 = ParametricTools::J<NGP>(smesh, i);
             // get the inverse of the mass matrix scaled with the test-functions in the gauss
             // points, with the gauss weights and with J. This is a 8 x 9 matrix
-            const Eigen::Matrix<Nextsim::FloatType, DGs, NGP * NGP> imass_psi
+            const Eigen::Matrix<Nextsim::FloatType, DGs, NGP* NGP> imass_psi
                 = ParametricTools::massMatrix<DGs>(smesh, i).inverse()
                 * (PSI<DGs, NGP>.array().rowwise() * (GAUSSWEIGHTS<3>.array() * J.array()))
                       .matrix();


### PR DESCRIPTION
# Improve execution speed of BBM stress update

Fixes #539 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

Replaced on-the-fly computing of quadrature in BBMStressUpdate by precomputed values from ParametricMomentumMap.

Required changes:

- added the vector iJMwPSI_dam[...] to ParametricMomentumMap. This is (inverse Mass(x_q))^{-1} * J(x_q) * w(q) * PSI[i] (xq) where x_q is the quadrature point and i is the basis function. iJMwPSI is the same in the DGstress-space, and _dam is in the DGadvection space.

This requires adding DGadvection as a template parameter, and hence, several classes with an interface to ParametricMomentumMap had to be touched. We broke compatibility with the old cgParametricMomentum.cpp class. But I think this should be removed anyway as it is replaced by the Kernels.

---
# Test Description

A one-day BBM computation (config_benchmark.cfg with BBM and shortened to 1 day) gives (on 4 threads)

before:
../build/nextsim --config-file config_benchmark-bbm-short.cfg  145,99s user 11,47s system 276% cpu 57,046 total

now:
../build/nextsim --config-file config_benchmark-bbm-short.cfg  56,99s user 9,79s system 195% cpu 34,141 total

34 instead of 57 seconds. 

---
# Documentation Impact

N/A

---
# Other Details

The poor parallelization (below 200% CPU util.) is likely due to some inefficiency in passing data. (too many pointers?). @winzerle will investigate.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README