### PR TITLE
Prepare for setting XIOS up via nextSIM-DG

### DIFF
--- a/core/src/ModelArray.cpp
+++ b/core/src/ModelArray.cpp
@@ -1,7 +1,7 @@
 /*!
- * @file ModelData.cpp
+ * @file   ModelArray.cpp
  *
- * @date Feb 24, 2022
+ * @date   Feb 24, 2022
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/src/ModelArray.cpp
+++ b/core/src/ModelArray.cpp
@@ -203,6 +203,9 @@ void ModelArray::setNComponents(std::map<Type, size_t> cMap)
 #ifdef USE_MPI
 void ModelArray::setDimension(Dimension dim, size_t globalLength, size_t localLength, size_t start)
 {
+    if ((dim == ModelArray::Dimension::Z) && (globalLength != localLength)) {
+        throw std::invalid_argument("Parallelism in the vertical not supported.");
+    }
     definedDimensions.at(dim).setLengths(globalLength, localLength, start);
 #else
 void ModelArray::setDimension(Dimension dim, size_t globalLength)

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -125,7 +125,7 @@ int Xios::getClientMPIRank() { return mpi_rank; }
  */
 bool Xios::isInitialized()
 {
-    bool init { false };
+    bool init = false;
     cxios_context_is_initialized(contextId.c_str(), contextId.length(), &init);
     return init;
 }
@@ -327,7 +327,7 @@ void Xios::updateCalendar(const int stepNumber) { cxios_update_calendar(stepNumb
  */
 xios::CAxisGroup* Xios::getAxisGroup()
 {
-    const std::string groupId = { "axis_definition" };
+    const std::string groupId = "axis_definition";
     xios::CAxisGroup* group = NULL;
     cxios_axisgroup_handle_create(&group, groupId.c_str(), groupId.length());
     if (!group) {
@@ -467,7 +467,7 @@ std::vector<double> Xios::getAxisValues(const std::string axisId)
  */
 xios::CDomainGroup* Xios::getDomainGroup()
 {
-    const std::string groupId = { "domain_definition" };
+    const std::string groupId = "domain_definition";
     xios::CDomainGroup* group = NULL;
     cxios_domaingroup_handle_create(&group, groupId.c_str(), groupId.length());
     if (!group) {
@@ -862,7 +862,7 @@ std::vector<double> Xios::getDomainLocalYValues(const std::string domainId)
  */
 xios::CGridGroup* Xios::getGridGroup()
 {
-    const std::string groupId = { "grid_definition" };
+    const std::string groupId = "grid_definition";
     xios::CGridGroup* group = NULL;
     cxios_gridgroup_handle_create(&group, groupId.c_str(), groupId.length());
     if (!group) {
@@ -1003,7 +1003,7 @@ std::vector<std::string> Xios::gridGetDomainIds(const std::string gridId)
  */
 xios::CFieldGroup* Xios::getFieldGroup()
 {
-    const std::string groupId = { "field_definition" };
+    const std::string groupId = "field_definition";
     xios::CFieldGroup* group = NULL;
     cxios_fieldgroup_handle_create(&group, groupId.c_str(), groupId.length());
     if (!group) {
@@ -1241,7 +1241,7 @@ Duration Xios::getFieldFreqOffset(const std::string fieldId)
  */
 xios::CFileGroup* Xios::getFileGroup()
 {
-    const std::string groupId = { "file_definition" };
+    const std::string groupId = "file_definition";
     xios::CFileGroup* group = NULL;
     cxios_filegroup_handle_create(&group, groupId.c_str(), groupId.length());
     if (!group) {

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -18,7 +18,6 @@
 #include <boost/date_time/posix_time/time_parsers.hpp>
 #if USE_XIOS
 
-#include "include/ModelArray.hpp"
 #include "include/Xios.hpp"
 
 #include <boost/algorithm/string.hpp>

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -2,7 +2,7 @@
  * @file    Xios.cpp
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    21 August 2024
+ * @date    01 Nov 2024
  * @brief   XIOS interface implementation
  * @details
  *
@@ -357,7 +357,10 @@ xios::CAxis* Xios::getAxis(const std::string axisId)
 }
 
 /*!
- * Create an axis with some ID
+ * Create an axis with some ID.
+ *
+ * If the axis ID is 'z_axis' and a domain called 'xy_domain' exists then a grid called 'grid_3D'
+ * will automatically be created with this axis and that domain.
  *
  * @param the axis ID
  */
@@ -376,6 +379,15 @@ void Xios::createAxis(const std::string axisId)
     cxios_axis_valid_id(&exists, axisId.c_str(), axisId.length());
     if (!exists) {
         throw std::runtime_error("Xios: Failed to create axis '" + axisId + "'");
+    }
+    if (axisId == "z_axis") {
+        std::string domainId = "xy_domain";
+        cxios_domain_valid_id(&exists, domainId.c_str(), domainId.length());
+        if (exists) {
+            createGrid("grid_3D");
+            gridAddDomain("grid_3D", "xy_domain");
+            gridAddAxis("grid_3D", "z_axis");
+        }
     }
 }
 
@@ -497,7 +509,11 @@ xios::CDomain* Xios::getDomain(const std::string domainId)
 }
 
 /*!
- * Create a domain with some ID
+ * Create a domain with some ID.
+ *
+ * If the domain ID is 'xy_domain' then a grid called 'grid_2D' will automatically be created with
+ * this domain. If an axis called 'z_axis' also exists then a grid called 'grid_3D' will
+ * automatically be created with this domain and that axis.
  *
  * @param the domain ID
  */
@@ -516,6 +532,17 @@ void Xios::createDomain(const std::string domainId)
     cxios_domain_valid_id(&exists, domainId.c_str(), domainId.length());
     if (!exists) {
         throw std::runtime_error("Xios: Failed to create domain '" + domainId + "'");
+    }
+    if (domainId == "xy_domain") {
+        createGrid("grid_2D");
+        gridAddDomain("grid_2D", "xy_domain");
+        std::string axisId = "z_axis";
+        cxios_axis_valid_id(&exists, axisId.c_str(), axisId.length());
+        if (exists) {
+            createGrid("grid_3D");
+            gridAddDomain("grid_3D", "xy_domain");
+            gridAddAxis("grid_3D", "z_axis");
+        }
     }
 }
 

--- a/core/src/include/ModelArray.hpp
+++ b/core/src/include/ModelArray.hpp
@@ -1,7 +1,7 @@
 /*!
- * @file ModelData.hpp
+ * @file   ModelArray.hpp
  *
- * @date Feb 24, 2022
+ * @date   31 Oct 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosGrid_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    5 August 2024
+ * @date    01 Nov 2024
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -48,18 +48,18 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     xios_handler.setCalendarTimestep(Duration("P0-0T01:30:00"));
 
     // Create a 4x2 horizontal domain with a partition halving the x-extent
-    xios_handler.createDomain("xy_domain");
-    xios_handler.setDomainType("xy_domain", "rectilinear");
-    xios_handler.setDomainGlobalXSize("xy_domain", 4);
-    xios_handler.setDomainGlobalYSize("xy_domain", 2);
-    xios_handler.setDomainLocalXStart("xy_domain", 2 * rank);
-    xios_handler.setDomainLocalYStart("xy_domain", 0);
-    xios_handler.setDomainLocalXValues("xy_domain", { -1.0 + rank, -0.5 + rank });
-    xios_handler.setDomainLocalYValues("xy_domain", { -1.0, 1.0 });
+    xios_handler.createDomain("domain_XY");
+    xios_handler.setDomainType("domain_XY", "rectilinear");
+    xios_handler.setDomainGlobalXSize("domain_XY", 4);
+    xios_handler.setDomainGlobalYSize("domain_XY", 2);
+    xios_handler.setDomainLocalXStart("domain_XY", 2 * rank);
+    xios_handler.setDomainLocalYStart("domain_XY", 0);
+    xios_handler.setDomainLocalXValues("domain_XY", { -1.0 + rank, -0.5 + rank });
+    xios_handler.setDomainLocalYValues("domain_XY", { -1.0, 1.0 });
 
     // Create a vertical axis with 2 points
-    xios_handler.createAxis("z_axis");
-    xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
+    xios_handler.createAxis("axis_Z");
+    xios_handler.setAxisValues("axis_Z", { 0.0, 1.0 });
 
     // --- Tests for grid API
     const std::string gridId = { "grid_2D" };
@@ -73,15 +73,15 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     xios_handler.setGridName(gridId, gridName);
     REQUIRE(xios_handler.getGridName(gridId) == gridName);
     // Add axis
-    xios_handler.gridAddAxis("grid_2D", "z_axis");
+    xios_handler.gridAddAxis("grid_2D", "axis_Z");
     std::vector<std::string> axisIds = xios_handler.gridGetAxisIds(gridId);
     REQUIRE(axisIds.size() == 1);
-    REQUIRE(axisIds[0] == "z_axis");
+    REQUIRE(axisIds[0] == "axis_Z");
     // Add domain
-    xios_handler.gridAddDomain("grid_2D", "xy_domain");
+    xios_handler.gridAddDomain("grid_2D", "domain_XY");
     std::vector<std::string> domainIds = xios_handler.gridGetDomainIds(gridId);
     REQUIRE(domainIds.size() == 1);
-    REQUIRE(domainIds[0] == "xy_domain");
+    REQUIRE(domainIds[0] == "domain_XY");
 
     xios_handler.close_context_definition();
     xios_handler.context_finalize();

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -87,14 +87,6 @@ MPI_TEST_CASE("TestXiosRead", 2)
     xios_handler.createAxis("z_axis");
     xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
 
-    // Create a 2D grid comprised of the xy-domain and a 3D grid which also includes the z-axis
-    // TODO: Create grid_2D along with xy_domain, grid_3D along with xy_domain plus z_axis
-    xios_handler.createGrid("grid_2D");
-    xios_handler.gridAddDomain("grid_2D", "xy_domain");
-    xios_handler.createGrid("grid_3D");
-    xios_handler.gridAddDomain("grid_3D", "xy_domain");
-    xios_handler.gridAddAxis("grid_3D", "z_axis");
-
     // Create some fake data to test writing methods
     HField field_2D(ModelArray::Type::H);
     field_2D.resize();
@@ -105,12 +97,12 @@ MPI_TEST_CASE("TestXiosRead", 2)
     // TODO: Create field along with HField
     xios_handler.createField("field_2D");
     xios_handler.setFieldOperation("field_2D", "instant");
-    xios_handler.setFieldGridRef("field_2D", "grid_2D");
+    xios_handler.setFieldGridRef("field_2D", "grid_2D"); // NOTE: grid_2D auto-generated
     xios_handler.setFieldReadAccess("field_2D", true);
     xios_handler.setFieldFreqOffset("field_2D", timestep);
     xios_handler.createField("field_3D");
     xios_handler.setFieldOperation("field_3D", "instant");
-    xios_handler.setFieldGridRef("field_3D", "grid_3D");
+    xios_handler.setFieldGridRef("field_3D", "grid_3D"); // NOTE: grid_3D auto-generated
     xios_handler.setFieldReadAccess("field_3D", true);
     xios_handler.setFieldFreqOffset("field_3D", timestep);
 

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosRead_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    21 August 2024
+ * @date    31 Oct 2024
  * @brief   Tests for XIOS read method
  * @details
  * This test is designed to test the read method of the C++ interface

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosRead_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk
- * @date    31 Oct 2024
+ * @date    01 Nov 2024
  * @brief   Tests for XIOS read method
  * @details
  * This test is designed to test the read method of the C++ interface
@@ -41,7 +41,14 @@ MPI_TEST_CASE("TestXiosRead", 2)
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
+    // Create ParametricGrid and ParaGridIO instances
+    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
+    ParametricGrid grid;
+    ParaGridIO* pio = new ParaGridIO(grid);
+    grid.setIO(pio);
+
     // Initialize an Xios instance called xios_handler
+    // TODO: Create XIOS handler along with ParaGridIO instance
     Xios xios_handler;
     REQUIRE(xios_handler.isInitialized());
     const size_t size = xios_handler.getClientMPISize();
@@ -54,28 +61,48 @@ MPI_TEST_CASE("TestXiosRead", 2)
     Duration timestep("P0-0T01:30:00");
     xios_handler.setCalendarTimestep(timestep);
 
+    // Set ModelArray dimensions
+    const size_t nx_glo = 4;
+    const size_t ny_glo = 2;
+    const size_t nx = 2;
+    const size_t ny = 2;
+    const size_t nz = 2;
+    ModelArray::setDimension(ModelArray::Dimension::X, nx_glo, nx, 0);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny_glo, ny, 0);
+    ModelArray::setDimension(ModelArray::Dimension::Z, nz, nz, 0);
+
     // Create a 4x2 horizontal domain with a partition halving the x-extent
+    // TODO: Set local and global domain sizes upon calling ModelArray::setDimension for X and Y
     xios_handler.createDomain("xy_domain");
     xios_handler.setDomainType("xy_domain", "rectilinear");
-    xios_handler.setDomainGlobalXSize("xy_domain", 4);
-    xios_handler.setDomainGlobalYSize("xy_domain", 2);
+    xios_handler.setDomainGlobalXSize("xy_domain", nx_glo);
+    xios_handler.setDomainGlobalYSize("xy_domain", ny_glo);
     xios_handler.setDomainLocalXStart("xy_domain", 2 * rank);
     xios_handler.setDomainLocalYStart("xy_domain", 0);
     xios_handler.setDomainLocalXValues("xy_domain", { -1.0 + rank, -0.5 + rank });
     xios_handler.setDomainLocalYValues("xy_domain", { -1.0, 1.0 });
 
     // Create a vertical axis with 2 points
+    // TODO: Set axis size upon calling ModelArray::setDimension for Z
     xios_handler.createAxis("z_axis");
     xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
 
     // Create a 2D grid comprised of the xy-domain and a 3D grid which also includes the z-axis
+    // TODO: Create grid_2D along with xy_domain, grid_3D along with xy_domain plus z_axis
     xios_handler.createGrid("grid_2D");
     xios_handler.gridAddDomain("grid_2D", "xy_domain");
     xios_handler.createGrid("grid_3D");
     xios_handler.gridAddDomain("grid_3D", "xy_domain");
     xios_handler.gridAddAxis("grid_3D", "z_axis");
 
+    // Create some fake data to test writing methods
+    HField field_2D(ModelArray::Type::H);
+    field_2D.resize();
+    HField field_3D(ModelArray::Type::Z);
+    field_3D.resize();
+
     // Field setup
+    // TODO: Create field along with HField
     xios_handler.createField("field_2D");
     xios_handler.setFieldOperation("field_2D", "instant");
     xios_handler.setFieldGridRef("field_2D", "grid_2D");
@@ -96,30 +123,9 @@ MPI_TEST_CASE("TestXiosRead", 2)
     xios_handler.fileAddField("xios_test_input", "field_2D");
     xios_handler.fileAddField("xios_test_input", "field_3D");
 
-    // Set ModelArray dimensions
-    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-    const size_t nx = xios_handler.getDomainLocalXSize("xy_domain");
-    const size_t ny = xios_handler.getDomainLocalYSize("xy_domain");
-    const size_t nz = xios_handler.getAxisSize("z_axis");
-    ModelArray::setDimension(
-        ModelArray::Dimension::X, xios_handler.getDomainGlobalXSize("xy_domain"), nx, 0);
-    ModelArray::setDimension(
-        ModelArray::Dimension::Y, xios_handler.getDomainGlobalYSize("xy_domain"), ny, 0);
-    ModelArray::setDimension(ModelArray::Dimension::Z, nz, nz, 0);
-
-    // Create ParametricGrid and ParaGridIO instances
-    ParametricGrid grid;
-    ParaGridIO* pio = new ParaGridIO(grid);
-    grid.setIO(pio);
-
     xios_handler.close_context_definition();
 
     // --- Tests for reading to file
-    // Create some fake data to test writing methods
-    HField field_2D(ModelArray::Type::H);
-    field_2D.resize();
-    HField field_3D(ModelArray::Type::Z);
-    field_3D.resize();
     // Verify calendar step is starting from zero
     REQUIRE(xios_handler.getCalendarStep() == 0);
     // Check the input file exists

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -112,13 +112,15 @@ MPI_TEST_CASE("TestXiosRead", 2)
     xios_handler.fileAddField("xios_test_input", "field_3D");
     xios_handler.fileAddField("xios_test_input", "field_4D");
 
-    xios_handler.close_context_definition();
-
-    // --- Tests for reading to file
+    // Set ModelArray dimensions
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
     ModelArray::setDimension(ModelArray::Dimension::X, n1, n1, 0);
     ModelArray::setDimension(ModelArray::Dimension::Y, n2, n2, 0);
     ModelArray::setDimension(ModelArray::Dimension::Z, n3, n3, 0);
+
+    xios_handler.close_context_definition();
+
+    // --- Tests for reading to file
     // Create some fake data to test writing methods
     HField field_2D(ModelArray::Type::H);
     field_2D.resize();

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -14,6 +14,7 @@
 #include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Configurator.hpp"
 #include "include/NextsimModule.hpp"
+#include "include/ParaGridIO.hpp"
 #include "include/Xios.hpp"
 
 #include <filesystem>
@@ -53,37 +54,26 @@ MPI_TEST_CASE("TestXiosRead", 2)
     Duration timestep("P0-0T01:30:00");
     xios_handler.setCalendarTimestep(timestep);
 
-    // Axis setup
-    const int n1 = 2;
-    const int n2 = 3;
-    const int n3 = 4;
-    const int n4 = 5;
-    xios_handler.createAxis("axis_A");
-    xios_handler.setAxisSize("axis_A", n1);
-    xios_handler.setAxisValues("axis_A", { 0, 1 });
-    xios_handler.createAxis("axis_B");
-    xios_handler.setAxisSize("axis_B", n2);
-    xios_handler.setAxisValues("axis_B", { 0, 1, 2 });
-    xios_handler.createAxis("axis_C");
-    xios_handler.setAxisSize("axis_C", n3);
-    xios_handler.setAxisValues("axis_C", { 0, 1, 2, 3 });
-    xios_handler.createAxis("axis_D");
-    xios_handler.setAxisSize("axis_D", n4);
-    xios_handler.setAxisValues("axis_D", { 0, 1, 2, 3, 4 });
+    // Create a 4x2 horizontal domain with a partition halving the x-extent
+    xios_handler.createDomain("xy_domain");
+    xios_handler.setDomainType("xy_domain", "rectilinear");
+    xios_handler.setDomainGlobalXSize("xy_domain", 4);
+    xios_handler.setDomainGlobalYSize("xy_domain", 2);
+    xios_handler.setDomainLocalXStart("xy_domain", 2 * rank);
+    xios_handler.setDomainLocalYStart("xy_domain", 0);
+    xios_handler.setDomainLocalXValues("xy_domain", { -1.0 + rank, -0.5 + rank });
+    xios_handler.setDomainLocalYValues("xy_domain", { -1.0, 1.0 });
 
-    // Grid setup
+    // Create a vertical axis with 2 points
+    xios_handler.createAxis("z_axis");
+    xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
+
+    // Create a 2D grid comprised of the xy-domain and a 3D grid which also includes the z-axis
     xios_handler.createGrid("grid_2D");
-    xios_handler.gridAddAxis("grid_2D", "axis_A");
-    xios_handler.gridAddAxis("grid_2D", "axis_B");
+    xios_handler.gridAddDomain("grid_2D", "xy_domain");
     xios_handler.createGrid("grid_3D");
-    xios_handler.gridAddAxis("grid_3D", "axis_A");
-    xios_handler.gridAddAxis("grid_3D", "axis_B");
-    xios_handler.gridAddAxis("grid_3D", "axis_C");
-    xios_handler.createGrid("grid_4D");
-    xios_handler.gridAddAxis("grid_4D", "axis_A");
-    xios_handler.gridAddAxis("grid_4D", "axis_B");
-    xios_handler.gridAddAxis("grid_4D", "axis_C");
-    xios_handler.gridAddAxis("grid_4D", "axis_D");
+    xios_handler.gridAddDomain("grid_3D", "xy_domain");
+    xios_handler.gridAddAxis("grid_3D", "z_axis");
 
     // Field setup
     xios_handler.createField("field_2D");
@@ -96,11 +86,6 @@ MPI_TEST_CASE("TestXiosRead", 2)
     xios_handler.setFieldGridRef("field_3D", "grid_3D");
     xios_handler.setFieldReadAccess("field_3D", true);
     xios_handler.setFieldFreqOffset("field_3D", timestep);
-    xios_handler.createField("field_4D");
-    xios_handler.setFieldOperation("field_4D", "instant");
-    xios_handler.setFieldGridRef("field_4D", "grid_4D");
-    xios_handler.setFieldReadAccess("field_4D", true);
-    xios_handler.setFieldFreqOffset("field_4D", timestep);
 
     // File setup
     xios_handler.createFile("xios_test_input");
@@ -110,13 +95,22 @@ MPI_TEST_CASE("TestXiosRead", 2)
     xios_handler.setFileParAccess("xios_test_input", "collective");
     xios_handler.fileAddField("xios_test_input", "field_2D");
     xios_handler.fileAddField("xios_test_input", "field_3D");
-    xios_handler.fileAddField("xios_test_input", "field_4D");
 
     // Set ModelArray dimensions
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-    ModelArray::setDimension(ModelArray::Dimension::X, n1, n1, 0);
-    ModelArray::setDimension(ModelArray::Dimension::Y, n2, n2, 0);
-    ModelArray::setDimension(ModelArray::Dimension::Z, n3, n3, 0);
+    const size_t nx = xios_handler.getDomainLocalXSize("xy_domain");
+    const size_t ny = xios_handler.getDomainLocalYSize("xy_domain");
+    const size_t nz = xios_handler.getAxisSize("z_axis");
+    ModelArray::setDimension(
+        ModelArray::Dimension::X, xios_handler.getDomainGlobalXSize("xy_domain"), nx, 0);
+    ModelArray::setDimension(
+        ModelArray::Dimension::Y, xios_handler.getDomainGlobalYSize("xy_domain"), ny, 0);
+    ModelArray::setDimension(ModelArray::Dimension::Z, nz, nz, 0);
+
+    // Create ParametricGrid and ParaGridIO instances
+    ParametricGrid grid;
+    ParaGridIO* pio = new ParaGridIO(grid);
+    grid.setIO(pio);
 
     xios_handler.close_context_definition();
 
@@ -126,7 +120,6 @@ MPI_TEST_CASE("TestXiosRead", 2)
     field_2D.resize();
     HField field_3D(ModelArray::Type::Z);
     field_3D.resize();
-    // TODO: Implement 4D case
     // Verify calendar step is starting from zero
     REQUIRE(xios_handler.getCalendarStep() == 0);
     // Check the input file exists
@@ -138,24 +131,24 @@ MPI_TEST_CASE("TestXiosRead", 2)
         // Receive data from XIOS that is read from disk
         xios_handler.read("field_2D", field_2D);
         xios_handler.read("field_3D", field_3D);
-        // TODO: Implement 4D case
         // Verify timestep
         REQUIRE(xios_handler.getCalendarStep() == ts);
     }
     // Verify fields have been read in correctly
-    for (size_t j = 0; j < n2; ++j) {
-        for (size_t i = 0; i < n1; ++i) {
-            REQUIRE(field_2D(i, j) == doctest::Approx(1.0 * (i + n1 * j)));
+    for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+            REQUIRE(field_2D(i, j) == doctest::Approx(1.0 * (i + nx * j)));
         }
     }
-    for (size_t k = 0; k < n3; ++k) {
-        for (size_t j = 0; j < n2; ++j) {
-            for (size_t i = 0; i < n1; ++i) {
-                REQUIRE(field_3D(i, j, k) == doctest::Approx(1.0 * (i + n1 * (j + n2 * k))));
+    for (size_t k = 0; k < nz; ++k) {
+        for (size_t j = 0; j < ny; ++j) {
+            for (size_t i = 0; i < nx; ++i) {
+                REQUIRE(field_3D(i, j, k) == doctest::Approx(1.0 * (i + nx * (j + ny * k))));
             }
         }
     }
-
     xios_handler.context_finalize();
+
+    // TODO: Consider adding a 4D test case
 }
 }

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -87,14 +87,6 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.createAxis("z_axis");
     xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
 
-    // Create a 2D grid comprised of the xy-domain and a 3D grid which also includes the z-axis
-    // TODO: Create grid_2D along with xy_domain, grid_3D along with xy_domain plus z_axis
-    xios_handler.createGrid("grid_2D");
-    xios_handler.gridAddDomain("grid_2D", "xy_domain");
-    xios_handler.createGrid("grid_3D");
-    xios_handler.gridAddDomain("grid_3D", "xy_domain");
-    xios_handler.gridAddAxis("grid_3D", "z_axis");
-
     // Create some fake data to test writing methods
     HField field_2D(ModelArray::Type::H);
     field_2D.resize();
@@ -117,11 +109,11 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     // TODO: Create field along with HField
     xios_handler.createField("field_2D");
     xios_handler.setFieldOperation("field_2D", "instant");
-    xios_handler.setFieldGridRef("field_2D", "grid_2D");
+    xios_handler.setFieldGridRef("field_2D", "grid_2D"); // NOTE: grid_2D auto-generated
     xios_handler.setFieldReadAccess("field_2D", false);
     xios_handler.createField("field_3D");
     xios_handler.setFieldOperation("field_3D", "instant");
-    xios_handler.setFieldGridRef("field_3D", "grid_3D");
+    xios_handler.setFieldGridRef("field_3D", "grid_3D"); // NOTE: grid_3D auto-generated
     xios_handler.setFieldReadAccess("field_3D", false);
 
     // Create an output file to hold data from both fields

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosWrite_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    31 Oct 2024
+ * @date    01 Nov 2024
  * @brief   Tests for XIOS write method
  * @details
  * This test is designed to test the write method of the C++ interface
@@ -41,7 +41,14 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
+    // Create ParametricGrid and ParaGridIO instances
+    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
+    ParametricGrid grid;
+    ParaGridIO* pio = new ParaGridIO(grid);
+    grid.setIO(pio);
+
     // Initialize an Xios instance called xios_handler
+    // TODO: Create XIOS handler along with ParaGridIO instance
     Xios xios_handler;
     REQUIRE(xios_handler.isInitialized());
     const size_t size = xios_handler.getClientMPISize();
@@ -54,7 +61,18 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     Duration timestep("P0-0T01:30:00");
     xios_handler.setCalendarTimestep(timestep);
 
+    // Set ModelArray dimensions
+    const size_t nx_glo = 4;
+    const size_t ny_glo = 2;
+    const size_t nx = 2;
+    const size_t ny = 2;
+    const size_t nz = 2;
+    ModelArray::setDimension(ModelArray::Dimension::X, nx_glo, nx, 0);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny_glo, ny, 0);
+    ModelArray::setDimension(ModelArray::Dimension::Z, nz, nz, 0);
+
     // Create a 4x2 horizontal domain with a partition halving the x-extent
+    // TODO: Set local and global domain sizes upon calling ModelArray::setDimension for X and Y
     xios_handler.createDomain("xy_domain");
     xios_handler.setDomainType("xy_domain", "rectilinear");
     xios_handler.setDomainGlobalXSize("xy_domain", 4);
@@ -65,17 +83,38 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.setDomainLocalYValues("xy_domain", { -1.0, 1.0 });
 
     // Create a vertical axis with 2 points
+    // TODO: Set axis size upon calling ModelArray::setDimension for Z
     xios_handler.createAxis("z_axis");
     xios_handler.setAxisValues("z_axis", { 0.0, 1.0 });
 
     // Create a 2D grid comprised of the xy-domain and a 3D grid which also includes the z-axis
+    // TODO: Create grid_2D along with xy_domain, grid_3D along with xy_domain plus z_axis
     xios_handler.createGrid("grid_2D");
     xios_handler.gridAddDomain("grid_2D", "xy_domain");
     xios_handler.createGrid("grid_3D");
     xios_handler.gridAddDomain("grid_3D", "xy_domain");
     xios_handler.gridAddAxis("grid_3D", "z_axis");
 
+    // Create some fake data to test writing methods
+    HField field_2D(ModelArray::Type::H);
+    field_2D.resize();
+    for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+            field_2D(i, j) = 1.0 * (i + nx * j);
+        }
+    }
+    HField field_3D(ModelArray::Type::Z);
+    field_3D.resize();
+    for (size_t k = 0; k < nz; ++k) {
+        for (size_t j = 0; j < ny; ++j) {
+            for (size_t i = 0; i < nx; ++i) {
+                field_3D(i, j, k) = 1.0 * (i + nx * (j + ny * k));
+            }
+        }
+    }
+
     // Create fields on the two grids
+    // TODO: Create field along with HField
     xios_handler.createField("field_2D");
     xios_handler.setFieldOperation("field_2D", "instant");
     xios_handler.setFieldGridRef("field_2D", "grid_2D");
@@ -94,42 +133,9 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.fileAddField("xios_test_output", "field_2D");
     xios_handler.fileAddField("xios_test_output", "field_3D");
 
-    // Set ModelArray dimensions
-    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-    const size_t nx = xios_handler.getDomainLocalXSize("xy_domain");
-    const size_t ny = xios_handler.getDomainLocalYSize("xy_domain");
-    const size_t nz = xios_handler.getAxisSize("z_axis");
-    ModelArray::setDimension(
-        ModelArray::Dimension::X, xios_handler.getDomainGlobalXSize("xy_domain"), nx, 0);
-    ModelArray::setDimension(
-        ModelArray::Dimension::Y, xios_handler.getDomainGlobalYSize("xy_domain"), ny, 0);
-    ModelArray::setDimension(ModelArray::Dimension::Z, nz, nz, 0);
-
-    // Create ParametricGrid and ParaGridIO instances
-    ParametricGrid grid;
-    ParaGridIO* pio = new ParaGridIO(grid);
-    grid.setIO(pio);
-
     xios_handler.close_context_definition();
 
     // --- Tests for writing to file
-    // Create some fake data to test writing methods
-    HField field_2D(ModelArray::Type::H);
-    field_2D.resize();
-    for (size_t j = 0; j < ny; ++j) {
-        for (size_t i = 0; i < nx; ++i) {
-            field_2D(i, j) = 1.0 * (i + nx * j);
-        }
-    }
-    HField field_3D(ModelArray::Type::Z);
-    field_3D.resize();
-    for (size_t k = 0; k < nz; ++k) {
-        for (size_t j = 0; j < ny; ++j) {
-            for (size_t i = 0; i < nx; ++i) {
-                field_3D(i, j, k) = 1.0 * (i + nx * (j + ny * k));
-            }
-        }
-    }
     // Verify calendar step is starting from zero
     REQUIRE(xios_handler.getCalendarStep() == 0);
     // Check a file with the expected name doesn't exist yet

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosWrite_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    24 Sep 2024
+ * @date    31 Oct 2024
  * @brief   Tests for XIOS write method
  * @details
  * This test is designed to test the write method of the C++ interface
@@ -14,6 +14,7 @@
 #include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Configurator.hpp"
 #include "include/NextsimModule.hpp"
+#include "include/ParaGridIO.hpp"
 #include "include/Xios.hpp"
 
 #include <filesystem>
@@ -50,7 +51,8 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     // Calendar setup
     xios_handler.setCalendarOrigin(TimePoint("2020-01-23T00:08:15Z"));
     xios_handler.setCalendarStart(TimePoint("2023-03-17T17:11:00Z"));
-    xios_handler.setCalendarTimestep(Duration("P0-0T01:30:00"));
+    Duration timestep("P0-0T01:30:00");
+    xios_handler.setCalendarTimestep(timestep);
 
     // Create a 4x2 horizontal domain with a partition halving the x-extent
     xios_handler.createDomain("xy_domain");
@@ -86,7 +88,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     // Create an output file to hold data from both fields
     xios_handler.createFile("xios_test_output");
     xios_handler.setFileType("xios_test_output", "one_file");
-    xios_handler.setFileOutputFreq("xios_test_output", Duration("P0-0T01:30:00"));
+    xios_handler.setFileOutputFreq("xios_test_output", timestep);
     xios_handler.setFileSplitFreq("xios_test_output", Duration("P0-0T03:00:00"));
     xios_handler.setFileMode("xios_test_output", "write");
     xios_handler.fileAddField("xios_test_output", "field_2D");
@@ -102,6 +104,11 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     ModelArray::setDimension(
         ModelArray::Dimension::Y, xios_handler.getDomainGlobalYSize("xy_domain"), ny, 0);
     ModelArray::setDimension(ModelArray::Dimension::Z, nz, nz, 0);
+
+    // Create ParametricGrid and ParaGridIO instances
+    ParametricGrid grid;
+    ParaGridIO* pio = new ParaGridIO(grid);
+    grid.setIO(pio);
 
     xios_handler.close_context_definition();
 

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -92,9 +92,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xios_handler.fileAddField("xios_test_output", "field_2D");
     xios_handler.fileAddField("xios_test_output", "field_3D");
 
-    xios_handler.close_context_definition();
-
-    // --- Tests for writing to file
+    // Set ModelArray dimensions
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
     const size_t nx = xios_handler.getDomainLocalXSize("xy_domain");
     const size_t ny = xios_handler.getDomainLocalYSize("xy_domain");
@@ -104,6 +102,10 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     ModelArray::setDimension(
         ModelArray::Dimension::Y, xios_handler.getDomainGlobalYSize("xy_domain"), ny, 0);
     ModelArray::setDimension(ModelArray::Dimension::Z, nz, nz, 0);
+
+    xios_handler.close_context_definition();
+
+    // --- Tests for writing to file
     // Create some fake data to test writing methods
     HField field_2D(ModelArray::Type::H);
     field_2D.resize();

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -1,20 +1,23 @@
-netcdf input {
+netcdf xios_test_output {
 dimensions:
 	axis_nbounds = 2 ;
-	axis_A = 2 ;
-	axis_B = 3 ;
-	axis_C = 4 ;
-	axis_D = 5 ;
+	lon = 4 ;
+	lat = 2 ;
+	z_axis = 2 ;
 	time_counter = UNLIMITED ; // (4 currently)
 variables:
-	float axis_A(axis_A) ;
-		axis_A:name = "axis_A" ;
-	float axis_B(axis_B) ;
-		axis_B:name = "axis_B" ;
-	float axis_C(axis_C) ;
-		axis_C:name = "axis_C" ;
-	float axis_D(axis_D) ;
-		axis_D:name = "axis_D" ;
+	float lat(lat) ;
+		lat:axis = "Y" ;
+		lat:standard_name = "latitude" ;
+		lat:long_name = "Latitude" ;
+		lat:units = "degrees_north" ;
+	float lon(lon) ;
+		lon:axis = "X" ;
+		lon:standard_name = "longitude" ;
+		lon:long_name = "Longitude" ;
+		lon:units = "degrees_east" ;
+	float z_axis(z_axis) ;
+		z_axis:name = "z_axis" ;
 	double time_instant(time_counter) ;
 		time_instant:standard_name = "time" ;
 		time_instant:long_name = "Time axis" ;
@@ -32,361 +35,75 @@ variables:
 		time_counter:time_origin = "2020-01-23 00:08:15" ;
 		time_counter:bounds = "time_counter_bounds" ;
 	double time_counter_bounds(time_counter, axis_nbounds) ;
-	float field_2D(time_counter, axis_B, axis_A) ;
+	float field_2D(time_counter, lat, lon) ;
 		field_2D:online_operation = "instant" ;
-		field_2D:interval_operation = "5400 min" ;
-		field_2D:interval_write = "5400 min" ;
+		field_2D:interval_operation = "5400 s" ;
+		field_2D:interval_write = "5400 s" ;
 		field_2D:cell_methods = "time: point" ;
 		field_2D:coordinates = "time_instant" ;
-	float field_3D(time_counter, axis_C, axis_B, axis_A) ;
+	float field_3D(time_counter, z_axis, lat, lon) ;
 		field_3D:online_operation = "instant" ;
-		field_3D:interval_operation = "5400 min" ;
-		field_3D:interval_write = "5400 min" ;
+		field_3D:interval_operation = "5400 s" ;
+		field_3D:interval_write = "5400 s" ;
 		field_3D:cell_methods = "time: point" ;
 		field_3D:coordinates = "time_instant" ;
-	float field_4D(time_counter, axis_D, axis_C, axis_B, axis_A) ;
-		field_4D:online_operation = "instant" ;
-		field_4D:interval_operation = "5400 min" ;
-		field_4D:interval_write = "5400 min" ;
-		field_4D:cell_methods = "time: point" ;
-		field_4D:coordinates = "time_instant" ;
 
 // global attributes:
-		:name = "input" ;
+		:name = "xios_test_output" ;
 		:description = "Created by xios" ;
 		:title = "Created by xios" ;
 		:Conventions = "CF-1.6" ;
-		:timeStamp = "2024-Jun-27 17:39:59 GMT" ;
-		:uuid = "3c5d57c2-a779-4728-9365-b991e8602cc5" ;
+		:timeStamp = "2024-Aug-27 08:47:07 GMT" ;
+		:uuid = "28e10e5f-e296-4219-903d-bc75bd2e4a9a" ;
 data:
 
- axis_A = 0, 1 ;
+ lat = -1, 1 ;
 
- axis_B = 0, 1, 2 ;
+ lon = -1, -0.5, 0, 0.5 ;
 
- axis_C = 0, 1, 2, 3 ;
+ z_axis = 0, 1 ;
 
- axis_D = 0, 1, 2, 3, 4 ;
-
- time_instant = 99658965, 99982965, 100306965, 100630965 ;
+ time_instant = 99340365, 99345765, 99351165, 99356565 ;
 
  time_instant_bounds =
-  99658965, 99658965,
-  99982965, 99982965,
-  100306965, 100306965,
-  100630965, 100630965 ;
+  99340365, 99340365,
+  99345765, 99345765,
+  99351165, 99351165,
+  99356565, 99356565 ;
 
- time_counter = 99658965, 99982965, 100306965, 100630965 ;
+ time_counter = 99340365, 99345765, 99351165, 99356565 ;
 
  time_counter_bounds =
-  99658965, 99658965,
-  99982965, 99982965,
-  100306965, 100306965,
-  100630965, 100630965 ;
+  99340365, 99340365,
+  99345765, 99345765,
+  99351165, 99351165,
+  99356565, 99356565 ;
 
  field_2D =
-  0, 1,
-  2, 3,
-  4, 5,
-  0, 1,
-  2, 3,
-  4, 5,
-  0, 1,
-  2, 3,
-  4, 5,
-  0, 1,
-  2, 3,
-  4, 5 ;
+  0, 1, 0, 1,
+  2, 3, 2, 3,
+  0, 1, 0, 1,
+  2, 3, 2, 3,
+  0, 1, 0, 1,
+  2, 3, 2, 3,
+  0, 1, 0, 1,
+  2, 3, 2, 3 ;
 
  field_3D =
-  0, 1,
-  2, 3,
-  4, 5,
-  6, 7,
-  8, 9,
-  10, 11,
-  12, 13,
-  14, 15,
-  16, 17,
-  18, 19,
-  20, 21,
-  22, 23,
-  0, 1,
-  2, 3,
-  4, 5,
-  6, 7,
-  8, 9,
-  10, 11,
-  12, 13,
-  14, 15,
-  16, 17,
-  18, 19,
-  20, 21,
-  22, 23,
-  0, 1,
-  2, 3,
-  4, 5,
-  6, 7,
-  8, 9,
-  10, 11,
-  12, 13,
-  14, 15,
-  16, 17,
-  18, 19,
-  20, 21,
-  22, 23,
-  0, 1,
-  2, 3,
-  4, 5,
-  6, 7,
-  8, 9,
-  10, 11,
-  12, 13,
-  14, 15,
-  16, 17,
-  18, 19,
-  20, 21,
-  22, 23 ;
-
- field_4D =
-  0, 1,
-  2, 3,
-  4, 5,
-  6, 7,
-  8, 9,
-  10, 11,
-  12, 13,
-  14, 15,
-  16, 17,
-  18, 19,
-  20, 21,
-  22, 23,
-  24, 25,
-  26, 27,
-  28, 29,
-  30, 31,
-  32, 33,
-  34, 35,
-  36, 37,
-  38, 39,
-  40, 41,
-  42, 43,
-  44, 45,
-  46, 47,
-  48, 49,
-  50, 51,
-  52, 53,
-  54, 55,
-  56, 57,
-  58, 59,
-  60, 61,
-  62, 63,
-  64, 65,
-  66, 67,
-  68, 69,
-  70, 71,
-  72, 73,
-  74, 75,
-  76, 77,
-  78, 79,
-  80, 81,
-  82, 83,
-  84, 85,
-  86, 87,
-  88, 89,
-  90, 91,
-  92, 93,
-  94, 95,
-  96, 97,
-  98, 99,
-  100, 101,
-  102, 103,
-  104, 105,
-  106, 107,
-  108, 109,
-  110, 111,
-  112, 113,
-  114, 115,
-  116, 117,
-  118, 119,
-  0, 1,
-  2, 3,
-  4, 5,
-  6, 7,
-  8, 9,
-  10, 11,
-  12, 13,
-  14, 15,
-  16, 17,
-  18, 19,
-  20, 21,
-  22, 23,
-  24, 25,
-  26, 27,
-  28, 29,
-  30, 31,
-  32, 33,
-  34, 35,
-  36, 37,
-  38, 39,
-  40, 41,
-  42, 43,
-  44, 45,
-  46, 47,
-  48, 49,
-  50, 51,
-  52, 53,
-  54, 55,
-  56, 57,
-  58, 59,
-  60, 61,
-  62, 63,
-  64, 65,
-  66, 67,
-  68, 69,
-  70, 71,
-  72, 73,
-  74, 75,
-  76, 77,
-  78, 79,
-  80, 81,
-  82, 83,
-  84, 85,
-  86, 87,
-  88, 89,
-  90, 91,
-  92, 93,
-  94, 95,
-  96, 97,
-  98, 99,
-  100, 101,
-  102, 103,
-  104, 105,
-  106, 107,
-  108, 109,
-  110, 111,
-  112, 113,
-  114, 115,
-  116, 117,
-  118, 119,
-  0, 1,
-  2, 3,
-  4, 5,
-  6, 7,
-  8, 9,
-  10, 11,
-  12, 13,
-  14, 15,
-  16, 17,
-  18, 19,
-  20, 21,
-  22, 23,
-  24, 25,
-  26, 27,
-  28, 29,
-  30, 31,
-  32, 33,
-  34, 35,
-  36, 37,
-  38, 39,
-  40, 41,
-  42, 43,
-  44, 45,
-  46, 47,
-  48, 49,
-  50, 51,
-  52, 53,
-  54, 55,
-  56, 57,
-  58, 59,
-  60, 61,
-  62, 63,
-  64, 65,
-  66, 67,
-  68, 69,
-  70, 71,
-  72, 73,
-  74, 75,
-  76, 77,
-  78, 79,
-  80, 81,
-  82, 83,
-  84, 85,
-  86, 87,
-  88, 89,
-  90, 91,
-  92, 93,
-  94, 95,
-  96, 97,
-  98, 99,
-  100, 101,
-  102, 103,
-  104, 105,
-  106, 107,
-  108, 109,
-  110, 111,
-  112, 113,
-  114, 115,
-  116, 117,
-  118, 119,
-  0, 1,
-  2, 3,
-  4, 5,
-  6, 7,
-  8, 9,
-  10, 11,
-  12, 13,
-  14, 15,
-  16, 17,
-  18, 19,
-  20, 21,
-  22, 23,
-  24, 25,
-  26, 27,
-  28, 29,
-  30, 31,
-  32, 33,
-  34, 35,
-  36, 37,
-  38, 39,
-  40, 41,
-  42, 43,
-  44, 45,
-  46, 47,
-  48, 49,
-  50, 51,
-  52, 53,
-  54, 55,
-  56, 57,
-  58, 59,
-  60, 61,
-  62, 63,
-  64, 65,
-  66, 67,
-  68, 69,
-  70, 71,
-  72, 73,
-  74, 75,
-  76, 77,
-  78, 79,
-  80, 81,
-  82, 83,
-  84, 85,
-  86, 87,
-  88, 89,
-  90, 91,
-  92, 93,
-  94, 95,
-  96, 97,
-  98, 99,
-  100, 101,
-  102, 103,
-  104, 105,
-  106, 107,
-  108, 109,
-  110, 111,
-  112, 113,
-  114, 115,
-  116, 117,
-  118, 119 ;
+  0, 1, 0, 1,
+  2, 3, 2, 3,
+  4, 5, 4, 5,
+  6, 7, 6, 7,
+  0, 1, 0, 1,
+  2, 3, 2, 3,
+  4, 5, 4, 5,
+  6, 7, 6, 7,
+  0, 1, 0, 1,
+  2, 3, 2, 3,
+  4, 5, 4, 5,
+  6, 7, 6, 7,
+  0, 1, 0, 1,
+  2, 3, 2, 3,
+  4, 5, 4, 5,
+  6, 7, 6, 7 ;
 }


### PR DESCRIPTION
# Prepare for setting XIOS up via nextSIM-DG

Partially addresses #633.

This PR reworks the XIOS setup workflow in preparation for farming much of it off to happen automatically via nextSIM-DG. For example, when `ModelArray::setDimension` is called with `ModelArray::Dimension::X`, we can have the XIOS handler set the local and global X sizes correspondingly.

Main changes:
* Use `xy_domain` and `z_axis` consistently in XIOS read and write demos.
* Reorder operations in XIOS read and write demos, with TODOs planning out how the setup steps will be automated via nextSIM-DG.
* Automatically create an XIOS Grid `grid_2D` upon creating an XIOS Domain with the special name `xy_domain`.
* Automatically create an XIOS Grid `grid_3D` upon creating XIOS Domain and Axis with the special names `xy_domain` and `z_axis`, respectively.

Other minor changes:
* Finish moving from initialising strings with `{}` to `=`.
* Add a check to ensure local and global sizes match for `Z` dimension because we only MPI parallelise in the horizontal.