### PR TITLE
Zero out the high DG components when setting forcing data.

### DIFF
--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -66,18 +66,22 @@ void CGDynamicsKernel<DGadvection>::setData(const std::string& name, const Model
         Nextsim::Interpolations::DG2CG(*smesh, v, vtmp);
     } else if (name == uWindName) {
         DGVector<DGadvection> utmp(*smesh);
+        utmp.zero();
         DGModelArray::ma2dg(data, utmp);
         Nextsim::Interpolations::DG2CG(*smesh, uAtmos, utmp);
     } else if (name == vWindName) {
         DGVector<DGadvection> vtmp(*smesh);
+        vtmp.zero();
         DGModelArray::ma2dg(data, vtmp);
         Nextsim::Interpolations::DG2CG(*smesh, vAtmos, vtmp);
     } else if (name == uOceanName) {
         DGVector<DGadvection> utmp(*smesh);
+        utmp.zero();
         DGModelArray::ma2dg(data, utmp);
         Nextsim::Interpolations::DG2CG(*smesh, uOcean, utmp);
     } else if (name == vOceanName) {
         DGVector<DGadvection> vtmp(*smesh);
+        vtmp.zero();
         DGModelArray::ma2dg(data, vtmp);
         Nextsim::Interpolations::DG2CG(*smesh, vOcean, vtmp);
     } else {

--- a/dynamics/src/include/DynamicsKernel.hpp
+++ b/dynamics/src/include/DynamicsKernel.hpp
@@ -107,6 +107,7 @@ public:
         } else if (name == ciceName) {
             DGModelArray::ma2dg(data, cice);
         } else if (name == sshName) {
+            seaSurfaceHeight.zero();
             DGModelArray::ma2dg(data, seaSurfaceHeight);
         } else {
             // All other fields get shoved in a (labelled) bucket


### PR DESCRIPTION
# Zero out the high DG components when setting forcing data.

Fixes #711

---
# Change Description

Zero out DG arrays before copying in DG0 forcing data. This should not be done with prognostic fields as it will wipe out the higher DG components.
