### PR TITLE
Issue 614 Model Component

### DIFF
--- a/core/src/ModelComponent.cpp
+++ b/core/src/ModelComponent.cpp
@@ -12,7 +12,6 @@
 namespace Nextsim {
 
 ModelArray* ModelComponent::p_oceanMaskH = nullptr;
-std::vector<size_t> ModelComponent::oceanIndex;
 
 ModelComponent::ModelComponent() { noLandMask(); }
 
@@ -38,11 +37,11 @@ void ModelComponent::setOceanMask(const ModelArray& mask)
         if (oceanMaskH[i] > 0)
             ++nOcean;
     }
-    oceanIndex.resize(nOcean);
+    oceanIndex().resize(nOcean);
     size_t iOceanIndex = 0;
     for (size_t i = 0; i < ModelArray::size(ModelArray::Type::H); ++i) {
         if (oceanMaskH[i] > 0) {
-            oceanIndex[iOceanIndex++] = i;
+            oceanIndex(iOceanIndex++) = i;
         }
     }
 }
@@ -57,9 +56,9 @@ void ModelComponent::noLandMask()
     *p_oceanMaskH = 1.; // All ocean
 
     size_t nOcean = ModelArray::size(ModelArray::Type::H);
-    oceanIndex.resize(nOcean);
+    oceanIndex().resize(nOcean);
     for (size_t i = 0; i < ModelArray::size(ModelArray::Type::H); ++i) {
-        oceanIndex[i] = i;
+        oceanIndex(i) = i;
     }
 }
 
@@ -80,7 +79,7 @@ ModelArray ModelComponent::mask(const ModelArray& data)
         ModelArray copy = ModelArray::ZField();
         copy = MissingData::value();
         size_t nZ = data.dimensions()[data.nDimensions() - 1];
-        for (size_t i : oceanIndex) {
+        for (size_t i : oceanIndex()) {
             for (size_t k = 0; k < nZ; ++k) {
                 copy.zIndexAndLayer(i, k) = data.zIndexAndLayer(i, k);
             }

--- a/core/src/ModelComponent.cpp
+++ b/core/src/ModelComponent.cpp
@@ -11,42 +11,12 @@
 
 namespace Nextsim {
 
-std::unordered_map<std::string, ModelComponent*> ModelComponent::registeredModules;
 ModelArrayReferenceStore ModelComponent::store;
 ModelArray* ModelComponent::p_oceanMaskH = nullptr;
 size_t ModelComponent::nOcean;
 std::vector<size_t> ModelComponent::oceanIndex;
 
 ModelComponent::ModelComponent() { noLandMask(); }
-
-void ModelComponent::setAllModuleData(const ModelState& stateIn)
-{
-    for (auto entry : registeredModules) {
-        entry.second->setData(stateIn.data);
-    }
-}
-ModelState ModelComponent::getAllModuleState()
-{
-    ModelState overallState;
-    for (auto entry : registeredModules) {
-        overallState.data.merge(entry.second->getState().data);
-    }
-    return overallState;
-}
-
-void ModelComponent::registerModule() { registeredModules[getName()] = this; }
-
-void ModelComponent::unregisterAllModules() { registeredModules.clear(); }
-
-void ModelComponent::getAllFieldNames(std::unordered_set<std::string>& uF,
-    std::unordered_set<std::string>& vF, std::unordered_set<std::string>& zF)
-{
-    for (auto entry : registeredModules) {
-        uF.merge(entry.second->uFields());
-        vF.merge(entry.second->vFields());
-        zF.merge(entry.second->zFields());
-    }
-}
 
 /*
  * This assumes that the HField array size has already been set in the restart

--- a/core/src/ModelComponent.cpp
+++ b/core/src/ModelComponent.cpp
@@ -12,7 +12,6 @@
 namespace Nextsim {
 
 ModelArray* ModelComponent::p_oceanMaskH = nullptr;
-size_t ModelComponent::nOcean;
 std::vector<size_t> ModelComponent::oceanIndex;
 
 ModelComponent::ModelComponent() { noLandMask(); }
@@ -30,6 +29,8 @@ void ModelComponent::setOceanMask(const ModelArray& mask)
     ModelArray& oceanMaskH = *p_oceanMaskH;
     oceanMaskH.resize();
     oceanMaskH = mask;
+
+    size_t nOcean;
 
     // Generate the oceanIndex to grid index mapping
     // 1. Count the number of non-land squares
@@ -55,7 +56,7 @@ void ModelComponent::noLandMask()
     p_oceanMaskH->resize();
     *p_oceanMaskH = 1.; // All ocean
 
-    nOcean = ModelArray::size(ModelArray::Type::H);
+    size_t nOcean = ModelArray::size(ModelArray::Type::H);
     oceanIndex.resize(nOcean);
     for (size_t i = 0; i < ModelArray::size(ModelArray::Type::H); ++i) {
         oceanIndex[i] = i;
@@ -79,8 +80,7 @@ ModelArray ModelComponent::mask(const ModelArray& data)
         ModelArray copy = ModelArray::ZField();
         copy = MissingData::value();
         size_t nZ = data.dimensions()[data.nDimensions() - 1];
-        for (size_t iOcean = 0; iOcean < nOcean; ++iOcean) {
-            size_t i = oceanIndex[iOcean];
+        for (size_t i : oceanIndex) {
             for (size_t k = 0; k < nZ; ++k) {
                 copy.zIndexAndLayer(i, k) = data.zIndexAndLayer(i, k);
             }

--- a/core/src/ModelComponent.cpp
+++ b/core/src/ModelComponent.cpp
@@ -11,7 +11,6 @@
 
 namespace Nextsim {
 
-ModelArrayReferenceStore ModelComponent::store;
 ModelArray* ModelComponent::p_oceanMaskH = nullptr;
 size_t ModelComponent::nOcean;
 std::vector<size_t> ModelComponent::oceanIndex;

--- a/core/src/ModelComponent.cpp
+++ b/core/src/ModelComponent.cpp
@@ -7,14 +7,12 @@
 
 #include "include/ModelComponent.hpp"
 
-#include "include/gridNames.hpp"
 #include "include/MissingData.hpp"
+#include "include/gridNames.hpp"
 
 namespace Nextsim {
 
-ModelComponent::ModelComponent()
-{
-}
+ModelComponent::ModelComponent() { }
 
 void ModelComponent::setData(const ModelState::DataMap& state)
 {
@@ -34,7 +32,8 @@ void ModelComponent::setOceanMask(const ModelArray& mask)
     bool maskMatch = mask.trueSize() == oceanMaskInternal().trueSize();
 
     for (size_t i = 0; i < ModelArray::size(ModelArray::Type::H); ++i) {
-        if (!maskMatch) break;
+        if (!maskMatch)
+            break;
         maskMatch = (mask[i] == oceanMaskInternal(i));
     }
 

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -215,10 +215,7 @@ private:
         static std::vector<size_t> indices;
         return indices;
     }
-    static size_t& oceanIndex(size_t i)
-    {
-        return oceanIndex()[i];
-    }
+    static size_t& oceanIndex(size_t i) { return oceanIndex()[i]; }
 
     static ModelArray& oceanMaskInternal()
     {
@@ -226,10 +223,7 @@ private:
         return mask;
     }
 
-    static bool oceanMaskInternal(size_t i)
-    {
-        return oceanMaskInternal()[i];
-    }
+    static bool oceanMaskInternal(size_t i) { return oceanMaskInternal()[i]; }
 };
 
 } /* namespace Nextsim */

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -170,8 +170,8 @@ public:
 protected:
     inline static void overElements(IteratedFn fn, const TimestepTime& tst)
     {
-        for (size_t i = 0; i < nOcean; ++i) {
-            fn(oceanIndex[i], tst);
+        for (size_t i : oceanIndex) {
+            fn(i, tst);
         }
     }
 
@@ -209,7 +209,6 @@ private:
         return store;
     }
 
-    static size_t nOcean;
     static std::vector<size_t> oceanIndex;
 };
 

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -162,21 +162,12 @@ public:
     //! @brief Returns the names of all Type::Z ModelArrays defined in this component.
     virtual std::unordered_set<std::string> zFields() const { return {}; }
 
-    static void setAllModuleData(const ModelState& stateIn);
-    static ModelState getAllModuleState();
-    static void unregisterAllModules();
-
-    static void getAllFieldNames(std::unordered_set<std::string>& uF,
-        std::unordered_set<std::string>& vF, std::unordered_set<std::string>& zF);
-
     /*!
      * @brief Returns the ModelArrayRef backing store.
      */
     static ModelArrayReferenceStore& getStore() { return store; }
 
 protected:
-    void registerModule();
-
     inline static void overElements(IteratedFn fn, const TimestepTime& tst)
     {
         for (size_t i = 0; i < nOcean; ++i) {
@@ -213,7 +204,6 @@ protected:
 
 private:
     static ModelArrayReferenceStore store;
-    static std::unordered_map<std::string, ModelComponent*> registeredModules;
 
     static size_t nOcean;
     static std::vector<size_t> oceanIndex;

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -165,7 +165,7 @@ public:
     /*!
      * @brief Returns the ModelArrayRef backing store.
      */
-    static ModelArrayReferenceStore& getStore() { return store; }
+    static ModelArrayReferenceStore& getStore() { return store(); }
 
 protected:
     inline static void overElements(IteratedFn fn, const TimestepTime& tst)
@@ -203,7 +203,11 @@ protected:
     static ModelArray* p_oceanMaskH;
 
 private:
-    static ModelArrayReferenceStore store;
+    static ModelArrayReferenceStore& store()
+    {
+        static ModelArrayReferenceStore store;
+        return store;
+    }
 
     static size_t nOcean;
     static std::vector<size_t> oceanIndex;

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -117,9 +117,13 @@ public:
     /*!
      * @brief Set the initial data of the component from the passed ModelState.
      *
+     * @details The base class implementation will set the land mask if the 'mask' dataset is
+     * present. Otherwise no land mask will be set and noLandMask() must be called. Derived classes
+     * also set their own data in their polymorphic versions of this function.
+     *
      * @param state The ModelState containing the data to be set.
      */
-    virtual void setData(const ModelState::DataMap& state) = 0;
+    virtual void setData(const ModelState::DataMap& state);
     /*!
      * @brief Returns a ModelState from this component.
      *
@@ -199,9 +203,6 @@ protected:
      */
     static const ModelArray& oceanMask();
 
-protected:
-    static ModelArray* p_oceanMaskH;
-
 private:
     static ModelArrayReferenceStore& store()
     {
@@ -217,6 +218,17 @@ private:
     static size_t& oceanIndex(size_t i)
     {
         return oceanIndex()[i];
+    }
+
+    static ModelArray& oceanMaskInternal()
+    {
+        static ModelArray mask = ModelArray(ModelArray::Type::H);
+        return mask;
+    }
+
+    static bool oceanMaskInternal(size_t i)
+    {
+        return oceanMaskInternal()[i];
     }
 };
 

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -170,7 +170,7 @@ public:
 protected:
     inline static void overElements(IteratedFn fn, const TimestepTime& tst)
     {
-        for (size_t i : oceanIndex) {
+        for (size_t i : oceanIndex()) {
             fn(i, tst);
         }
     }
@@ -209,7 +209,15 @@ private:
         return store;
     }
 
-    static std::vector<size_t> oceanIndex;
+    static std::vector<size_t>& oceanIndex()
+    {
+        static std::vector<size_t> indices;
+        return indices;
+    }
+    static size_t& oceanIndex(size_t i)
+    {
+        return oceanIndex()[i];
+    }
 };
 
 } /* namespace Nextsim */

--- a/core/test/ModelArray_test.cpp
+++ b/core/test/ModelArray_test.cpp
@@ -297,6 +297,28 @@ TEST_CASE("zIndexAndLayer")
     REQUIRE(threeD.zIndexAndLayer(ind, z) == threeD(x, y, z));
 
 }
+
+TEST_CASE("Resizing on assignment")
+{
+    const size_t nx = 23;
+    const size_t ny = 19;
+
+    ModelArray::setDimension(ModelArray::Dimension::X, nx);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny);
+
+    TwoDField to(ModelArray::Type::TWOD);
+    REQUIRE(to.size() == nx * ny);
+    // Assignment from a scalar
+    to = 2.;
+    REQUIRE(to.trueSize() == nx * ny);
+
+    // Assignment from another ModelArray
+    TwoDField too(ModelArray::Type::TWOD);
+    REQUIRE(too.size() == nx * ny);
+    too = to;
+    REQUIRE(too.trueSize() == nx * ny);
+
+}
 TEST_SUITE_END();
 
 } /* namespace Nextsim */

--- a/core/test/ModelComponent_test.cpp
+++ b/core/test/ModelComponent_test.cpp
@@ -22,7 +22,9 @@ class HappyExcept : public std::runtime_error {
 
 class Module1 : public ModelComponent {
 public:
-    Module1() { registerModule(); }
+    Module1()
+    {
+    }
     std::string getName() const override { return "Module1"; }
     void setData(const ModelState::DataMap& st) override
     {
@@ -35,30 +37,12 @@ public:
     std::unordered_set<std::string> zFields() const override { return { "z1", "z2", "z3" }; }
 };
 
-TEST_CASE("Register a new module")
-{
-    Module1 m1;
-    REQUIRE_THROWS_AS(ModelComponent::setAllModuleData(ModelState()), HappyExcept);
-
-    std::unordered_set<std::string> uu;
-    std::unordered_set<std::string> vv;
-    std::unordered_set<std::string> zz;
-
-    ModelComponent::getAllFieldNames(uu, vv, zz);
-    REQUIRE(uu.size() == 1);
-    REQUIRE(vv.size() == 2);
-    REQUIRE(zz.size() == 3);
-
-    ModelComponent::unregisterAllModules();
-}
-
 class ModuleSupplyAndWait : public ModelComponent {
 public:
     ModuleSupplyAndWait()
         : hice(ModelArray::HField())
         , cice_ref(getStore())
     {
-        registerModule();
         getStore().registerArray(Protected::H_ICE, &hice, RO);
     }
     void setData(const ModelState::DataMap& ms) override { hice[0] = hiceData; }
@@ -86,7 +70,6 @@ public:
         : cice(ModelArray::HField())
         , hice_ref(getStore())
     {
-        registerModule();
         getStore().registerArray(Protected::C_ICE, &cice, RO);
     }
     void setData(const ModelState::DataMap& ms) override { cice[0] = ciceData; }
@@ -125,7 +108,6 @@ public:
         : qic(ModelArray::HField())
         , qio_ref(getStore())
     {
-        registerModule();
         getStore().registerArray(Shared::Q_IC, &qic, RW);
     }
     void setData(const ModelState::DataMap& ms) override { qic[0] = qicData; }
@@ -153,7 +135,6 @@ public:
         : qio(ModelArray::HField())
         , qic_ref(getStore())
     {
-        registerModule();
         getStore().registerArray(Shared::Q_IO, &qio, RW);
     }
     void setData(const ModelState::DataMap& ms) override { qio[0]; }

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -40,7 +40,6 @@ IceGrowth::IceGrowth()
     , tf(getStore())
     , deltaHi(getStore())
 {
-    registerModule();
     getStore().registerArray(Shared::H_ICE, &hice, RW);
     getStore().registerArray(Shared::C_ICE, &cice, RW);
     getStore().registerArray(Shared::H_SNOW, &hsnow, RW);

--- a/physics/src/modules/include/IIceThermodynamics.hpp
+++ b/physics/src/modules/include/IIceThermodynamics.hpp
@@ -65,8 +65,6 @@ protected:
         , snowfall(getStore())
         , sss(getStore())
     {
-        registerModule();
-
         getStore().registerArray(Shared::DELTA_HICE, &deltaHi, RW);
         getStore().registerArray(Shared::T_ICE, &tice, RW);
     }

--- a/physics/src/modules/include/ILateralIceSpread.hpp
+++ b/physics/src/modules/include/ILateralIceSpread.hpp
@@ -65,7 +65,6 @@ protected:
         , hsnow(getStore())
         , deltaHi(getStore())
     {
-        registerModule();
     }
 
     ModelArrayRef<Shared::C_ICE, RW> cice; // From IceGrowth


### PR DESCRIPTION
# Model Component static data
Fixes #614 (partially)

---
# Change Description

Removed all references to the `registerModule` and the data members it uses. Also remove `hField()` and similar functions, which don't now do anything, and were originally planned to be used alongside the module register.

Moved the `ModelArrayRefStore` to be lazily allocated.

Moved the ocean mask and ocean index look-up vector to be lazily allocated.

---
# Test Description

The `ModelComponent_test` still passes.

Adds some test to `ModelArray_test` to check sizes around assignment operations.
