### PR TITLE
No sea surface height

### DIFF
--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -248,7 +248,9 @@ ModelState ParaGridIO::readForcingTimeStatic(
         auto availableForcings = dataGroup.getVars();
         for (const std::string& varName : forcings) {
             // Don't try to read non-existent data
-            if (!availableForcings.count(varName)) continue;
+            if (!availableForcings.count(varName)) {
+                continue;
+            }
             netCDF::NcVar var = dataGroup.getVar(varName);
             state.data[varName] = ModelArray(ModelArray::Type::H);
             ModelArray& data = state.data.at(varName);

--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -245,7 +245,10 @@ ModelState ParaGridIO::readForcingTimeStatic(
             extentArray.push_back(ModelArray::definedDimensions.at(*riter).localLength);
         }
 
+        auto availableForcings = dataGroup.getVars();
         for (const std::string& varName : forcings) {
+            // Don't try to read non-existent data
+            if (!availableForcings.count(varName)) continue;
             netCDF::NcVar var = dataGroup.getVar(varName);
             state.data[varName] = ModelArray(ModelArray::Type::H);
             ModelArray& data = state.data.at(varName);

--- a/core/src/include/gridNames.hpp
+++ b/core/src/include/gridNames.hpp
@@ -30,6 +30,8 @@ static const std::string vWindName = "vwind";
 static const std::string uOceanName = "uocean";
 static const std::string vOceanName = "vocean";
 static const std::string sshName = "ssh";
+// Mixed layer depth
+static const std::string mldName = "mld";
 
 static const std::string uIOStressName = "uiostress";
 static const std::string vIOStressName = "viostress";

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file TOPAZOcean.cpp
  *
- * @date 24 Sep 2024
+ * @date 17 Oct 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -12,6 +12,7 @@
 #include "include/Module.hpp"
 #include "include/ParaGridIO.hpp"
 #include "include/constants.hpp"
+#include "include/gridnames.hpp"
 
 namespace Nextsim {
 
@@ -54,16 +55,16 @@ void TOPAZOcean::configure()
 void TOPAZOcean::updateBefore(const TimestepTime& tst)
 {
     // TODO: Get more authoritative names for the forcings
-    std::set<std::string> forcings = { "sst", "sss", "mld", "u", "v", "ssh" };
+    std::set<std::string> forcings = { sstName, sssName, "mld", uName, vName, sshName };
 
     ModelState state = ParaGridIO::readForcingTimeStatic(forcings, tst.start, filePath);
-    sstExt = state.data.at("sst");
-    sssExt = state.data.at("sss");
-    mld = state.data.at("mld");
-    u = state.data.at("u");
-    v = state.data.at("v");
-    if (state.data.count("ssh")) {
-        ssh = state.data.at("ssh");
+    sstExt = state.data.at(sstName);
+    sssExt = state.data.at(sssName);
+    mld = state.data.at(mldName);
+    u = state.data.at(uName);
+    v = state.data.at(vName);
+    if (state.data.count(sshName)) {
+        ssh = state.data.at(sshName);
     } else {
         ssh = 0.;
     }

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -12,7 +12,7 @@
 #include "include/Module.hpp"
 #include "include/ParaGridIO.hpp"
 #include "include/constants.hpp"
-#include "include/gridnames.hpp"
+#include "include/gridNames.hpp"
 
 namespace Nextsim {
 

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -62,7 +62,11 @@ void TOPAZOcean::updateBefore(const TimestepTime& tst)
     mld = state.data.at("mld");
     u = state.data.at("u");
     v = state.data.at("v");
-    ssh = state.data.at("ssh");
+    if (state.data.count("ssh")) {
+        ssh = state.data.at("ssh");
+    } else {
+        ssh = 0.;
+    }
 
     cpml = Water::rho * Water::cp * mld;
     overElements(


### PR DESCRIPTION
# No sea surface height

Fixes #714

---
# Change Description

The function that reads forcing files in `ParaGridIO` now check that fields exist in the forcings file before trying to read them. Absent fields are not added to the returned `ModelState` object and the absence of sea surface height is now handled by `TOPAZOcean` by setting the sea surface height field to 0 everywhere.
 