### PR TITLE
Fix a bug in BBM by adding a +1 to Pmax

### DIFF
--- a/dynamics/src/include/BBMStressUpdateStep.hpp
+++ b/dynamics/src/include/BBMStressUpdateStep.hpp
@@ -86,8 +86,8 @@ public:
 
             //! BBM  Computing tildeP according to (Eqn. 7b and Eqn. 8)
             // (Eqn. 8)
-            const Eigen::Matrix<double, 1, nGauss * nGauss> Pmax
-                = params.P0 * hGauss.array().pow(params.exponent_compression_factor) * expC.array();
+            const Eigen::Matrix<double, 1, nGauss * nGauss> Pmax = params.P0
+                * hGauss.array().pow(params.exponent_compression_factor + 1.) * expC.array();
 
             // (Eqn. 7b) Prepare tildeP
             // tildeP must be capped at 1 to get an elastic response


### PR DESCRIPTION
# Fix a bug in BBM by adding a +1 to Pmax

Fixes partially #717

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

We need to add a + 1 to the Pmax equation, because we're using the integrated stress now (so everything's multiplied with h). The correct equation is

P_{max} =h [ P_0 h^f e^{-C(1-A)} ]  = P_0 h^{f+1} e^{-C(1-A),

which differs from equation (8) of Ólason et al. (2022) by factor h (or a +1).

---
# Test Description

The benchmark test case now gives more reasonable results, but more work is required. See issue #717.

---
# Documentation Impact

N/A

---
# Other Details

N/A

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
