### PR TITLE
Issue614 model component

### DIFF
--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -157,6 +157,7 @@ public:
         return os ? getState() : ModelState();
     }
 
+    /*
     //! @brief Returns the names of all Type::H ModelArrays defined in this component.
     virtual std::unordered_set<std::string> hFields() const { return {}; }
     //! @brief Returns the names of all Type::U ModelArrays defined in this component.
@@ -165,7 +166,7 @@ public:
     virtual std::unordered_set<std::string> vFields() const { return {}; }
     //! @brief Returns the names of all Type::Z ModelArrays defined in this component.
     virtual std::unordered_set<std::string> zFields() const { return {}; }
-
+*/
     /*!
      * @brief Returns the ModelArrayRef backing store.
      */
@@ -185,6 +186,7 @@ protected:
      *             0/false is land, >0 is sea.
      */
     static void setOceanMask(const ModelArray& mask);
+
     /*!
      * If there is no valid land mask, assume all points are ocean and
      * initialize accordingly.

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -172,6 +172,13 @@ public:
      */
     static ModelArrayReferenceStore& getStore() { return store(); }
 
+    /*!
+     * @brief Sets the model-wide land-ocean mask (for HField arrays).
+     * @param mask The HField ModelArray containing the mask data.
+     *             0/false is land, >0 is sea.
+     */
+    static void setOceanMask(const ModelArray& mask);
+
 protected:
     inline static void overElements(IteratedFn fn, const TimestepTime& tst)
     {
@@ -179,13 +186,6 @@ protected:
             fn(i, tst);
         }
     }
-
-    /*!
-     * @brief Sets the model-wide land-ocean mask (for HField arrays).
-     * @param mask The HField ModelArray containing the mask data.
-     *             0/false is land, >0 is sea.
-     */
-    static void setOceanMask(const ModelArray& mask);
 
     /*!
      * If there is no valid land mask, assume all points are ocean and

--- a/core/src/include/PrognosticData.hpp
+++ b/core/src/include/PrognosticData.hpp
@@ -41,14 +41,6 @@ public:
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
-    std::unordered_set<std::string> hFields() const override
-    {
-        return { "h_ice", "c_cice", "h_snow" };
-    };
-    std::unordered_set<std::string> uFields() const override { return { "u" }; }
-    std::unordered_set<std::string> vFields() const override { return { "v" }; }
-    std::unordered_set<std::string> zFields() const override { return { "tice" }; }
-
     /*!
      *  @brief Updates the state of the prognostic data for this timestep
      *

--- a/core/test/ModelComponent_test.cpp
+++ b/core/test/ModelComponent_test.cpp
@@ -32,9 +32,6 @@ public:
     }
     ModelState getState() const override { return ModelState(); }
     ModelState getState(const OutputLevel& lvl) const override { return getState(); }
-    std::unordered_set<std::string> uFields() const override { return { "u1" }; }
-    std::unordered_set<std::string> vFields() const override { return { "v1", "v2" }; }
-    std::unordered_set<std::string> zFields() const override { return { "z1", "z2", "z3" }; }
 };
 
 class ModuleSupplyAndWait : public ModelComponent {

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -69,8 +69,6 @@ ModelState SlabOcean::getState() const
 }
 ModelState SlabOcean::getState(const OutputLevel&) const { return getState(); }
 
-std::unordered_set<std::string> SlabOcean::hFields() const { return { sstSlabName, sssSlabName }; }
-
 void SlabOcean::update(const TimestepTime& tst)
 {
     double dt = tst.step.seconds();

--- a/physics/src/include/IceGrowth.hpp
+++ b/physics/src/include/IceGrowth.hpp
@@ -46,14 +46,6 @@ public:
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
-    std::unordered_set<std::string> hFields() const override
-    {
-        return { "updated_hice", "updated_cice", "updated_hsnow" };
-    }
-    std::unordered_set<std::string> uFields() const override { return {}; }
-    std::unordered_set<std::string> vFields() const override { return {}; }
-    std::unordered_set<std::string> zFields() const override { return {}; }
-
     void update(const TimestepTime&);
 
     static double minimumIceThickness() { return IceMinima::h(); }

--- a/physics/src/include/SlabOcean.hpp
+++ b/physics/src/include/SlabOcean.hpp
@@ -58,7 +58,6 @@ public:
     ModelState getState(const OutputLevel&) const override;
     std::string getName() const override { return "SlabOcean"; }
 
-    std::unordered_set<std::string> hFields() const override;
     void update(const TimestepTime&);
 
     static const double defaultRelaxationTime; // A default value for the relaxation time in s.

--- a/physics/test/ConstantOceanBoundary_test.cpp
+++ b/physics/test/ConstantOceanBoundary_test.cpp
@@ -12,6 +12,7 @@
 
 #include "include/ModelArrayRef.hpp"
 #include "include/ModelState.hpp"
+#include "include/gridNames.hpp"
 
 namespace Nextsim {
 
@@ -26,7 +27,10 @@ TEST_CASE("ConstantOcean Qio calculation")
     ModelComponent::getStore().registerArray(Protected::C_ICE, &cice, RO);
     ConstantOceanBoundary cob;
 
+    HField mask(ModelArray::Type::H);
+    mask = 1;
     cob.setData(ModelState::DataMap());
+    cob.setOceanMask(mask);
     cob.updateBefore(TimestepTime());
     ModelArrayRef<Shared::Q_IO, RW> qio(ModelComponent::getStore());
 


### PR DESCRIPTION
# Model Component static data
Fixes #614 (partially)

---
# Change Description

Remove `hField()` and similar functions, which don't now do anything, and were originally planned to be used alongside the module register.

Make `setOceanMask()` public.

---
# Test Description

The constant ocean boundary condition test now passes.