### PR TITLE
Issue 614: Localize Configured keyMaps

### DIFF
--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -27,7 +27,7 @@ namespace Nextsim {
 const std::string Model::restartOptionName = "model.init_file";
 // Map of all configuration keys for the main model, including those not to be
 // written to the restart file.
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
 #include "include/ModelConfigMapElements.ipp"
     { Model::RESTARTFILE_KEY, Model::restartOptionName },
 #ifdef USE_MPI
@@ -80,11 +80,11 @@ void Model::configure()
     // Store the start/stop/step configuration directly in ModelConfig before
     // parsing these values to the numerical time values used by the model.
     ModelConfig::startTimeStr
-        = Configured::getConfiguration(localKeyMap.at(STARTTIME_KEY), std::string());
-    ModelConfig::stopTimeStr = Configured::getConfiguration(localKeyMap.at(STOPTIME_KEY), std::string());
+        = Configured::getConfiguration(keyMap.at(STARTTIME_KEY), std::string());
+    ModelConfig::stopTimeStr = Configured::getConfiguration(keyMap.at(STOPTIME_KEY), std::string());
     ModelConfig::durationStr
-        = Configured::getConfiguration(localKeyMap.at(RUNLENGTH_KEY), std::string());
-    ModelConfig::stepStr = Configured::getConfiguration(localKeyMap.at(TIMESTEP_KEY), std::string());
+        = Configured::getConfiguration(keyMap.at(RUNLENGTH_KEY), std::string());
+    ModelConfig::stepStr = Configured::getConfiguration(keyMap.at(TIMESTEP_KEY), std::string());
 
     // Set the time correspond to the current (initial) model state
     TimePoint timeNow = iterator.parseAndSet(ModelConfig::startTimeStr, ModelConfig::stopTimeStr,
@@ -93,11 +93,11 @@ void Model::configure()
 
     // Configure the missing data value
     MissingData::value
-        = Configured::getConfiguration(localKeyMap.at(MISSINGVALUE_KEY), MissingData::defaultValue);
+        = Configured::getConfiguration(keyMap.at(MISSINGVALUE_KEY), MissingData::defaultValue);
 
     // Parse the initial restart file name and the pattern for output restart files
-    initialFileName = Configured::getConfiguration(localKeyMap.at(RESTARTFILE_KEY), std::string());
-    finalFileName = Configured::getConfiguration(localKeyMap.at(RESTARTOUTFILE_KEY), finalFileName);
+    initialFileName = Configured::getConfiguration(keyMap.at(RESTARTFILE_KEY), std::string());
+    finalFileName = Configured::getConfiguration(keyMap.at(RESTARTOUTFILE_KEY), finalFileName);
 
     pData.configure();
 
@@ -106,7 +106,7 @@ void Model::configure()
 
 #ifdef USE_MPI
     std::string partitionFile
-        = Configured::getConfiguration(localKeyMap.at(PARTITIONFILE_KEY), std::string("partition.nc"));
+        = Configured::getConfiguration(keyMap.at(PARTITIONFILE_KEY), std::string("partition.nc"));
     m_etadata.getPartitionMetadata(partitionFile);
 #endif
 
@@ -118,7 +118,7 @@ void Model::configure()
 
     // The period with which to write restart files.
     std::string restartPeriodStr
-        = Configured::getConfiguration(localKeyMap.at(RESTARTPERIOD_KEY), std::string("0"));
+        = Configured::getConfiguration(keyMap.at(RESTARTPERIOD_KEY), std::string("0"));
     restartPeriod = Duration(restartPeriodStr);
 
     // Get the coordinates from the ModelState for persistence
@@ -139,27 +139,27 @@ ConfigMap Model::getConfig() const
 Model::HelpMap& Model::getHelpText(HelpMap& map, bool getAll)
 {
     map["Model"] = {
-        { localKeyMap.at(STARTTIME_KEY), ConfigType::STRING, {}, "", "",
+        { keyMap.at(STARTTIME_KEY), ConfigType::STRING, {}, "", "",
             "Model start time, formatted as an ISO8601 date. "
             "Non-calendretical runs can start from year 0 or 1. " },
-        { localKeyMap.at(STOPTIME_KEY), ConfigType::STRING, {}, "", "",
+        { keyMap.at(STOPTIME_KEY), ConfigType::STRING, {}, "", "",
             "Model stop time, formatted as an ISO8601 data. "
             " Will be overridden if a model run length is set. " },
-        { localKeyMap.at(RUNLENGTH_KEY), ConfigType::STRING, {}, "", "",
+        { keyMap.at(RUNLENGTH_KEY), ConfigType::STRING, {}, "", "",
             "Model run length, formatted as an ISO8601 duration (P prefix). "
             "Overrides the stop time if set. " },
-        { localKeyMap.at(TIMESTEP_KEY), ConfigType::STRING, {}, "", "",
+        { keyMap.at(TIMESTEP_KEY), ConfigType::STRING, {}, "", "",
             "Model physics timestep, formatted as an ISO8601 duration (P prefix). " },
-        { localKeyMap.at(RESTARTFILE_KEY), ConfigType::STRING, {}, "", "",
+        { keyMap.at(RESTARTFILE_KEY), ConfigType::STRING, {}, "", "",
             "The file path to the restart file to use for the run." },
-        { localKeyMap.at(RESTARTPERIOD_KEY), ConfigType::STRING, {}, "0", "",
+        { keyMap.at(RESTARTPERIOD_KEY), ConfigType::STRING, {}, "0", "",
             "The period between restart file outputs, formatted as an ISO8601 "
             "duration (P prefix) or number of seconds. A value of zero "
             "ensures no intermediate restart files are written." },
-        { localKeyMap.at(MISSINGVALUE_KEY), ConfigType::NUMERIC, { "-∞", "∞" }, "-2³⁰⁰", "",
+        { keyMap.at(MISSINGVALUE_KEY), ConfigType::NUMERIC, { "-∞", "∞" }, "-2³⁰⁰", "",
             "Missing data indicator used for input and output." },
 #ifdef USE_MPI
-        { localKeyMap.at(PARTITIONFILE_KEY), ConfigType::STRING, {}, "", "",
+        { keyMap.at(PARTITIONFILE_KEY), ConfigType::STRING, {}, "", "",
             "The file path to the file describing MPI domain decomposition to use for the run." },
 #endif
     };

--- a/core/src/ModelConfig.cpp
+++ b/core/src/ModelConfig.cpp
@@ -16,11 +16,7 @@ std::string ModelConfig::durationStr;
 std::string ModelConfig::stepStr;
 
 const std::map<int, std::string> ModelConfig::keyMap = {
-    { ModelConfig::STARTTIME_KEY, "model.start" },
-    { ModelConfig::STOPTIME_KEY, "model.stop" },
-    { ModelConfig::RUNLENGTH_KEY, "model.run_length" },
-    { ModelConfig::TIMESTEP_KEY, "model.time_step" },
-    { ModelConfig::MISSINGVALUE_KEY, "model.missing_value" },
+#include "include/ModelConfigMapElements.ipp"
 };
 
 ConfigMap ModelConfig::getConfig()

--- a/core/src/include/Configured.hpp
+++ b/core/src/include/Configured.hpp
@@ -135,9 +135,6 @@ public:
     //! Clear the configuration map. Usually used only in test suites.
     static void clearConfigurationMap() { singleOptions.clear(); }
 
-    //! A per-class static map to provide compile-time checking of configuration keys.
-    static const std::map<int, std::string> keyMap;
-
 protected:
     /*!
      * @brief Adds an option to the per-class option map.

--- a/core/src/include/ModelConfigMapElements.ipp
+++ b/core/src/include/ModelConfigMapElements.ipp
@@ -1,0 +1,5 @@
+    { ModelConfig::STARTTIME_KEY, "model.start" },
+    { ModelConfig::STOPTIME_KEY, "model.stop" },
+    { ModelConfig::RUNLENGTH_KEY, "model.run_length" },
+    { ModelConfig::TIMESTEP_KEY, "model.time_step" },
+    { ModelConfig::MISSINGVALUE_KEY, "model.missing_value" },

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -31,8 +31,7 @@ static const std::string filePeriodKey = pfx + ".file_period";
 // Access the model.start key. There's no clean way of getting this from Model, I think.
 static const std::string modelStartKey = "model.start";
 
-template <>
-const std::map<int, std::string> Configured<ConfigOutput>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { ConfigOutput::PERIOD_KEY, periodKey },
     { ConfigOutput::START_KEY, startKey },
     { ConfigOutput::FIELDNAMES_KEY, fieldNamesKey },
@@ -79,13 +78,13 @@ ConfigurationHelp::HelpMap& ConfigOutput::getHelpRecursive(HelpMap& map, bool ge
 }
 void ConfigOutput::configure()
 {
-    std::string periodString = Configured::getConfiguration(keyMap.at(PERIOD_KEY), std::string(""));
+    std::string periodString = Configured::getConfiguration(localKeyMap.at(PERIOD_KEY), std::string(""));
     if (periodString.empty()) {
         everyTS = true;
     } else {
         outputPeriod.parse(periodString);
     }
-    std::string startString = Configured::getConfiguration(keyMap.at(START_KEY), std::string(""));
+    std::string startString = Configured::getConfiguration(localKeyMap.at(START_KEY), std::string(""));
     if (startString.empty()) {
         startString = Configured::getConfiguration(modelStartKey, std::string(""));
         if (startString.empty())
@@ -99,7 +98,7 @@ void ConfigOutput::configure()
     }
 
     std::string outputFields
-        = Configured::getConfiguration(keyMap.at(FIELDNAMES_KEY), std::string(""));
+        = Configured::getConfiguration(localKeyMap.at(FIELDNAMES_KEY), std::string(""));
     if (outputFields == all || outputFields.empty()) { // Output *all* the fields?
         outputAllTheFields = true; // Output all the fields!
     } else {
@@ -128,7 +127,7 @@ void ConfigOutput::configure()
 
     // The default string is the number of seconds in 10000 years of 365 days
     std::string newFilePeriodStr
-        = Configured::getConfiguration(keyMap.at(FILEPERIOD_KEY), std::string("315360000000"));
+        = Configured::getConfiguration(localKeyMap.at(FILEPERIOD_KEY), std::string("315360000000"));
     fileChangePeriod = Duration(newFilePeriodStr);
     lastFileChange = lastOutput;
 }
@@ -218,9 +217,9 @@ ModelState ConfigOutput::getStateRecursive(const OutputSpec& os) const
 {
     return { {},
         {
-            { keyMap.at(PERIOD_KEY), outputPeriod.format() },
-            { keyMap.at(START_KEY), lastOutput.format() }, // FIXME Not necessarily the start date!
-            { keyMap.at(FIELDNAMES_KEY), concatenateFields(fieldsForOutput) },
+            { localKeyMap.at(PERIOD_KEY), outputPeriod.format() },
+            { localKeyMap.at(START_KEY), lastOutput.format() }, // FIXME Not necessarily the start date!
+            { localKeyMap.at(FIELDNAMES_KEY), concatenateFields(fieldsForOutput) },
         } };
 }
 

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -31,7 +31,7 @@ static const std::string filePeriodKey = pfx + ".file_period";
 // Access the model.start key. There's no clean way of getting this from Model, I think.
 static const std::string modelStartKey = "model.start";
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { ConfigOutput::PERIOD_KEY, periodKey },
     { ConfigOutput::START_KEY, startKey },
     { ConfigOutput::FIELDNAMES_KEY, fieldNamesKey },
@@ -78,13 +78,13 @@ ConfigurationHelp::HelpMap& ConfigOutput::getHelpRecursive(HelpMap& map, bool ge
 }
 void ConfigOutput::configure()
 {
-    std::string periodString = Configured::getConfiguration(localKeyMap.at(PERIOD_KEY), std::string(""));
+    std::string periodString = Configured::getConfiguration(keyMap.at(PERIOD_KEY), std::string(""));
     if (periodString.empty()) {
         everyTS = true;
     } else {
         outputPeriod.parse(periodString);
     }
-    std::string startString = Configured::getConfiguration(localKeyMap.at(START_KEY), std::string(""));
+    std::string startString = Configured::getConfiguration(keyMap.at(START_KEY), std::string(""));
     if (startString.empty()) {
         startString = Configured::getConfiguration(modelStartKey, std::string(""));
         if (startString.empty())
@@ -98,7 +98,7 @@ void ConfigOutput::configure()
     }
 
     std::string outputFields
-        = Configured::getConfiguration(localKeyMap.at(FIELDNAMES_KEY), std::string(""));
+        = Configured::getConfiguration(keyMap.at(FIELDNAMES_KEY), std::string(""));
     if (outputFields == all || outputFields.empty()) { // Output *all* the fields?
         outputAllTheFields = true; // Output all the fields!
     } else {
@@ -127,7 +127,7 @@ void ConfigOutput::configure()
 
     // The default string is the number of seconds in 10000 years of 365 days
     std::string newFilePeriodStr
-        = Configured::getConfiguration(localKeyMap.at(FILEPERIOD_KEY), std::string("315360000000"));
+        = Configured::getConfiguration(keyMap.at(FILEPERIOD_KEY), std::string("315360000000"));
     fileChangePeriod = Duration(newFilePeriodStr);
     lastFileChange = lastOutput;
 }
@@ -217,9 +217,9 @@ ModelState ConfigOutput::getStateRecursive(const OutputSpec& os) const
 {
     return { {},
         {
-            { localKeyMap.at(PERIOD_KEY), outputPeriod.format() },
-            { localKeyMap.at(START_KEY), lastOutput.format() }, // FIXME Not necessarily the start date!
-            { localKeyMap.at(FIELDNAMES_KEY), concatenateFields(fieldsForOutput) },
+            { keyMap.at(PERIOD_KEY), outputPeriod.format() },
+            { keyMap.at(START_KEY), lastOutput.format() }, // FIXME Not necessarily the start date!
+            { keyMap.at(FIELDNAMES_KEY), concatenateFields(fieldsForOutput) },
         } };
 }
 

--- a/core/test/Configurator_test.cpp
+++ b/core/test/Configurator_test.cpp
@@ -61,8 +61,7 @@ private:
     std::string name;
 };
 
-template<>
-const std::map<int, std::string> Nextsim::Configured<Config2>::keyMap = {
+const std::map<int, std::string> keyMap2 = {
         {Config2::VALUE_KEY, "config.value"},
         {Config2::NAME_KEY, "config.name"},
 };
@@ -70,14 +69,14 @@ const std::map<int, std::string> Nextsim::Configured<Config2>::keyMap = {
 Config2::Config2()
     : value(0)
 {
-addOption<int>(keyMap.at(VALUE_KEY), -1);
-addOption<std::string>(keyMap.at(NAME_KEY), "");
+addOption<int>(keyMap2.at(VALUE_KEY), -1);
+addOption<std::string>(keyMap2.at(NAME_KEY), "");
 }
 
 void Config2::configure()
 {
-    value = retrieveValue<int>(keyMap.at(VALUE_KEY));
-    name = retrieveValue<std::string>(keyMap.at(NAME_KEY));
+    value = retrieveValue<int>(keyMap2.at(VALUE_KEY));
+    name = retrieveValue<std::string>(keyMap2.at(NAME_KEY));
 }
 
 
@@ -102,16 +101,15 @@ private:
     double weight;
 };
 
-template<>
-const std::map<int, std::string> Nextsim::Configured<Config3>::keyMap = {
+const std::map<int, std::string> keyMap3 = {
         {Config3::VALUE_KEY, "config.value"},
         {Config3::WEIGHT_KEY, "data.weight"},
 };
 
 void Config3::configure()
 {
-    value = Configured::getConfiguration(keyMap.at(VALUE_KEY), -1);
-    weight = Configured::getConfiguration(keyMap.at(WEIGHT_KEY), 1.);
+    value = Configured::getConfiguration(keyMap3.at(VALUE_KEY), -1);
+    weight = Configured::getConfiguration(keyMap3.at(WEIGHT_KEY), 1.);
 }
 
 namespace Nextsim {

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -13,8 +13,7 @@
 
 namespace Nextsim {
 
-template <>
-const std::map<int, std::string> Configured<IceGrowth>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { IceGrowth::ICE_THERMODYNAMICS_KEY, "IceThermodynamicsModel" },
     { IceGrowth::LATERAL_GROWTH_KEY, "LateralIceModel" },
     { IceGrowth::MINC_KEY, "nextsim_thermo.min_conc" },
@@ -98,11 +97,11 @@ ModelState IceGrowth::getStateRecursive(const OutputSpec& os) const
 IceGrowth::HelpMap& IceGrowth::getHelpText(HelpMap& map, bool getAll)
 {
     map["IceGrowth"] = {
-        { keyMap.at(MINC_KEY), ConfigType::NUMERIC, { "0", "1" },
+        { localKeyMap.at(MINC_KEY), ConfigType::NUMERIC, { "0", "1" },
             std::to_string(IceMinima::cMinDefault), "", "Minimum allowed ice concentration." },
-        { keyMap.at(MINH_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { localKeyMap.at(MINH_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(IceMinima::hMinDefault), "m", "Minimum allowed ice thickness." },
-        { keyMap.at(USE_THERMO_KEY), ConfigType::BOOLEAN, { "true", "false" }, "true", "",
+        { localKeyMap.at(USE_THERMO_KEY), ConfigType::BOOLEAN, { "true", "false" }, "true", "",
             "Perform ice physics calculations as part of the timestep." },
     };
     return map;
@@ -119,10 +118,10 @@ IceGrowth::HelpMap& IceGrowth::getHelpRecursive(HelpMap& map, bool getAll)
 void IceGrowth::configure()
 {
     // Configure whether we actually do anything here
-    doThermo = Configured::getConfiguration(keyMap.at(USE_THERMO_KEY), true);
+    doThermo = Configured::getConfiguration(localKeyMap.at(USE_THERMO_KEY), true);
     // Configure constants
-    IceMinima::cMin = Configured::getConfiguration(keyMap.at(MINC_KEY), IceMinima::cMinDefault);
-    IceMinima::hMin = Configured::getConfiguration(keyMap.at(MINH_KEY), IceMinima::hMinDefault);
+    IceMinima::cMin = Configured::getConfiguration(localKeyMap.at(MINC_KEY), IceMinima::cMinDefault);
+    IceMinima::hMin = Configured::getConfiguration(localKeyMap.at(MINH_KEY), IceMinima::hMinDefault);
 
     // Configure the vertical and lateral growth modules
     iVertical = std::move(Module::getInstance<IIceThermodynamics>());
@@ -136,8 +135,8 @@ void IceGrowth::configure()
 ConfigMap IceGrowth::getConfiguration() const
 {
     return {
-        { keyMap.at(MINC_KEY), IceMinima::cMin },
-        { keyMap.at(MINH_KEY), IceMinima::hMin },
+        { localKeyMap.at(MINC_KEY), IceMinima::cMin },
+        { localKeyMap.at(MINH_KEY), IceMinima::hMin },
     };
 }
 

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -13,7 +13,7 @@
 
 namespace Nextsim {
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { IceGrowth::ICE_THERMODYNAMICS_KEY, "IceThermodynamicsModel" },
     { IceGrowth::LATERAL_GROWTH_KEY, "LateralIceModel" },
     { IceGrowth::MINC_KEY, "nextsim_thermo.min_conc" },
@@ -97,11 +97,11 @@ ModelState IceGrowth::getStateRecursive(const OutputSpec& os) const
 IceGrowth::HelpMap& IceGrowth::getHelpText(HelpMap& map, bool getAll)
 {
     map["IceGrowth"] = {
-        { localKeyMap.at(MINC_KEY), ConfigType::NUMERIC, { "0", "1" },
+        { keyMap.at(MINC_KEY), ConfigType::NUMERIC, { "0", "1" },
             std::to_string(IceMinima::cMinDefault), "", "Minimum allowed ice concentration." },
-        { localKeyMap.at(MINH_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { keyMap.at(MINH_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(IceMinima::hMinDefault), "m", "Minimum allowed ice thickness." },
-        { localKeyMap.at(USE_THERMO_KEY), ConfigType::BOOLEAN, { "true", "false" }, "true", "",
+        { keyMap.at(USE_THERMO_KEY), ConfigType::BOOLEAN, { "true", "false" }, "true", "",
             "Perform ice physics calculations as part of the timestep." },
     };
     return map;
@@ -118,10 +118,10 @@ IceGrowth::HelpMap& IceGrowth::getHelpRecursive(HelpMap& map, bool getAll)
 void IceGrowth::configure()
 {
     // Configure whether we actually do anything here
-    doThermo = Configured::getConfiguration(localKeyMap.at(USE_THERMO_KEY), true);
+    doThermo = Configured::getConfiguration(keyMap.at(USE_THERMO_KEY), true);
     // Configure constants
-    IceMinima::cMin = Configured::getConfiguration(localKeyMap.at(MINC_KEY), IceMinima::cMinDefault);
-    IceMinima::hMin = Configured::getConfiguration(localKeyMap.at(MINH_KEY), IceMinima::hMinDefault);
+    IceMinima::cMin = Configured::getConfiguration(keyMap.at(MINC_KEY), IceMinima::cMinDefault);
+    IceMinima::hMin = Configured::getConfiguration(keyMap.at(MINH_KEY), IceMinima::hMinDefault);
 
     // Configure the vertical and lateral growth modules
     iVertical = std::move(Module::getInstance<IIceThermodynamics>());
@@ -135,8 +135,8 @@ void IceGrowth::configure()
 ConfigMap IceGrowth::getConfiguration() const
 {
     return {
-        { localKeyMap.at(MINC_KEY), IceMinima::cMin },
-        { localKeyMap.at(MINH_KEY), IceMinima::hMin },
+        { keyMap.at(MINC_KEY), IceMinima::cMin },
+        { keyMap.at(MINH_KEY), IceMinima::hMin },
     };
 }
 

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -23,14 +23,14 @@ static const std::string className = "SlabOcean";
 static const std::string relaxationTimeTName = "timeT";
 static const std::string relaxationTimeSName = "timeS";
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { SlabOcean::TIMET_KEY, className + "." + relaxationTimeTName },
     { SlabOcean::TIMES_KEY, className + "." + relaxationTimeSName },
 };
 void SlabOcean::configure()
 {
-    relaxationTimeT = Configured::getConfiguration(localKeyMap.at(TIMET_KEY), defaultRelaxationTime);
-    relaxationTimeS = Configured::getConfiguration(localKeyMap.at(TIMES_KEY), defaultRelaxationTime);
+    relaxationTimeT = Configured::getConfiguration(keyMap.at(TIMET_KEY), defaultRelaxationTime);
+    relaxationTimeS = Configured::getConfiguration(keyMap.at(TIMES_KEY), defaultRelaxationTime);
 
     getStore().registerArray(Protected::SLAB_QDW, &qdw, RO);
     getStore().registerArray(Protected::SLAB_FDW, &fdw, RO);
@@ -41,10 +41,10 @@ void SlabOcean::configure()
 SlabOcean::HelpMap& SlabOcean::getHelpText(HelpMap& map, bool getAll)
 {
     map[className] = {
-        { localKeyMap.at(TIMET_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { keyMap.at(TIMET_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(defaultRelaxationTime), "s",
             "Relaxation time of the slab ocean to external temperature forcing." },
-        { localKeyMap.at(TIMES_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { keyMap.at(TIMES_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(defaultRelaxationTime), "s",
             "Relaxation time of the slab ocean to external salinity forcing." },
     };

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -23,15 +23,14 @@ static const std::string className = "SlabOcean";
 static const std::string relaxationTimeTName = "timeT";
 static const std::string relaxationTimeSName = "timeS";
 
-template <>
-const std::map<int, std::string> Configured<SlabOcean>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { SlabOcean::TIMET_KEY, className + "." + relaxationTimeTName },
     { SlabOcean::TIMES_KEY, className + "." + relaxationTimeSName },
 };
 void SlabOcean::configure()
 {
-    relaxationTimeT = Configured::getConfiguration(keyMap.at(TIMET_KEY), defaultRelaxationTime);
-    relaxationTimeS = Configured::getConfiguration(keyMap.at(TIMES_KEY), defaultRelaxationTime);
+    relaxationTimeT = Configured::getConfiguration(localKeyMap.at(TIMET_KEY), defaultRelaxationTime);
+    relaxationTimeS = Configured::getConfiguration(localKeyMap.at(TIMES_KEY), defaultRelaxationTime);
 
     getStore().registerArray(Protected::SLAB_QDW, &qdw, RO);
     getStore().registerArray(Protected::SLAB_FDW, &fdw, RO);
@@ -42,10 +41,10 @@ void SlabOcean::configure()
 SlabOcean::HelpMap& SlabOcean::getHelpText(HelpMap& map, bool getAll)
 {
     map[className] = {
-        { keyMap.at(TIMET_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { localKeyMap.at(TIMET_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(defaultRelaxationTime), "s",
             "Relaxation time of the slab ocean to external temperature forcing." },
-        { keyMap.at(TIMES_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { localKeyMap.at(TIMES_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(defaultRelaxationTime), "s",
             "Relaxation time of the slab ocean to external salinity forcing." },
     };

--- a/physics/src/modules/AtmosphereBoundaryModule/ConfiguredAtmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ConfiguredAtmosphere.cpp
@@ -30,7 +30,7 @@ static const std::string snowKey = pfx + ".snow";
 static const std::string rainKey = pfx + ".rainfall";
 static const std::string windKey = pfx + ".wind_speed";
 
-const static std::map<int, std::string> localKeyMap = {
+const static std::map<int, std::string> keyMap = {
     { ConfiguredAtmosphere::TAIR_KEY, tKey },
     { ConfiguredAtmosphere::TDEW_KEY, tdewKey },
     { ConfiguredAtmosphere::PAIR_KEY, pKey },
@@ -79,14 +79,14 @@ ConfigurationHelp::HelpMap& ConfiguredAtmosphere::getHelpRecursive(HelpMap& map,
 
 void ConfiguredAtmosphere::configure()
 {
-    tair0 = Configured::getConfiguration(localKeyMap.at(TAIR_KEY), tair0);
-    tdew0 = Configured::getConfiguration(localKeyMap.at(TDEW_KEY), tdew0);
-    pair0 = Configured::getConfiguration(localKeyMap.at(PAIR_KEY), pair0);
-    sw0 = Configured::getConfiguration(localKeyMap.at(SW_KEY), sw0);
-    lw0 = Configured::getConfiguration(localKeyMap.at(LW_KEY), lw0);
-    snowfall0 = Configured::getConfiguration(localKeyMap.at(SNOW_KEY), snowfall0);
-    rain0 = Configured::getConfiguration(localKeyMap.at(RAIN_KEY), rain0);
-    windspeed0 = Configured::getConfiguration(localKeyMap.at(WIND_KEY), windspeed0);
+    tair0 = Configured::getConfiguration(keyMap.at(TAIR_KEY), tair0);
+    tdew0 = Configured::getConfiguration(keyMap.at(TDEW_KEY), tdew0);
+    pair0 = Configured::getConfiguration(keyMap.at(PAIR_KEY), pair0);
+    sw0 = Configured::getConfiguration(keyMap.at(SW_KEY), sw0);
+    lw0 = Configured::getConfiguration(keyMap.at(LW_KEY), lw0);
+    snowfall0 = Configured::getConfiguration(keyMap.at(SNOW_KEY), snowfall0);
+    rain0 = Configured::getConfiguration(keyMap.at(RAIN_KEY), rain0);
+    windspeed0 = Configured::getConfiguration(keyMap.at(WIND_KEY), windspeed0);
 
     fluxImpl = &Module::getImplementation<IFluxCalculation>();
     tryConfigure(fluxImpl);

--- a/physics/src/modules/AtmosphereBoundaryModule/ConfiguredAtmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ConfiguredAtmosphere.cpp
@@ -30,8 +30,7 @@ static const std::string snowKey = pfx + ".snow";
 static const std::string rainKey = pfx + ".rainfall";
 static const std::string windKey = pfx + ".wind_speed";
 
-template <>
-const std::map<int, std::string> Configured<ConfiguredAtmosphere>::keyMap = {
+const static std::map<int, std::string> localKeyMap = {
     { ConfiguredAtmosphere::TAIR_KEY, tKey },
     { ConfiguredAtmosphere::TDEW_KEY, tdewKey },
     { ConfiguredAtmosphere::PAIR_KEY, pKey },
@@ -52,7 +51,6 @@ ConfiguredAtmosphere::ConfiguredAtmosphere()
     getStore().registerArray(Protected::LW_IN, &lw_in, RO);
     getStore().registerArray(Protected::WIND_SPEED, &wind, RO);
 }
-
 
 ConfigurationHelp::HelpMap& ConfiguredAtmosphere::getHelpRecursive(HelpMap& map, bool getAll)
 {
@@ -81,14 +79,14 @@ ConfigurationHelp::HelpMap& ConfiguredAtmosphere::getHelpRecursive(HelpMap& map,
 
 void ConfiguredAtmosphere::configure()
 {
-    tair0 = Configured::getConfiguration(keyMap.at(TAIR_KEY), tair0);
-    tdew0 = Configured::getConfiguration(keyMap.at(TDEW_KEY), tdew0);
-    pair0 = Configured::getConfiguration(keyMap.at(PAIR_KEY), pair0);
-    sw0 = Configured::getConfiguration(keyMap.at(SW_KEY), sw0);
-    lw0 = Configured::getConfiguration(keyMap.at(LW_KEY), lw0);
-    snowfall0 = Configured::getConfiguration(keyMap.at(SNOW_KEY), snowfall0);
-    rain0 = Configured::getConfiguration(keyMap.at(RAIN_KEY), rain0);
-    windspeed0 = Configured::getConfiguration(keyMap.at(WIND_KEY), windspeed0);
+    tair0 = Configured::getConfiguration(localKeyMap.at(TAIR_KEY), tair0);
+    tdew0 = Configured::getConfiguration(localKeyMap.at(TDEW_KEY), tdew0);
+    pair0 = Configured::getConfiguration(localKeyMap.at(PAIR_KEY), pair0);
+    sw0 = Configured::getConfiguration(localKeyMap.at(SW_KEY), sw0);
+    lw0 = Configured::getConfiguration(localKeyMap.at(LW_KEY), lw0);
+    snowfall0 = Configured::getConfiguration(localKeyMap.at(SNOW_KEY), snowfall0);
+    rain0 = Configured::getConfiguration(localKeyMap.at(RAIN_KEY), rain0);
+    windspeed0 = Configured::getConfiguration(localKeyMap.at(WIND_KEY), windspeed0);
 
     fluxImpl = &Module::getImplementation<IFluxCalculation>();
     tryConfigure(fluxImpl);

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -17,8 +17,7 @@ std::string ERA5Atmosphere::filePath;
 static const std::string pfx = "ERA5Atmosphere";
 static const std::string fileKey = pfx + ".file";
 
-template <>
-const std::map<int, std::string> Configured<ERA5Atmosphere>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { ERA5Atmosphere::FILEPATH_KEY, fileKey },
 };
 
@@ -46,7 +45,7 @@ ConfigurationHelp::HelpMap& ERA5Atmosphere::getHelpRecursive(HelpMap& map, bool 
 
 void ERA5Atmosphere::configure()
 {
-    filePath = Configured::getConfiguration(keyMap.at(FILEPATH_KEY), std::string());
+    filePath = Configured::getConfiguration(localKeyMap.at(FILEPATH_KEY), std::string());
 
     fluxImpl = &Module::getImplementation<IFluxCalculation>();
     tryConfigure(fluxImpl);

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -17,7 +17,7 @@ std::string ERA5Atmosphere::filePath;
 static const std::string pfx = "ERA5Atmosphere";
 static const std::string fileKey = pfx + ".file";
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { ERA5Atmosphere::FILEPATH_KEY, fileKey },
 };
 
@@ -45,7 +45,7 @@ ConfigurationHelp::HelpMap& ERA5Atmosphere::getHelpRecursive(HelpMap& map, bool 
 
 void ERA5Atmosphere::configure()
 {
-    filePath = Configured::getConfiguration(localKeyMap.at(FILEPATH_KEY), std::string());
+    filePath = Configured::getConfiguration(keyMap.at(FILEPATH_KEY), std::string());
 
     fluxImpl = &Module::getImplementation<IFluxCalculation>();
     tryConfigure(fluxImpl);

--- a/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
@@ -30,8 +30,7 @@ static const std::string evapKey = pfx + ".evaporation";
 static const std::string uKey = pfx + ".wind_u";
 static const std::string vKey = pfx + ".wind_v";
 
-template <>
-const std::map<int, std::string> Configured<FluxConfiguredAtmosphere>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { FluxConfiguredAtmosphere::QIA_KEY, qiaKey },
     { FluxConfiguredAtmosphere::DQIA_DT_KEY, dqiaKey },
     { FluxConfiguredAtmosphere::QOW_KEY, qowKey },
@@ -69,15 +68,15 @@ ConfigurationHelp::HelpMap& FluxConfiguredAtmosphere::getHelpRecursive(HelpMap& 
 }
 void FluxConfiguredAtmosphere::configure()
 {
-    qia0 = Configured::getConfiguration(keyMap.at(QIA_KEY), qia0);
-    dqia_dt0 = Configured::getConfiguration(keyMap.at(DQIA_DT_KEY), dqia_dt0);
-    qow0 = Configured::getConfiguration(keyMap.at(QOW_KEY), qow0);
-    subl0 = Configured::getConfiguration(keyMap.at(SUBL_KEY), subl0);
-    snowfall0 = Configured::getConfiguration(keyMap.at(SNOW_KEY), snowfall0);
-    rain0 = Configured::getConfiguration(keyMap.at(RAIN_KEY), rain0);
-    evap0 = Configured::getConfiguration(keyMap.at(EVAP_KEY), evap0);
-    u0 = Configured::getConfiguration(keyMap.at(WINDU_KEY), u0);
-    v0 = Configured::getConfiguration(keyMap.at(WINDV_KEY), v0);
+    qia0 = Configured::getConfiguration(localKeyMap.at(QIA_KEY), qia0);
+    dqia_dt0 = Configured::getConfiguration(localKeyMap.at(DQIA_DT_KEY), dqia_dt0);
+    qow0 = Configured::getConfiguration(localKeyMap.at(QOW_KEY), qow0);
+    subl0 = Configured::getConfiguration(localKeyMap.at(SUBL_KEY), subl0);
+    snowfall0 = Configured::getConfiguration(localKeyMap.at(SNOW_KEY), snowfall0);
+    rain0 = Configured::getConfiguration(localKeyMap.at(RAIN_KEY), rain0);
+    evap0 = Configured::getConfiguration(localKeyMap.at(EVAP_KEY), evap0);
+    u0 = Configured::getConfiguration(localKeyMap.at(WINDU_KEY), u0);
+    v0 = Configured::getConfiguration(localKeyMap.at(WINDV_KEY), v0);
 }
 
 void FluxConfiguredAtmosphere::setData(const ModelState::DataMap& dm)

--- a/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
@@ -30,7 +30,7 @@ static const std::string evapKey = pfx + ".evaporation";
 static const std::string uKey = pfx + ".wind_u";
 static const std::string vKey = pfx + ".wind_v";
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { FluxConfiguredAtmosphere::QIA_KEY, qiaKey },
     { FluxConfiguredAtmosphere::DQIA_DT_KEY, dqiaKey },
     { FluxConfiguredAtmosphere::QOW_KEY, qowKey },
@@ -68,15 +68,15 @@ ConfigurationHelp::HelpMap& FluxConfiguredAtmosphere::getHelpRecursive(HelpMap& 
 }
 void FluxConfiguredAtmosphere::configure()
 {
-    qia0 = Configured::getConfiguration(localKeyMap.at(QIA_KEY), qia0);
-    dqia_dt0 = Configured::getConfiguration(localKeyMap.at(DQIA_DT_KEY), dqia_dt0);
-    qow0 = Configured::getConfiguration(localKeyMap.at(QOW_KEY), qow0);
-    subl0 = Configured::getConfiguration(localKeyMap.at(SUBL_KEY), subl0);
-    snowfall0 = Configured::getConfiguration(localKeyMap.at(SNOW_KEY), snowfall0);
-    rain0 = Configured::getConfiguration(localKeyMap.at(RAIN_KEY), rain0);
-    evap0 = Configured::getConfiguration(localKeyMap.at(EVAP_KEY), evap0);
-    u0 = Configured::getConfiguration(localKeyMap.at(WINDU_KEY), u0);
-    v0 = Configured::getConfiguration(localKeyMap.at(WINDV_KEY), v0);
+    qia0 = Configured::getConfiguration(keyMap.at(QIA_KEY), qia0);
+    dqia_dt0 = Configured::getConfiguration(keyMap.at(DQIA_DT_KEY), dqia_dt0);
+    qow0 = Configured::getConfiguration(keyMap.at(QOW_KEY), qow0);
+    subl0 = Configured::getConfiguration(keyMap.at(SUBL_KEY), subl0);
+    snowfall0 = Configured::getConfiguration(keyMap.at(SNOW_KEY), snowfall0);
+    rain0 = Configured::getConfiguration(keyMap.at(RAIN_KEY), rain0);
+    evap0 = Configured::getConfiguration(keyMap.at(EVAP_KEY), evap0);
+    u0 = Configured::getConfiguration(keyMap.at(WINDU_KEY), u0);
+    v0 = Configured::getConfiguration(keyMap.at(WINDV_KEY), v0);
 }
 
 void FluxConfiguredAtmosphere::setData(const ModelState::DataMap& dm)

--- a/physics/src/modules/AtmosphereBoundaryModule/MU71Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/MU71Atmosphere.cpp
@@ -11,8 +11,7 @@ double MU71Atmosphere::m_I0;
 
 static const double i0_default = 0.30;
 
-template <>
-const std::map<int, std::string> Configured<MU71Atmosphere>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { MU71Atmosphere::I0_KEY, "nextsim_thermo.I_0" },
 };
 
@@ -21,13 +20,13 @@ void MU71Atmosphere::configure()
     iIceAlbedoImpl = &Module::getImplementation<IIceAlbedo>();
     tryConfigure(iIceAlbedoImpl);
 
-    m_I0 = Configured::getConfiguration(keyMap.at(I0_KEY), i0_default);
+    m_I0 = Configured::getConfiguration(localKeyMap.at(I0_KEY), i0_default);
 }
 
 MU71Atmosphere::HelpMap& MU71Atmosphere::getHelpText(HelpMap& map, bool getAll)
 {
     map["FiniteElementFluxes"] = {
-        { keyMap.at(I0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(i0_default), "",
+        { localKeyMap.at(I0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(i0_default), "",
             "Transmissivity of ice." },
     };
     return map;

--- a/physics/src/modules/AtmosphereBoundaryModule/MU71Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/MU71Atmosphere.cpp
@@ -11,7 +11,7 @@ double MU71Atmosphere::m_I0;
 
 static const double i0_default = 0.30;
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { MU71Atmosphere::I0_KEY, "nextsim_thermo.I_0" },
 };
 
@@ -20,13 +20,13 @@ void MU71Atmosphere::configure()
     iIceAlbedoImpl = &Module::getImplementation<IIceAlbedo>();
     tryConfigure(iIceAlbedoImpl);
 
-    m_I0 = Configured::getConfiguration(localKeyMap.at(I0_KEY), i0_default);
+    m_I0 = Configured::getConfiguration(keyMap.at(I0_KEY), i0_default);
 }
 
 MU71Atmosphere::HelpMap& MU71Atmosphere::getHelpText(HelpMap& map, bool getAll)
 {
     map["FiniteElementFluxes"] = {
-        { localKeyMap.at(I0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(i0_default), "",
+        { keyMap.at(I0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(i0_default), "",
             "Transmissivity of ice." },
     };
     return map;

--- a/physics/src/modules/DamageHealingModule/ConstantHealing.cpp
+++ b/physics/src/modules/DamageHealingModule/ConstantHealing.cpp
@@ -12,26 +12,25 @@ namespace Nextsim {
 double ConstantHealing::tD = 0.;
 static const double tDDefault = 15;
 
-template <>
-const std::map<int, std::string> Configured<ConstantHealing>::keyMap
+static const std::map<int, std::string> localKeyMap
     = { { ConstantHealing::TD_KEY, "ConstantHealing.td" } };
 
 void ConstantHealing::configure()
 {
     // the option is defined in days, but the model wants seconds
-    tD = Configured::getConfiguration(keyMap.at(TD_KEY), tDDefault);
+    tD = Configured::getConfiguration(localKeyMap.at(TD_KEY), tDDefault);
     tD *= 86400.;
 }
 
 ModelState ConstantHealing::getStateRecursive(const Nextsim::OutputSpec& os) const
 {
-    return { {}, { { keyMap.at(TD_KEY), tD } } };
+    return { {}, { { localKeyMap.at(TD_KEY), tD } } };
 }
 
 ConstantHealing::HelpMap& ConstantHealing::getHelpText(HelpMap& map, bool getAll)
 {
     map["ConstantHealing"]
-        = { { keyMap.at(TD_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(tDDefault),
+        = { { localKeyMap.at(TD_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(tDDefault),
             "days", "The healing time scale (t_d) for brittle rheologies" } };
     return map;
 }

--- a/physics/src/modules/DamageHealingModule/ConstantHealing.cpp
+++ b/physics/src/modules/DamageHealingModule/ConstantHealing.cpp
@@ -12,25 +12,25 @@ namespace Nextsim {
 double ConstantHealing::tD = 0.;
 static const double tDDefault = 15;
 
-static const std::map<int, std::string> localKeyMap
+static const std::map<int, std::string> keyMap
     = { { ConstantHealing::TD_KEY, "ConstantHealing.td" } };
 
 void ConstantHealing::configure()
 {
     // the option is defined in days, but the model wants seconds
-    tD = Configured::getConfiguration(localKeyMap.at(TD_KEY), tDDefault);
+    tD = Configured::getConfiguration(keyMap.at(TD_KEY), tDDefault);
     tD *= 86400.;
 }
 
 ModelState ConstantHealing::getStateRecursive(const Nextsim::OutputSpec& os) const
 {
-    return { {}, { { localKeyMap.at(TD_KEY), tD } } };
+    return { {}, { { keyMap.at(TD_KEY), tD } } };
 }
 
 ConstantHealing::HelpMap& ConstantHealing::getHelpText(HelpMap& map, bool getAll)
 {
     map["ConstantHealing"]
-        = { { localKeyMap.at(TD_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(tDDefault),
+        = { { keyMap.at(TD_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(tDDefault),
             "days", "The healing time scale (t_d) for brittle rheologies" } };
     return map;
 }

--- a/physics/src/modules/FluxCalculationModule/FiniteElementFluxes.cpp
+++ b/physics/src/modules/FluxCalculationModule/FiniteElementFluxes.cpp
@@ -29,8 +29,7 @@ static const double dragIce_t_default = 1.3e-3;
 static const double oceanAlbedo_default = 0.07;
 static const double i0_default = 0.17;
 
-template <>
-const std::map<int, std::string> Configured<FiniteElementFluxes>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { FiniteElementFluxes::DRAGOCEANQ_KEY, "nextsim_thermo.drag_ocean_q" },
     { FiniteElementFluxes::DRAGOCEANT_KEY, "nextsim_thermo.drag_ocean_t" },
     { FiniteElementFluxes::DRAGICET_KEY, "nextsim_thermo.drag_ice_t" },
@@ -43,11 +42,11 @@ void FiniteElementFluxes::configure()
     iIceAlbedoImpl = &Module::getImplementation<IIceAlbedo>();
     tryConfigure(iIceAlbedoImpl);
 
-    dragOcean_q = Configured::getConfiguration(keyMap.at(DRAGOCEANQ_KEY), dragOcean_q_default);
-    dragOcean_t = Configured::getConfiguration(keyMap.at(DRAGOCEANT_KEY), dragOcean_t_default);
-    dragIce_t = Configured::getConfiguration(keyMap.at(DRAGICET_KEY), dragIce_t_default);
-    m_oceanAlbedo = Configured::getConfiguration(keyMap.at(OCEANALBEDO_KEY), oceanAlbedo_default);
-    m_I0 = Configured::getConfiguration(keyMap.at(I0_KEY), i0_default);
+    dragOcean_q = Configured::getConfiguration(localKeyMap.at(DRAGOCEANQ_KEY), dragOcean_q_default);
+    dragOcean_t = Configured::getConfiguration(localKeyMap.at(DRAGOCEANT_KEY), dragOcean_t_default);
+    dragIce_t = Configured::getConfiguration(localKeyMap.at(DRAGICET_KEY), dragIce_t_default);
+    m_oceanAlbedo = Configured::getConfiguration(localKeyMap.at(OCEANALBEDO_KEY), oceanAlbedo_default);
+    m_I0 = Configured::getConfiguration(localKeyMap.at(I0_KEY), i0_default);
 }
 
 void FiniteElementFluxes::setData(const ModelState::DataMap& ms)
@@ -83,17 +82,17 @@ ModelState FiniteElementFluxes::getStateRecursive(const OutputSpec& os) const
 FiniteElementFluxes::HelpMap& FiniteElementFluxes::getHelpText(HelpMap& map, bool getAll)
 {
     map["FiniteElementFluxes"] = {
-        { keyMap.at(DRAGOCEANQ_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { localKeyMap.at(DRAGOCEANQ_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(dragOcean_q_default), "??",
             "Coefficient for evaporative mass flux calculation." },
-        { keyMap.at(DRAGOCEANT_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { localKeyMap.at(DRAGOCEANT_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(dragOcean_t_default), "??",
             "Coefficient for sensible heat flux calculation." },
-        { keyMap.at(DRAGICET_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { localKeyMap.at(DRAGICET_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(dragIce_t_default), "??", "Ice drag coefficient for heat fluxes." },
-        { keyMap.at(OCEANALBEDO_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { localKeyMap.at(OCEANALBEDO_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(oceanAlbedo_default), "", "Shortwave albedo of open ocean water." },
-        { keyMap.at(I0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(i0_default), "",
+        { localKeyMap.at(I0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(i0_default), "",
             "Transmissivity of ice." },
     };
     return map;

--- a/physics/src/modules/FluxCalculationModule/FiniteElementFluxes.cpp
+++ b/physics/src/modules/FluxCalculationModule/FiniteElementFluxes.cpp
@@ -29,7 +29,7 @@ static const double dragIce_t_default = 1.3e-3;
 static const double oceanAlbedo_default = 0.07;
 static const double i0_default = 0.17;
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { FiniteElementFluxes::DRAGOCEANQ_KEY, "nextsim_thermo.drag_ocean_q" },
     { FiniteElementFluxes::DRAGOCEANT_KEY, "nextsim_thermo.drag_ocean_t" },
     { FiniteElementFluxes::DRAGICET_KEY, "nextsim_thermo.drag_ice_t" },
@@ -42,11 +42,11 @@ void FiniteElementFluxes::configure()
     iIceAlbedoImpl = &Module::getImplementation<IIceAlbedo>();
     tryConfigure(iIceAlbedoImpl);
 
-    dragOcean_q = Configured::getConfiguration(localKeyMap.at(DRAGOCEANQ_KEY), dragOcean_q_default);
-    dragOcean_t = Configured::getConfiguration(localKeyMap.at(DRAGOCEANT_KEY), dragOcean_t_default);
-    dragIce_t = Configured::getConfiguration(localKeyMap.at(DRAGICET_KEY), dragIce_t_default);
-    m_oceanAlbedo = Configured::getConfiguration(localKeyMap.at(OCEANALBEDO_KEY), oceanAlbedo_default);
-    m_I0 = Configured::getConfiguration(localKeyMap.at(I0_KEY), i0_default);
+    dragOcean_q = Configured::getConfiguration(keyMap.at(DRAGOCEANQ_KEY), dragOcean_q_default);
+    dragOcean_t = Configured::getConfiguration(keyMap.at(DRAGOCEANT_KEY), dragOcean_t_default);
+    dragIce_t = Configured::getConfiguration(keyMap.at(DRAGICET_KEY), dragIce_t_default);
+    m_oceanAlbedo = Configured::getConfiguration(keyMap.at(OCEANALBEDO_KEY), oceanAlbedo_default);
+    m_I0 = Configured::getConfiguration(keyMap.at(I0_KEY), i0_default);
 }
 
 void FiniteElementFluxes::setData(const ModelState::DataMap& ms)
@@ -82,17 +82,17 @@ ModelState FiniteElementFluxes::getStateRecursive(const OutputSpec& os) const
 FiniteElementFluxes::HelpMap& FiniteElementFluxes::getHelpText(HelpMap& map, bool getAll)
 {
     map["FiniteElementFluxes"] = {
-        { localKeyMap.at(DRAGOCEANQ_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { keyMap.at(DRAGOCEANQ_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(dragOcean_q_default), "??",
             "Coefficient for evaporative mass flux calculation." },
-        { localKeyMap.at(DRAGOCEANT_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { keyMap.at(DRAGOCEANT_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(dragOcean_t_default), "??",
             "Coefficient for sensible heat flux calculation." },
-        { localKeyMap.at(DRAGICET_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { keyMap.at(DRAGICET_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(dragIce_t_default), "??", "Ice drag coefficient for heat fluxes." },
-        { localKeyMap.at(OCEANALBEDO_KEY), ConfigType::NUMERIC, { "0", "∞" },
+        { keyMap.at(OCEANALBEDO_KEY), ConfigType::NUMERIC, { "0", "∞" },
             std::to_string(oceanAlbedo_default), "", "Shortwave albedo of open ocean water." },
-        { localKeyMap.at(I0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(i0_default), "",
+        { keyMap.at(I0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(i0_default), "",
             "Transmissivity of ice." },
     };
     return map;

--- a/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
@@ -39,14 +39,13 @@ void ThermoIce0::update(const TimestepTime& tsTime)
         tsTime);
 }
 
-template <>
-const std::map<int, std::string> Configured<ThermoIce0>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { ThermoIce0::KS_KEY, IIceThermodynamics::getKappaSConfigKey() },
 };
 
 void ThermoIce0::configure()
 {
-    kappa_s = Configured::getConfiguration(keyMap.at(KS_KEY), k_sDefault);
+    kappa_s = Configured::getConfiguration(localKeyMap.at(KS_KEY), k_sDefault);
     NZLevels::set(nZLevels);
 }
 
@@ -54,7 +53,7 @@ ModelState ThermoIce0::getStateRecursive(const OutputSpec& os) const
 {
     ModelState state = { {},
         {
-            { keyMap.at(KS_KEY), kappa_s },
+            { localKeyMap.at(KS_KEY), kappa_s },
         } };
     return os ? state : ModelState();
 }
@@ -62,7 +61,7 @@ ModelState ThermoIce0::getStateRecursive(const OutputSpec& os) const
 ThermoIce0::HelpMap& ThermoIce0::getHelpText(HelpMap& map, bool getAll)
 {
     map["ThermoIce0"] = {
-        { keyMap.at(KS_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(k_sDefault),
+        { localKeyMap.at(KS_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(k_sDefault),
             "W K⁻¹ m⁻¹", "Thermal conductivity of snow." },
     };
     return map;

--- a/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
@@ -39,13 +39,13 @@ void ThermoIce0::update(const TimestepTime& tsTime)
         tsTime);
 }
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { ThermoIce0::KS_KEY, IIceThermodynamics::getKappaSConfigKey() },
 };
 
 void ThermoIce0::configure()
 {
-    kappa_s = Configured::getConfiguration(localKeyMap.at(KS_KEY), k_sDefault);
+    kappa_s = Configured::getConfiguration(keyMap.at(KS_KEY), k_sDefault);
     NZLevels::set(nZLevels);
 }
 
@@ -53,7 +53,7 @@ ModelState ThermoIce0::getStateRecursive(const OutputSpec& os) const
 {
     ModelState state = { {},
         {
-            { localKeyMap.at(KS_KEY), kappa_s },
+            { keyMap.at(KS_KEY), kappa_s },
         } };
     return os ? state : ModelState();
 }
@@ -61,7 +61,7 @@ ModelState ThermoIce0::getStateRecursive(const OutputSpec& os) const
 ThermoIce0::HelpMap& ThermoIce0::getHelpText(HelpMap& map, bool getAll)
 {
     map["ThermoIce0"] = {
-        { localKeyMap.at(KS_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(k_sDefault),
+        { keyMap.at(KS_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(k_sDefault),
             "W K⁻¹ m⁻¹", "Thermal conductivity of snow." },
     };
     return map;

--- a/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
@@ -38,15 +38,15 @@ ThermoWinton::ThermoWinton()
     snowToIce.resize();
 }
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { ThermoWinton::KS_KEY, IIceThermodynamics::getKappaSConfigKey() },
     { ThermoWinton::FLOODING_KEY, "nextsim_thermo.doFlooding" },
 };
 
 void ThermoWinton::configure()
 {
-    kappa_s = Configured::getConfiguration(localKeyMap.at(KS_KEY), k_sDefault);
-    doFlooding = Configured::getConfiguration(localKeyMap.at(FLOODING_KEY), doFlooding);
+    kappa_s = Configured::getConfiguration(keyMap.at(KS_KEY), k_sDefault);
+    doFlooding = Configured::getConfiguration(keyMap.at(FLOODING_KEY), doFlooding);
     NZLevels::set(nLevels);
 }
 
@@ -54,7 +54,7 @@ ModelState ThermoWinton::getStateRecursive(const OutputSpec& os) const
 {
     ModelState state = { {},
         {
-            { localKeyMap.at(KS_KEY), kappa_s },
+            { keyMap.at(KS_KEY), kappa_s },
         } };
     return os ? state : ModelState();
 }
@@ -62,7 +62,7 @@ ModelState ThermoWinton::getStateRecursive(const OutputSpec& os) const
 ThermoWinton::HelpMap& ThermoWinton::getHelpText(HelpMap& map, bool getAll)
 {
     map["ThermoWinton"] = {
-        { localKeyMap.at(KS_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(k_sDefault),
+        { keyMap.at(KS_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(k_sDefault),
             "W K⁻¹ m⁻¹", "Thermal conductivity of snow." },
     };
     return map;

--- a/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
@@ -38,16 +38,15 @@ ThermoWinton::ThermoWinton()
     snowToIce.resize();
 }
 
-template <>
-const std::map<int, std::string> Configured<ThermoWinton>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { ThermoWinton::KS_KEY, IIceThermodynamics::getKappaSConfigKey() },
     { ThermoWinton::FLOODING_KEY, "nextsim_thermo.doFlooding" },
 };
 
 void ThermoWinton::configure()
 {
-    kappa_s = Configured::getConfiguration(keyMap.at(KS_KEY), k_sDefault);
-    doFlooding = Configured::getConfiguration(keyMap.at(FLOODING_KEY), doFlooding);
+    kappa_s = Configured::getConfiguration(localKeyMap.at(KS_KEY), k_sDefault);
+    doFlooding = Configured::getConfiguration(localKeyMap.at(FLOODING_KEY), doFlooding);
     NZLevels::set(nLevels);
 }
 
@@ -55,7 +54,7 @@ ModelState ThermoWinton::getStateRecursive(const OutputSpec& os) const
 {
     ModelState state = { {},
         {
-            { keyMap.at(KS_KEY), kappa_s },
+            { localKeyMap.at(KS_KEY), kappa_s },
         } };
     return os ? state : ModelState();
 }
@@ -63,7 +62,7 @@ ModelState ThermoWinton::getStateRecursive(const OutputSpec& os) const
 ThermoWinton::HelpMap& ThermoWinton::getHelpText(HelpMap& map, bool getAll)
 {
     map["ThermoWinton"] = {
-        { keyMap.at(KS_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(k_sDefault),
+        { localKeyMap.at(KS_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(k_sDefault),
             "W K⁻¹ m⁻¹", "Thermal conductivity of snow." },
     };
     return map;

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -15,33 +15,32 @@ double HiblerSpread::phiM = 0;
 static const double h0Default = 0.25;
 static const double phimDefault = 0.5;
 
-template <>
-const std::map<int, std::string> Configured<HiblerSpread>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { HiblerSpread::H0_KEY, "Hibler.h0" },
     { HiblerSpread::PHIM_KEY, "Hibler.phiM" },
 };
 
 void HiblerSpread::configure()
 {
-    h0 = Configured::getConfiguration(keyMap.at(H0_KEY), h0Default);
-    phiM = Configured::getConfiguration(keyMap.at(PHIM_KEY), phimDefault);
+    h0 = Configured::getConfiguration(localKeyMap.at(H0_KEY), h0Default);
+    phiM = Configured::getConfiguration(localKeyMap.at(PHIM_KEY), phimDefault);
 }
 
 ModelState HiblerSpread::getStateRecursive(const OutputSpec& os) const
 {
     return { {},
         {
-            { keyMap.at(H0_KEY), h0 },
-            { keyMap.at(PHIM_KEY), phiM },
+            { localKeyMap.at(H0_KEY), h0 },
+            { localKeyMap.at(PHIM_KEY), phiM },
         } };
 }
 
 HiblerSpread::HelpMap& HiblerSpread::getHelpText(HelpMap& map, bool getAll)
 {
     map["HiblerSpread"] = {
-        { keyMap.at(H0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(h0Default), "m",
+        { localKeyMap.at(H0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(h0Default), "m",
             "The thickness of newly frozen ice." },
-        { keyMap.at(PHIM_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(phimDefault), "",
+        { localKeyMap.at(PHIM_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(phimDefault), "",
             "Power-law exponent for melting ice." },
     };
     return map;

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -15,32 +15,32 @@ double HiblerSpread::phiM = 0;
 static const double h0Default = 0.25;
 static const double phimDefault = 0.5;
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { HiblerSpread::H0_KEY, "Hibler.h0" },
     { HiblerSpread::PHIM_KEY, "Hibler.phiM" },
 };
 
 void HiblerSpread::configure()
 {
-    h0 = Configured::getConfiguration(localKeyMap.at(H0_KEY), h0Default);
-    phiM = Configured::getConfiguration(localKeyMap.at(PHIM_KEY), phimDefault);
+    h0 = Configured::getConfiguration(keyMap.at(H0_KEY), h0Default);
+    phiM = Configured::getConfiguration(keyMap.at(PHIM_KEY), phimDefault);
 }
 
 ModelState HiblerSpread::getStateRecursive(const OutputSpec& os) const
 {
     return { {},
         {
-            { localKeyMap.at(H0_KEY), h0 },
-            { localKeyMap.at(PHIM_KEY), phiM },
+            { keyMap.at(H0_KEY), h0 },
+            { keyMap.at(PHIM_KEY), phiM },
         } };
 }
 
 HiblerSpread::HelpMap& HiblerSpread::getHelpText(HelpMap& map, bool getAll)
 {
     map["HiblerSpread"] = {
-        { localKeyMap.at(H0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(h0Default), "m",
+        { keyMap.at(H0_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(h0Default), "m",
             "The thickness of newly frozen ice." },
-        { localKeyMap.at(PHIM_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(phimDefault), "",
+        { keyMap.at(PHIM_KEY), ConfigType::NUMERIC, { "0", "∞" }, std::to_string(phimDefault), "",
             "Power-law exponent for melting ice." },
     };
     return map;

--- a/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
@@ -28,8 +28,7 @@ static const std::string mldKey = pfx + ".mld";
 static const std::string uKey = pfx + ".current_u";
 static const std::string vKey = pfx + ".current_v";
 
-template <>
-const std::map<int, std::string> Configured<ConfiguredOcean>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { ConfiguredOcean::SST_KEY, sstKey },
     { ConfiguredOcean::SSS_KEY, sssKey },
     { ConfiguredOcean::MLD_KEY, mldKey },
@@ -64,16 +63,11 @@ ConfigurationHelp::HelpMap& ConfiguredOcean::getHelpRecursive(HelpMap& map, bool
 
 void ConfiguredOcean::configure()
 {
-    sst0 = Configured<ConfiguredOcean>::getConfiguration(
-        Configured<ConfiguredOcean>::keyMap.at(SST_KEY), sst0);
-    sss0 = Configured<ConfiguredOcean>::getConfiguration(
-        Configured<ConfiguredOcean>::keyMap.at(SSS_KEY), sss0);
-    mld0 = Configured<ConfiguredOcean>::getConfiguration(
-        Configured<ConfiguredOcean>::keyMap.at(MLD_KEY), mld0);
-    u0 = Configured<ConfiguredOcean>::getConfiguration(
-        Configured<ConfiguredOcean>::keyMap.at(CURRENTU_KEY), u0);
-    v0 = Configured<ConfiguredOcean>::getConfiguration(
-        Configured<ConfiguredOcean>::keyMap.at(CURRENTV_KEY), v0);
+    sst0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(SST_KEY), sst0);
+    sss0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(SSS_KEY), sss0);
+    mld0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(MLD_KEY), mld0);
+    u0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(CURRENTU_KEY), u0);
+    v0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(CURRENTV_KEY), v0);
 
     // set the external SS* arrays as part of configuration, as opposed to at construction as normal
     getStore().registerArray(Protected::EXT_SST, &sstExt, RO);
@@ -113,6 +107,5 @@ void ConfiguredOcean::updateAfter(const TimestepTime& tst)
     slabOcean.update(tst);
     sst = ModelArrayRef<Protected::SLAB_SST, RO>(getStore()).data();
     sss = ModelArrayRef<Protected::SLAB_SSS, RO>(getStore()).data();
-
 }
 } /* namespace Nextsim */

--- a/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
@@ -28,7 +28,7 @@ static const std::string mldKey = pfx + ".mld";
 static const std::string uKey = pfx + ".current_u";
 static const std::string vKey = pfx + ".current_v";
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { ConfiguredOcean::SST_KEY, sstKey },
     { ConfiguredOcean::SSS_KEY, sssKey },
     { ConfiguredOcean::MLD_KEY, mldKey },
@@ -63,11 +63,11 @@ ConfigurationHelp::HelpMap& ConfiguredOcean::getHelpRecursive(HelpMap& map, bool
 
 void ConfiguredOcean::configure()
 {
-    sst0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(SST_KEY), sst0);
-    sss0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(SSS_KEY), sss0);
-    mld0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(MLD_KEY), mld0);
-    u0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(CURRENTU_KEY), u0);
-    v0 = Configured<ConfiguredOcean>::getConfiguration(localKeyMap.at(CURRENTV_KEY), v0);
+    sst0 = Configured<ConfiguredOcean>::getConfiguration(keyMap.at(SST_KEY), sst0);
+    sss0 = Configured<ConfiguredOcean>::getConfiguration(keyMap.at(SSS_KEY), sss0);
+    mld0 = Configured<ConfiguredOcean>::getConfiguration(keyMap.at(MLD_KEY), mld0);
+    u0 = Configured<ConfiguredOcean>::getConfiguration(keyMap.at(CURRENTU_KEY), u0);
+    v0 = Configured<ConfiguredOcean>::getConfiguration(keyMap.at(CURRENTV_KEY), v0);
 
     // set the external SS* arrays as part of configuration, as opposed to at construction as normal
     getStore().registerArray(Protected::EXT_SST, &sstExt, RO);

--- a/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
@@ -28,7 +28,7 @@ static const std::string mldKey = pfx + ".mld";
 static const std::string uKey = pfx + ".current_u";
 static const std::string vKey = pfx + ".current_v";
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { FluxConfiguredOcean::QIO_KEY, qioKey },
     { FluxConfiguredOcean::SST_KEY, sstKey },
     { FluxConfiguredOcean::SSS_KEY, sssKey },
@@ -59,12 +59,12 @@ ConfigurationHelp::HelpMap& FluxConfiguredOcean::getHelpRecursive(HelpMap& map, 
 
 void FluxConfiguredOcean::configure()
 {
-    qio0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(QIO_KEY), qio0);
-    sst0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(SST_KEY), sst0);
-    sss0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(SSS_KEY), sss0);
-    mld0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(MLD_KEY), mld0);
-    u0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(CURRENTU_KEY), u0);
-    v0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(CURRENTV_KEY), v0);
+    qio0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(QIO_KEY), qio0);
+    sst0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(SST_KEY), sst0);
+    sss0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(SSS_KEY), sss0);
+    mld0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(MLD_KEY), mld0);
+    u0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(CURRENTU_KEY), u0);
+    v0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(CURRENTV_KEY), v0);
 }
 
 void FluxConfiguredOcean::setData(const ModelState::DataMap& ms)

--- a/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
@@ -28,8 +28,7 @@ static const std::string mldKey = pfx + ".mld";
 static const std::string uKey = pfx + ".current_u";
 static const std::string vKey = pfx + ".current_v";
 
-template <>
-const std::map<int, std::string> Configured<FluxConfiguredOcean>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { FluxConfiguredOcean::QIO_KEY, qioKey },
     { FluxConfiguredOcean::SST_KEY, sstKey },
     { FluxConfiguredOcean::SSS_KEY, sssKey },
@@ -60,12 +59,12 @@ ConfigurationHelp::HelpMap& FluxConfiguredOcean::getHelpRecursive(HelpMap& map, 
 
 void FluxConfiguredOcean::configure()
 {
-    qio0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(QIO_KEY), qio0);
-    sst0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(SST_KEY), sst0);
-    sss0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(SSS_KEY), sss0);
-    mld0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(MLD_KEY), mld0);
-    u0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(CURRENTU_KEY), u0);
-    v0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(CURRENTV_KEY), v0);
+    qio0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(QIO_KEY), qio0);
+    sst0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(SST_KEY), sst0);
+    sss0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(SSS_KEY), sss0);
+    mld0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(MLD_KEY), mld0);
+    u0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(CURRENTU_KEY), u0);
+    v0 = Configured<FluxConfiguredOcean>::getConfiguration(localKeyMap.at(CURRENTV_KEY), v0);
 }
 
 void FluxConfiguredOcean::setData(const ModelState::DataMap& ms)

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -20,8 +20,7 @@ std::string TOPAZOcean::filePath;
 static const std::string pfx = "TOPAZOcean";
 static const std::string fileKey = pfx + ".file";
 
-template <>
-const std::map<int, std::string> Configured<TOPAZOcean>::keyMap = {
+static const std::map<int, std::string> localKeyMap = {
     { TOPAZOcean::FILEPATH_KEY, fileKey },
 };
 
@@ -43,7 +42,7 @@ ConfigurationHelp::HelpMap& TOPAZOcean::getHelpRecursive(HelpMap& map, bool getA
 
 void TOPAZOcean::configure()
 {
-    filePath = Configured::getConfiguration(keyMap.at(FILEPATH_KEY), std::string());
+    filePath = Configured::getConfiguration(localKeyMap.at(FILEPATH_KEY), std::string());
 
     slabOcean.configure();
 

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -20,7 +20,7 @@ std::string TOPAZOcean::filePath;
 static const std::string pfx = "TOPAZOcean";
 static const std::string fileKey = pfx + ".file";
 
-static const std::map<int, std::string> localKeyMap = {
+static const std::map<int, std::string> keyMap = {
     { TOPAZOcean::FILEPATH_KEY, fileKey },
 };
 
@@ -42,7 +42,7 @@ ConfigurationHelp::HelpMap& TOPAZOcean::getHelpRecursive(HelpMap& map, bool getA
 
 void TOPAZOcean::configure()
 {
-    filePath = Configured::getConfiguration(localKeyMap.at(FILEPATH_KEY), std::string());
+    filePath = Configured::getConfiguration(keyMap.at(FILEPATH_KEY), std::string());
 
     slabOcean.configure();
 


### PR DESCRIPTION
# Localize `Configured<>::keyMap`s

Fixes #614 (partially)

---
# Change Description

Nothing depends on the keyMap template member variable being a template member variable. Redefine each key map as `static` (compilation unit localized) `const std::map`. Since many classes are configured, this PR changes many files. Only the source `.cpp` files are affected.

---
# Test Description

Configuration tests still pass.
