### PR TITLE
Fixes for XIOS install and Docker build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,13 @@
 name: Periodic Docker build
 
 on:
-  # Build the Docker container whenever commits are pushed to an open PR (under conditions defined below)
+  # Build the Docker container whenever commits are pushed to an open PR that changes one of the files listed
   pull_request:
+    paths:
+      - .github/workflows/docker.yml
+      - Dockerfiles/Dockerfile.devenv
+      - Dockerfiles/install-xios.sh
+      - Dockerfiles/spack_devenv.yaml
 
   # Build the Docker container at 00:00 on the first day of every 3 months
   schedule:
@@ -17,29 +22,12 @@ jobs:
       packages: write
     steps:
       - name: Checkout the repo
-        id: Checkout
         uses: actions/checkout@v4
 
-      - name: Determine if this file changed compared with develop
-        if: ${{ !(github.event_name == 'schedule') }}
-        id: changed-files
-        uses: tj-actions/changed-files@v44
-        with:
-          files: |
-            .github/workflows/docker.yml
-            Dockerfiles/Dockerfile.devenv
-            Dockerfiles/install-xios.sh
-            Dockerfiles/spack_devenv.yaml
-          base_sha: develop
-
       - name: Setup Docker buildx
-        id: buildx
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || (github.event_name == 'schedule') }}
         uses: docker/setup-buildx-action@v3
 
       - name: Log into GitHub Container Repository
-        id: login
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || ( github.event_name == 'schedule') }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -48,11 +36,8 @@ jobs:
           logout: true
 
       - name: Build container and push to ghcr
-        id: build-and-push
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true') || (github.event_name == 'schedule') }}
         uses: docker/build-push-action@v5
         with:
           push: true
-          no-cache: true
           file: Dockerfiles/Dockerfile.devenv
           tags: ghcr.io/nextsimhub/nextsimdg-dev-env:latest

--- a/Dockerfiles/install-xios.sh
+++ b/Dockerfiles/install-xios.sh
@@ -3,10 +3,10 @@
 # use svn to obtain current version of xios
 cd /
 installdir="xios"
-svn checkout http://forge.ipsl.jussieu.fr/ioserver/svn/XIOS/trunk $installdir
+svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS/trunk $installdir
 cd $installdir
 
-cat <<EOF > arch/arch-GCC_LINUX.path
+cat <<EOF >arch/arch-GCC_LINUX.path
 NETCDF_INCDIR="-I \$NETCDF_INC_DIR -I \$NETCDFFORT_INC_DIR"
 NETCDF_LIBDIR="-L \$NETCDF_LIB_DIR -L \$NETCDFFORT_LIB_DIR"
 NETCDF_LIB="-lnetcdff -lnetcdf"
@@ -28,7 +28,7 @@ OASIS_LIBDIR="-L\$PWD/../../oasis3-mct/BLD/lib"
 OASIS_LIB="-lpsmile.MPI1 -lscrip -lmct -lmpeu"
 EOF
 
-cat <<EOF > arch/arch-GCC_LINUX.env
+cat <<EOF >arch/arch-GCC_LINUX.env
 export HDF5_INC_DIR=\$(pkg-config --variable=prefix hdf5)/include
 export HDF5_LIB_DIR=\$(pkg-config --variable=prefix hdf5)/lib
 
@@ -42,7 +42,7 @@ export BOOST_INC_DIR=\$HOME/boost
 export BOOST_LIB_DIR=\$HOME/boost
 EOF
 
-cat <<EOF > arch/arch-GCC_LINUX.fcm
+cat <<EOF >arch/arch-GCC_LINUX.fcm
 ################################################################################
 ###################                Projet XIOS               ###################
 ################################################################################
@@ -71,5 +71,5 @@ EOF
 
 ./make_xios --arch GCC_LINUX --job 8 --full --debug
 rm -r /xios/obj /xios/bin/generic_testcase.exe /xios/src /xios/tools \
-    /xios/inputs /xios/doc /xios/arch /xios/xios_test_suite /xios/flags \
-    /xios/generic_testcase /xios/ppsrc /xios/done
+  /xios/inputs /xios/doc /xios/arch /xios/xios_test_suite /xios/flags \
+  /xios/generic_testcase /xios/ppsrc /xios/done

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -55,7 +55,7 @@ You must have root privilege :
 
         sudo apt-get update
         sudo apt-get install netcdf-bin libnetcdf-c++4-dev libboost-all-dev cmake subversion libeigen3-dev
-        svn checkout http://forge.ipsl.jussieu.fr/ioserver/svn/XIOS/trunk xios
+        svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS/trunk xios
         cd xios
         ./make_xios --arch <your_architecture>
 


### PR DESCRIPTION
Closes #719.

Apparently it has been recommended to use `forge.ipsl.fr` rather than `forge.ipsl.jussieu.fr` since March.

This PR also takes a neater approach to checking for changes in the periodic Docker build workflow.