### PR TITLE
bugfix: relax cmake version to remove deprecated version

### DIFF
--- a/Dockerfiles/spack.yaml
+++ b/Dockerfiles/spack.yaml
@@ -5,7 +5,7 @@ spack:
   specs:
   - boost@1.80.0+log+program_options
   - catch2
-  - cmake@3.27.7
+  - 'cmake@3.20:'
   - eigen@3.4.0
   - gmake
   - hdf5@1.14.3

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,7 +5,7 @@ spack:
   specs:
   - boost@1.80.0+log+program_options
   - catch2
-  - cmake@3.27.7
+  - 'cmake@3.20:'
   - eigen@3.4.0
   - gmake
   - hdf5@1.14.3


### PR DESCRIPTION
Fixes #706 

relax `cmake` version in `spack.yaml` files from `cmake@3.27.7` to `cmake@3.20:`.

The syntax means any version greater than `3.20`. This will help because `spack` recently deprecated many `cmake` versions including `3.27.7`

(related to discussion #705 )


