### PR TITLE
Issue 614: Remove the FileCallbackCloser static list.

### DIFF
--- a/core/src/FileCallbackCloser.cpp
+++ b/core/src/FileCallbackCloser.cpp
@@ -9,16 +9,14 @@
 
 namespace Nextsim {
 
-std::list<FileCallbackCloser::ClosingFn> FileCallbackCloser::closingFns;
-
-void FileCallbackCloser::onClose(FileCallbackCloser::ClosingFn fn) { closingFns.push_back(fn); }
+void FileCallbackCloser::onClose(FileCallbackCloser::ClosingFn fn) { closingFns().push_back(fn); }
 
 void FileCallbackCloser::close(const std::string& filename)
 {
-    for (auto& fn : closingFns) {
+    for (auto& fn : closingFns()) {
         fn(filename);
     }
 }
 
-void FileCallbackCloser::clearAllClose() { closingFns.clear(); }
+void FileCallbackCloser::clearAllClose() { closingFns().clear(); }
 } /* namespace Nextsim */

--- a/core/src/include/FileCallbackCloser.hpp
+++ b/core/src/include/FileCallbackCloser.hpp
@@ -41,7 +41,11 @@ public:
     static void clearAllClose();
 
 private:
-    static std::list<ClosingFn> closingFns;
+    static std::list<ClosingFn>& closingFns()
+    {
+        static std::list<ClosingFn> fns;
+        return fns;
+    }
 };
 } /* namespace Nextsim */
 


### PR DESCRIPTION
# Remove the `FileCallbackCloser` static list.

Fixes #614 (partially)

---
# Change Description

Replace with a singleton function providing a list.

---
# Test Description

The class unit test still passes.