### PR TITLE
Issue716 memory leaks in dynamics

### DIFF
--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -26,7 +26,7 @@ void CGDynamicsKernel<DGadvection>::initialise(
     DynamicsKernel<DGadvection, DGstressComp>::initialise(coords, isSpherical, mask);
 
     //! Initialize the parametric momentum map
-    pmap = new ParametricMomentumMap<CGdegree>(*smesh);
+    pmap = std::make_unique<ParametricMomentumMap<CGdegree, DGadvection>>(*smesh);
     pmap->InitializeLumpedCGMassMatrix();
     pmap->InitializeDivSMatrices();
 

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -26,7 +26,7 @@ void CGDynamicsKernel<DGadvection>::initialise(
     DynamicsKernel<DGadvection, DGstressComp>::initialise(coords, isSpherical, mask);
 
     //! Initialize the parametric momentum map
-    pmap = std::make_unique<ParametricMomentumMap<CGdegree, DGadvection>>(*smesh);
+    pmap = std::make_unique<ParametricMomentumMap<CGdegree>>(*smesh);
     pmap->InitializeLumpedCGMassMatrix();
     pmap->InitializeDivSMatrices();
 

--- a/dynamics/src/include/BBMDynamicsKernel.hpp
+++ b/dynamics/src/include/BBMDynamicsKernel.hpp
@@ -32,7 +32,7 @@ public:
     void initialise(const ModelArray& coords, bool isSpherical, const ModelArray& mask) override
     {
         BrittleCGDynamicsKernel<DGadvection>::initialise(coords, isSpherical, mask);
-        bbmStressStep.setPMap(pmap);
+        bbmStressStep.setPMap(pmap.get());
         bbmStressStep.setDamage(damage);
     }
 

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -71,7 +71,7 @@ public:
         CGDynamicsKernel<DGadvection>::initialise(coords, isSpherical, mask);
 
         //! Initialize stress transport
-        stresstransport = new Nextsim::DGTransport<DGstressComp>(*smesh);
+        stresstransport = std::make_unique<Nextsim::DGTransport<DGstressComp>>(*smesh);
         stresstransport->settimesteppingscheme("rk2");
 
         damage.resize_by_mesh(*smesh);
@@ -169,7 +169,7 @@ protected:
     StressUpdateStep<DGadvection, DGstressComp>& stressStep;
     const MEBParameters& params;
 
-    Nextsim::DGTransport<DGstressComp>* stresstransport;
+    std::unique_ptr<DGTransport<DGstressComp>> stresstransport;
 
     DGVector<DGadvection> damage;
 

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -36,9 +36,7 @@ protected:
     using typename DynamicsKernel<DGadvection, DGstressComp>::DataMap;
 
 public:
-    CGDynamicsKernel()
-    {
-    }
+    CGDynamicsKernel() { }
     virtual ~CGDynamicsKernel() = default;
     void initialise(const ModelArray& coords, bool isSpherical, const ModelArray& mask) override;
     void setData(const std::string& name, const ModelArray& data) override;

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -73,7 +73,7 @@ protected:
     CGVector<CGdegree> uAtmos;
     CGVector<CGdegree> vAtmos;
 
-    ParametricMomentumMap<CGdegree>* pmap;
+    std::unique_ptr<ParametricMomentumMap<CGdegree, DGadvection>> pmap;
 };
 
 } /* namespace Nextsim */

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -37,7 +37,6 @@ protected:
 
 public:
     CGDynamicsKernel()
-        : pmap(nullptr)
     {
     }
     virtual ~CGDynamicsKernel() = default;
@@ -73,7 +72,7 @@ protected:
     CGVector<CGdegree> uAtmos;
     CGVector<CGdegree> vAtmos;
 
-    std::unique_ptr<ParametricMomentumMap<CGdegree, DGadvection>> pmap;
+    std::unique_ptr<ParametricMomentumMap<CGdegree>> pmap;
 };
 
 } /* namespace Nextsim */

--- a/dynamics/src/include/DynamicsKernel.hpp
+++ b/dynamics/src/include/DynamicsKernel.hpp
@@ -25,6 +25,7 @@
 #include "include/gridNames.hpp"
 
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
 #include <unordered_map>
@@ -44,7 +45,8 @@ public:
     virtual void initialise(const ModelArray& coords, bool isSpherical, const ModelArray& mask)
     {
         //! Define the spatial mesh
-        smesh = new ParametricMesh((isSpherical) ? Nextsim::SPHERICAL : Nextsim::CARTESIAN);
+        smesh = std::make_unique<ParametricMesh>(
+            (isSpherical) ? Nextsim::SPHERICAL : Nextsim::CARTESIAN);
 
         smesh->coordinatesFromModelArray(coords);
         if (isSpherical)
@@ -57,7 +59,7 @@ public:
         }
 
         //! Initialize transport
-        dgtransport = new Nextsim::DGTransport<DGadvection>(*smesh);
+        dgtransport = std::make_unique<Nextsim::DGTransport<DGadvection>>(*smesh);
         dgtransport->settimesteppingscheme("rk2");
 
         // resize DG vectors
@@ -167,7 +169,7 @@ public:
     }
 
 protected:
-    Nextsim::DGTransport<DGadvection>* dgtransport;
+    std::unique_ptr<Nextsim::DGTransport<DGadvection>> dgtransport;
 
     DGVector<DGadvection> hice;
     DGVector<DGadvection> cice;
@@ -182,7 +184,7 @@ protected:
 
     double deltaT;
 
-    Nextsim::ParametricMesh* smesh;
+    std::unique_ptr<Nextsim::ParametricMesh> smesh;
 
     virtual void updateMomentum(const TimestepTime& tst) = 0;
 

--- a/dynamics/src/include/MEVPDynamicsKernel.hpp
+++ b/dynamics/src/include/MEVPDynamicsKernel.hpp
@@ -27,7 +27,7 @@ public:
     void initialise(const ModelArray& coords, bool isSpherical, const ModelArray& mask) override
     {
         CGDynamicsKernel<DGadvection>::initialise(coords, isSpherical, mask);
-        MEVPStressStep.setPMap(pmap);
+        MEVPStressStep.setPMap(pmap.get());
     }
 
 private:


### PR DESCRIPTION
# memory leaks in dynamics

Fixes #716 

# Change Description

With #674 integrated, all dynamic buffers held by modules should get freed before the program terminates. This update replaces raw pointers with `std::unique_ptr` for heap buffers that are used internally by the dynamics.

# Test Description
A manual test was done by running  the dynamics benchmark for 1 time step with valgrind:
```
==74249== LEAK SUMMARY:
==74249==    definitely lost: 0 bytes in 0 blocks
==74249==    indirectly lost: 0 bytes in 0 blocks
==74249==      possibly lost: 7,600 bytes in 19 blocks
==74249==    still reachable: 110,406 bytes in 717 blocks
==74249==         suppressed: 0 bytes in 0 blocks

```

The setup that was used is not suited for an automated test as it is takes too long (init + 1 step on 32x32 grid takes upwards of 30mins).


