### PR TITLE
Finalizer class

### DIFF
--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(BaseSources
     "RectGridIO.cpp"
     "ParaGridIO.cpp"
     "FileCallbackCloser.cpp"
+    "Finalizer.cpp"
     "DevStep.cpp"
     "StructureFactory.cpp"
     "MissingData.cpp"

--- a/core/src/Finalizer.cpp
+++ b/core/src/Finalizer.cpp
@@ -1,0 +1,54 @@
+/*!
+ * @file Finalizer.cpp
+ *
+ * @date Sep 11, 2024
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#include "include/Finalizer.hpp"
+
+namespace Nextsim {
+
+void Finalizer::registerFunc(const FinalFn& fn)
+    {
+        auto& fns = functions();
+        fns.push_back(fn);
+    }
+
+bool Finalizer::registerUnique(const FinalFn& fn)
+    {
+        if (contains(fn))
+            return false;
+        registerFunc(fn);
+        return true;
+    }
+
+bool Finalizer::contains(const FinalFn& fn)
+    {
+        auto& fns = functions();
+        for (const auto& stored : fns) {
+            if (stored == fn)
+                return true;
+        }
+        return false;
+    }
+
+void Finalizer::finalize()
+    {
+        while (!functions().empty()) {
+            auto fn = functions().back();
+            // Remove the function from the finalization list before executing it.
+            functions().pop_back();
+            fn();
+        }
+    }
+
+size_t Finalizer::count() { return functions().size(); }
+
+Finalizer::FinalFnContainer& Finalizer::functions()
+    {
+        static FinalFnContainer set;
+        return set;
+    }
+
+}

--- a/core/src/Finalizer.cpp
+++ b/core/src/Finalizer.cpp
@@ -10,45 +10,45 @@
 namespace Nextsim {
 
 void Finalizer::registerFunc(const FinalFn& fn)
-    {
-        auto& fns = functions();
-        fns.push_back(fn);
-    }
+{
+    auto& fns = functions();
+    fns.push_back(fn);
+}
 
 bool Finalizer::registerUnique(const FinalFn& fn)
-    {
-        if (contains(fn))
-            return false;
-        registerFunc(fn);
-        return true;
-    }
+{
+    if (contains(fn))
+        return false;
+    registerFunc(fn);
+    return true;
+}
 
 bool Finalizer::contains(const FinalFn& fn)
-    {
-        auto& fns = functions();
-        for (const auto& stored : fns) {
-            if (stored == fn)
-                return true;
-        }
-        return false;
+{
+    auto& fns = functions();
+    for (const auto& stored : fns) {
+        if (stored == fn)
+            return true;
     }
+    return false;
+}
 
 void Finalizer::finalize()
-    {
-        while (!functions().empty()) {
-            auto fn = functions().back();
-            // Remove the function from the finalization list before executing it.
-            functions().pop_back();
-            fn();
-        }
+{
+    while (!functions().empty()) {
+        auto fn = functions().back();
+        // Remove the function from the finalization list before executing it.
+        functions().pop_back();
+        fn();
     }
+}
 
 size_t Finalizer::count() { return functions().size(); }
 
 Finalizer::FinalFnContainer& Finalizer::functions()
-    {
-        static FinalFnContainer set;
-        return set;
-    }
+{
+    static FinalFnContainer set;
+    return set;
+}
 
 }

--- a/core/src/Finalizer.cpp
+++ b/core/src/Finalizer.cpp
@@ -27,8 +27,8 @@ bool Finalizer::contains(const FinalFn& fn)
 {
     auto& fns = functions();
     for (const auto& stored : fns) {
-        // Compare function pointer addresses
-        if (stored.target<FnType*>() == fn.target<FnType*>())
+        // Compare function addresses
+        if (*stored.target<FnType*>() == *fn.target<FnType*>())
             return true;
     }
     return false;
@@ -37,8 +37,14 @@ bool Finalizer::contains(const FinalFn& fn)
 void Finalizer::finalize()
 {
     while (!functions().empty()) {
-        // Execute the last function in the list
-        functions().back()();
+        try {
+            // Execute the last function in the list
+            functions().back()();
+        } catch (const std::exception& e) {
+            // Remove the function from the finalization list even if an exception was thrown.
+            functions().pop_back();
+            throw;
+        }
         // Remove the function from the finalization list.
         functions().pop_back();
     }

--- a/core/src/Finalizer.cpp
+++ b/core/src/Finalizer.cpp
@@ -27,7 +27,8 @@ bool Finalizer::contains(const FinalFn& fn)
 {
     auto& fns = functions();
     for (const auto& stored : fns) {
-        if (stored.target<void()>() == fn.target<void()>())
+        // Compare function pointer addresses
+        if (stored.target<FnType*>() == fn.target<FnType*>())
             return true;
     }
     return false;

--- a/core/src/Finalizer.cpp
+++ b/core/src/Finalizer.cpp
@@ -27,7 +27,7 @@ bool Finalizer::contains(const FinalFn& fn)
 {
     auto& fns = functions();
     for (const auto& stored : fns) {
-        if (stored == fn)
+        if (stored.target<void()>() == fn.target<void()>())
             return true;
     }
     return false;
@@ -36,10 +36,10 @@ bool Finalizer::contains(const FinalFn& fn)
 void Finalizer::finalize()
 {
     while (!functions().empty()) {
-        auto fn = functions().back();
-        // Remove the function from the finalization list before executing it.
+        // Execute the last function in the list
+        functions().back()();
+        // Remove the function from the finalization list.
         functions().pop_back();
-        fn();
     }
 }
 

--- a/core/src/include/Finalizer.hpp
+++ b/core/src/include/Finalizer.hpp
@@ -25,11 +25,7 @@ public:
      * Adds a function to be called at finalization. Functions are ordered last-in, first out.
      * @param fn The function to be added. Must have void() signature.
      */
-    inline static void registerFunc(const FinalFn& fn)
-    {
-        auto& fns = functions();
-        fns.push_back(fn);
-    }
+    static void registerFunc(const FinalFn& fn);
 
     /*!
      * @brief Adds a function to be called at finalization unless it will already be called at
@@ -41,13 +37,7 @@ public:
      * @param fn The function to be added. Must have void() signature.
      * @return true if the function was added, false if it already existed and was not added.
      */
-    inline static bool registerUnique(const FinalFn& fn)
-    {
-        if (contains(fn))
-            return false;
-        registerFunc(fn);
-        return true;
-    }
+    static bool registerUnique(const FinalFn& fn);
 
     /*!
      * @brief Returns whether a function will already be called at finalization.
@@ -60,15 +50,7 @@ public:
      * is not.
      *
      */
-    inline static bool contains(const FinalFn& fn)
-    {
-        auto& fns = functions();
-        for (const auto& stored : fns) {
-            if (stored == fn)
-                return true;
-        }
-        return false;
-    }
+    static bool contains(const FinalFn& fn);
 
     /*!
      * @brief Runs the finalize functions and erases them.
@@ -79,34 +61,20 @@ public:
      * be no finalization functions remaining. Otherwise, re-running finalize will begin execution
      * with the function assigned previous to the one that threw the exception.
      */
-    inline static void finalize()
-    {
-        while (!functions().empty()) {
-            auto fn = functions().back();
-            // Remove the function from the finalization list before executing it.
-            functions().pop_back();
-            fn();
-        }
-    }
+    static void finalize();
 
     /*!
      * Returns the number of finalize functions that will be run.
      * @return the number of finalize functions that will be run.
      */
-    inline static size_t count() { return functions().size(); }
-
-    /*!
-     * Eliminates all functions to be run at finalization.
-     */
-//    inline static void clear() { functions().clear(); }
+    static size_t count();
 
 private:
     typedef std::list<FinalFn> FinalFnContainer;
-    inline static FinalFnContainer& functions()
-    {
-        static FinalFnContainer set;
-        return set;
-    }
+    /*!
+     * Returns a reference to a static container of the finalizer functions.
+     */
+    static FinalFnContainer& functions();
 };
 
 } /* namespace Nextsim */

--- a/core/src/include/Finalizer.hpp
+++ b/core/src/include/Finalizer.hpp
@@ -1,0 +1,112 @@
+/*!
+ * @file ModelFinalizer.hpp
+ *
+ * @date Sep 3, 2024
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef FINALIZER_HPP
+#define FINALIZER_HPP
+
+#include <functional>
+#include <list>
+#include <set>
+#include <vector>
+
+#include <iostream> // FIXME remove me
+
+namespace Nextsim {
+
+class Finalizer {
+public:
+    typedef std::function<void()> FinalFn;
+
+    /*!
+     * Adds a function to be called at finalization. Functions are ordered last-in, first out.
+     * @param fn The function to be added. Must have void() signature.
+     */
+    inline static void atfinal(const FinalFn& fn)
+    {
+        auto& fnSet = functions();
+        fnSet.push_front(fn);
+    }
+
+    /*!
+     * @brief Adds a function to be called at finalization unless it will already be called at
+     * finalization.
+     *
+     * @details Adds a function in the same way as atfinal(), unless the function already exists in
+     * the list of functions to be called at finalization. Identity of functions is equality of the
+     * values of their target<void()>() member functions. Functions are ordered last-in, first out.
+     * @param fn The function to be added. Must have void() signature.
+     * @return true if the function was added, false if it already existed and was not added.
+     */
+    inline static bool atfinalUnique(const FinalFn& fn)
+    {
+        if (contains(fn)) return false;
+        atfinal(fn);
+        return true;
+    }
+
+    /*!
+     * @brief Returns whether a function will already be called at finalization.
+     *
+     * @details If the supplied function will already be called at finalization, return true, else
+     * return false. Identity of functions is equality of the values of their target<void()>()
+     * member functions.
+     * @param fn The function to be queried. Must have void() signature.
+     * @return true is the function is contained in those to be called at finalization, false if it
+     * is not.
+     *
+     */
+    inline static bool contains(const FinalFn& fn)
+    {
+        auto& fnSet = functions();
+        for (const auto& stored : fnSet) {
+            if (stored.target<void()>() == fn.target<void()>()) return true;
+        }
+        return false;
+    }
+
+    /*!
+     * @brief Runs the finalize functions without erasing all the functions.
+     */
+    inline static void run()
+    {
+        auto& fns = functions();
+        for (auto& fn : fns) {
+            fn();
+        }
+    }
+
+    /*!
+     * Runs the finalize functions and erases them.
+     */
+    inline static void finalize()
+    {
+        run();
+        clear();
+    }
+
+    /*!
+     * Returns the number of finalize functions that will be run.
+     * @return the number of finalize functions that will be run.
+     */
+    inline static size_t count() { return functions().size(); }
+
+    /*!
+     * Eliminates all functions to be run at finalization.
+     */
+    inline static void clear() { functions().clear(); }
+private:
+    typedef std::list<FinalFn> FinalFnContainer;
+    inline static FinalFnContainer& functions()
+    {
+        static FinalFnContainer set;
+        return set;
+    }
+};
+
+} /* namespace Nextsim */
+
+#endif /* FINALIZER_HPP */

--- a/core/src/include/Finalizer.hpp
+++ b/core/src/include/Finalizer.hpp
@@ -17,8 +17,7 @@ namespace Nextsim {
 
 class Finalizer {
 public:
-    using FinalFn = void (*)();
-
+    using FinalFn = std::function<void()>;
     /*!
      * Adds a function to be called at finalization. Functions are ordered last-in, first out.
      * @param fn The function to be added. Must have void() signature.

--- a/core/src/include/Finalizer.hpp
+++ b/core/src/include/Finalizer.hpp
@@ -17,7 +17,8 @@ namespace Nextsim {
 
 class Finalizer {
 public:
-    using FinalFn = std::function<void()>;
+    using FnType = void();
+    using FinalFn = std::function<FnType>;
     /*!
      * Adds a function to be called at finalization. Functions are ordered last-in, first out.
      * @param fn The function to be added. Must have void() signature.

--- a/core/src/include/Finalizer.hpp
+++ b/core/src/include/Finalizer.hpp
@@ -19,13 +19,13 @@ namespace Nextsim {
 
 class Finalizer {
 public:
-    typedef std::function<void()> FinalFn;
+    using FinalFn = std::function<void()>;
 
     /*!
      * Adds a function to be called at finalization. Functions are ordered last-in, first out.
      * @param fn The function to be added. Must have void() signature.
      */
-    inline static void atfinal(const FinalFn& fn)
+    inline static void registerFunc(const FinalFn& fn)
     {
         auto& fns = functions();
         fns.push_back(fn);
@@ -41,11 +41,11 @@ public:
      * @param fn The function to be added. Must have void() signature.
      * @return true if the function was added, false if it already existed and was not added.
      */
-    inline static bool atfinalUnique(const FinalFn& fn)
+    inline static bool registerUnique(const FinalFn& fn)
     {
         if (contains(fn))
             return false;
-        atfinal(fn);
+        registerFunc(fn);
         return true;
     }
 
@@ -68,17 +68,6 @@ public:
                 return true;
         }
         return false;
-    }
-
-    /*!
-     * @brief Runs the finalize functions without erasing all the functions.
-     */
-    inline static void run()
-    {
-        auto& fns = functions();
-        for (auto& fn : fns) {
-            fn();
-        }
     }
 
     /*!
@@ -109,7 +98,7 @@ public:
     /*!
      * Eliminates all functions to be run at finalization.
      */
-    inline static void clear() { functions().clear(); }
+//    inline static void clear() { functions().clear(); }
 
 private:
     typedef std::list<FinalFn> FinalFnContainer;

--- a/core/src/include/Finalizer.hpp
+++ b/core/src/include/Finalizer.hpp
@@ -43,7 +43,8 @@ public:
      */
     inline static bool atfinalUnique(const FinalFn& fn)
     {
-        if (contains(fn)) return false;
+        if (contains(fn))
+            return false;
         atfinal(fn);
         return true;
     }
@@ -63,7 +64,8 @@ public:
     {
         auto& fns = functions();
         for (const auto& stored : fns) {
-            if (stored.target<void()>() == fn.target<void()>()) return true;
+            if (stored.target<void()>() == fn.target<void()>())
+                return true;
         }
         return false;
     }
@@ -108,6 +110,7 @@ public:
      * Eliminates all functions to be run at finalization.
      */
     inline static void clear() { functions().clear(); }
+
 private:
     typedef std::list<FinalFn> FinalFnContainer;
     inline static FinalFnContainer& functions()

--- a/core/src/include/Finalizer.hpp
+++ b/core/src/include/Finalizer.hpp
@@ -13,13 +13,11 @@
 #include <set>
 #include <vector>
 
-#include <iostream> // FIXME remove me
-
 namespace Nextsim {
 
 class Finalizer {
 public:
-    using FinalFn = void(*)();
+    using FinalFn = void (*)();
 
     /*!
      * Adds a function to be called at finalization. Functions are ordered last-in, first out.

--- a/core/src/include/Finalizer.hpp
+++ b/core/src/include/Finalizer.hpp
@@ -19,7 +19,7 @@ namespace Nextsim {
 
 class Finalizer {
 public:
-    using FinalFn = std::function<void()>;
+    using FinalFn = void(*)();
 
     /*!
      * Adds a function to be called at finalization. Functions are ordered last-in, first out.
@@ -64,7 +64,7 @@ public:
     {
         auto& fns = functions();
         for (const auto& stored : fns) {
-            if (stored.target<void()>() == fn.target<void()>())
+            if (stored == fn)
                 return true;
         }
         return false;

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -252,6 +252,7 @@ else()
     add_executable(
         testFinalizer
         "Finalizer_test.cpp"
+        "../../core/src/Finalizer.cpp"
     )
     target_link_libraries(testFinalizer PRIVATE doctest::doctest)
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -249,6 +249,12 @@ else()
     )
     target_link_libraries(testFileCallbackCloser PRIVATE doctest::doctest)
 
+    add_executable(
+        testFinalizer
+        "Finalizer_test.cpp"
+    )
+    target_link_libraries(testFinalizer PRIVATE doctest::doctest)
+
     set(MODEL_INCLUDE_DIR "./testmodelarraydetails")
 
     add_executable(

--- a/core/test/Finalizer_test.cpp
+++ b/core/test/Finalizer_test.cpp
@@ -60,8 +60,8 @@ TEST_CASE("Duplicate functions")
     REQUIRE(TheCount::count() == 0);
 //    Finalizer::clear();
     REQUIRE(Finalizer::count() == 0);
-    Finalizer::registerFunc(TheCount::increment);
-    Finalizer::registerFunc(TheCount::increment);
+    Finalizer::registerFunc(Earl::incr);
+    Finalizer::registerFunc(Earl::incr);
     REQUIRE(Finalizer::count() == 2);
     Finalizer::finalize();
     REQUIRE(TheCount::count() == 2);
@@ -73,9 +73,9 @@ TEST_CASE("Unique functions")
     REQUIRE(TheCount::count() == 0);
 //    Finalizer::clear();
     REQUIRE(Finalizer::count() == 0);
-    Finalizer::registerUnique(TheCount::increment);
-    REQUIRE(Finalizer::contains(TheCount::increment));
-    Finalizer::registerUnique(TheCount::increment);
+    Finalizer::registerUnique(Earl::incr);
+    REQUIRE(Finalizer::contains(Earl::incr));
+    Finalizer::registerUnique(Earl::incr);
     REQUIRE(Finalizer::count() == 1);
     Finalizer::finalize();
     REQUIRE(TheCount::count() == 1);
@@ -87,8 +87,8 @@ TEST_CASE("Finalize")
     REQUIRE(TheCount::count() == 0);
 //    Finalizer::clear();
     REQUIRE(Finalizer::count() == 0);
-    Finalizer::registerFunc(TheCount::increment);
-    Finalizer::registerFunc(TheCount::increment);
+    Finalizer::registerFunc(Earl::incr);
+    Finalizer::registerFunc(Earl::incr);
     REQUIRE(Finalizer::count() == 2);
     Finalizer::finalize();
     REQUIRE(Finalizer::count() == 0);
@@ -105,9 +105,9 @@ TEST_CASE("Exception")
     REQUIRE(TheCount::count() == 0);
 //    Finalizer::clear();
     REQUIRE(Finalizer::count() == 0);
-    Finalizer::registerFunc(TheCount::increment);
+    Finalizer::registerFunc(Earl::incr);
     Finalizer::registerFunc(throwHappy);
-    Finalizer::registerFunc(TheCount::increment);
+    Finalizer::registerFunc(Earl::incr);
     REQUIRE(Finalizer::count() == 3);
     REQUIRE_THROWS_AS(Finalizer::finalize(), HappyTime);
     // Only one increment occurred because of the exception

--- a/core/test/Finalizer_test.cpp
+++ b/core/test/Finalizer_test.cpp
@@ -81,6 +81,43 @@ TEST_CASE("Unique functions")
     REQUIRE(TheCount::count() == 1);
 }
 
+template <typename T>
+class Module {
+public:
+  static void finalize()
+  {
+    std::cout << "Finalizing " << moduleName() << std::endl;
+  }
+
+  static std::string moduleName();
+};
+
+template <typename T>
+void finalize() { Module<T>::finalize(); }
+
+class Class1;
+class Class2;
+
+template<>
+std::string Module<Class1>::moduleName() { return "Class1"; }
+
+template<>
+std::string Module<Class2>::moduleName() { return "Class2"; }
+
+TEST_CASE("Function templates")
+{
+    // Different instantiations of the same function template should be different.
+    Finalizer::registerUnique(finalize<Class1>);
+    REQUIRE(Finalizer::count() == 1);
+    Finalizer::registerUnique(finalize<Class1>);
+    REQUIRE(Finalizer::count() == 1);
+    Finalizer::registerUnique(finalize<Class2>);
+    REQUIRE(Finalizer::count() == 2);
+    Finalizer::finalize();
+    REQUIRE(Finalizer::count() == 0);
+
+}
+
 TEST_CASE("Finalize")
 {
     TheCount::reset();

--- a/core/test/Finalizer_test.cpp
+++ b/core/test/Finalizer_test.cpp
@@ -1,0 +1,129 @@
+/*!
+ * @file ModelFinalizer_test.cpp
+ *
+ * @date Sep 3, 2024
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "include/Finalizer.hpp"
+
+namespace Nextsim {
+
+// A mock Model class. Does nothing except call copy the behaviour of the real
+// Model class in its destructor
+class Model
+{
+public:
+    Model() = default;
+    ~Model() { Finalizer::finalize(); }
+};
+
+class TheCount
+{
+public:
+    inline static size_t increment() { return get()++; }
+    inline static size_t preincrement() { return ++get(); }
+    inline static void incrementAndPrint() { std::cout << "TheCount=" << preincrement() << std::endl; }
+    inline static size_t value() { return get(); }
+    inline static size_t count() { return get(); }
+    inline static void reset() { get() = 0; }
+protected:
+    inline static size_t& get()
+    {
+        static size_t count;
+        return count;
+    }
+};
+
+// In the British aristocracy an Earl is equivalent to a count in the rest of Europe!
+class Earl
+{
+public:
+    inline static void incr() { TheCount::increment(); }
+};
+
+class HappyTime : public std::exception
+{
+public:
+    const char* what() const noexcept { return "Nothing is wrong :D"; }
+};
+
+void throwHappy() { throw HappyTime(); }
+
+TEST_SUITE_BEGIN("ModelFinalizer");
+TEST_CASE("Run final function")
+{
+    TheCount::reset();
+    REQUIRE(TheCount::count() == 0);
+    Finalizer::atfinal(TheCount::increment);
+    REQUIRE(Finalizer::count() == 1);
+    Finalizer::run();
+    REQUIRE(Finalizer::count() == 1);
+    REQUIRE(TheCount::count() == 1);
+}
+
+TEST_CASE("Duplicate functions")
+{
+    TheCount::reset();
+    REQUIRE(TheCount::count() == 0);
+    Finalizer::clear();
+    REQUIRE(Finalizer::count() == 0);
+    Finalizer::atfinal(TheCount::increment);
+    Finalizer::atfinal(TheCount::increment);
+    REQUIRE(Finalizer::count() == 2);
+    Finalizer::run();
+    REQUIRE(Finalizer::count() == 2);
+    REQUIRE(TheCount::count() == 2);
+}
+
+TEST_CASE("Unique functions")
+{
+    TheCount::reset();
+    REQUIRE(TheCount::count() == 0);
+    Finalizer::clear();
+    REQUIRE(Finalizer::count() == 0);
+    Finalizer::atfinalUnique(TheCount::increment);
+    REQUIRE(Finalizer::contains(TheCount::increment));
+    Finalizer::atfinalUnique(TheCount::increment);
+    REQUIRE(Finalizer::count() == 1);
+    Finalizer::run();
+    REQUIRE(Finalizer::count() == 1);
+    REQUIRE(TheCount::count() == 1);
+}
+
+TEST_CASE("Finalize")
+{
+    TheCount::reset();
+    REQUIRE(TheCount::count() == 0);
+    Finalizer::clear();
+    REQUIRE(Finalizer::count() == 0);
+    Finalizer::atfinal(TheCount::increment);
+    Finalizer::atfinal(TheCount::increment);
+    REQUIRE(Finalizer::count() == 2);
+    Finalizer::finalize();
+    REQUIRE(Finalizer::count() == 0);
+    REQUIRE(TheCount::count() == 2);
+    TheCount::reset();
+    Finalizer::finalize();
+    REQUIRE(Finalizer::count() == 0);
+    REQUIRE(TheCount::count() == 0);
+}
+
+TEST_CASE("Exception")
+{
+    TheCount::reset();
+    REQUIRE(TheCount::count() == 0);
+    Finalizer::clear();
+    REQUIRE(Finalizer::count() == 0);
+    Finalizer::atfinal(TheCount::increment);
+    Finalizer::atfinal(throwHappy);
+    Finalizer::atfinal(TheCount::increment);
+    REQUIRE(Finalizer::count() == 3);
+    REQUIRE_THROWS_AS(Finalizer::finalize(), HappyTime);
+    // Only one increment occurred because of the exception
+    REQUIRE(TheCount::count() == 1);
+}
+} /* namespace Nextsim */

--- a/core/test/Finalizer_test.cpp
+++ b/core/test/Finalizer_test.cpp
@@ -125,5 +125,8 @@ TEST_CASE("Exception")
     REQUIRE_THROWS_AS(Finalizer::finalize(), HappyTime);
     // Only one increment occurred because of the exception
     REQUIRE(TheCount::count() == 1);
+    // The executed increment and throwing function have been removed. Only one function (the
+    // second increment) should remain.
+    REQUIRE(Finalizer::count() == 1);
 }
 } /* namespace Nextsim */

--- a/core/test/Finalizer_test.cpp
+++ b/core/test/Finalizer_test.cpp
@@ -54,28 +54,16 @@ public:
 void throwHappy() { throw HappyTime(); }
 
 TEST_SUITE_BEGIN("ModelFinalizer");
-TEST_CASE("Run final function")
-{
-    TheCount::reset();
-    REQUIRE(TheCount::count() == 0);
-    Finalizer::atfinal(TheCount::increment);
-    REQUIRE(Finalizer::count() == 1);
-    Finalizer::run();
-    REQUIRE(Finalizer::count() == 1);
-    REQUIRE(TheCount::count() == 1);
-}
-
 TEST_CASE("Duplicate functions")
 {
     TheCount::reset();
     REQUIRE(TheCount::count() == 0);
-    Finalizer::clear();
+//    Finalizer::clear();
     REQUIRE(Finalizer::count() == 0);
-    Finalizer::atfinal(TheCount::increment);
-    Finalizer::atfinal(TheCount::increment);
+    Finalizer::registerFunc(TheCount::increment);
+    Finalizer::registerFunc(TheCount::increment);
     REQUIRE(Finalizer::count() == 2);
-    Finalizer::run();
-    REQUIRE(Finalizer::count() == 2);
+    Finalizer::finalize();
     REQUIRE(TheCount::count() == 2);
 }
 
@@ -83,14 +71,13 @@ TEST_CASE("Unique functions")
 {
     TheCount::reset();
     REQUIRE(TheCount::count() == 0);
-    Finalizer::clear();
+//    Finalizer::clear();
     REQUIRE(Finalizer::count() == 0);
-    Finalizer::atfinalUnique(TheCount::increment);
+    Finalizer::registerUnique(TheCount::increment);
     REQUIRE(Finalizer::contains(TheCount::increment));
-    Finalizer::atfinalUnique(TheCount::increment);
+    Finalizer::registerUnique(TheCount::increment);
     REQUIRE(Finalizer::count() == 1);
-    Finalizer::run();
-    REQUIRE(Finalizer::count() == 1);
+    Finalizer::finalize();
     REQUIRE(TheCount::count() == 1);
 }
 
@@ -98,10 +85,10 @@ TEST_CASE("Finalize")
 {
     TheCount::reset();
     REQUIRE(TheCount::count() == 0);
-    Finalizer::clear();
+//    Finalizer::clear();
     REQUIRE(Finalizer::count() == 0);
-    Finalizer::atfinal(TheCount::increment);
-    Finalizer::atfinal(TheCount::increment);
+    Finalizer::registerFunc(TheCount::increment);
+    Finalizer::registerFunc(TheCount::increment);
     REQUIRE(Finalizer::count() == 2);
     Finalizer::finalize();
     REQUIRE(Finalizer::count() == 0);
@@ -116,11 +103,11 @@ TEST_CASE("Exception")
 {
     TheCount::reset();
     REQUIRE(TheCount::count() == 0);
-    Finalizer::clear();
+//    Finalizer::clear();
     REQUIRE(Finalizer::count() == 0);
-    Finalizer::atfinal(TheCount::increment);
-    Finalizer::atfinal(throwHappy);
-    Finalizer::atfinal(TheCount::increment);
+    Finalizer::registerFunc(TheCount::increment);
+    Finalizer::registerFunc(throwHappy);
+    Finalizer::registerFunc(TheCount::increment);
     REQUIRE(Finalizer::count() == 3);
     REQUIRE_THROWS_AS(Finalizer::finalize(), HappyTime);
     // Only one increment occurred because of the exception


### PR DESCRIPTION
# Finalizer class

Fixes #683 

---
# Change Description

Adds a finalization class `Finalizer` which is designed to mimic `std::atexit()`, but with more flexibility. The class has a `static` function `finalize()`, which will execute all of the functions designated to be executed. As with `std::atexit()`, the functions must have a signature `void()`.

The class also allows the finalization functions to be cleared, to be queried by a `contains(fn)` function, counted and also run without clearing the functions.

---
# Test Description

A test is included in this PR.

---
# Documentation Impact

The class functions have Doxygen comments describing them.
