### PR TITLE
Initialise Shared::DAMAGE in PrognosticData::update

### DIFF
--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file PrognosticData.cpp
  *
- * @date 1 Jul 2024
+ * @date 21 Nov 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
@@ -82,7 +82,8 @@ void PrognosticData::setData(const ModelState::DataMap& ms)
 
 void PrognosticData::update(const TimestepTime& tst)
 {
-    ModelArrayRef<Shared::T_ICE, RW> ticeUpd(getStore());
+    ModelArrayRef<Shared::DAMAGE, RW> damageUpd(getStore());
+    damageUpd.data().setData(m_damage);
 
     pOcnBdy->updateBefore(tst);
     pAtmBdy->update(tst);

--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -82,9 +82,6 @@ void PrognosticData::setData(const ModelState::DataMap& ms)
 
 void PrognosticData::update(const TimestepTime& tst)
 {
-    ModelArrayRef<Shared::DAMAGE, RW> damageUpd(getStore());
-    damageUpd.data().setData(m_damage);
-
     pOcnBdy->updateBefore(tst);
     pAtmBdy->update(tst);
 

--- a/physics/src/modules/DamageHealingModule/ConstantHealing.cpp
+++ b/physics/src/modules/DamageHealingModule/ConstantHealing.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ConstantHealing.hpp
  *
- * @date 20 Nov 2024
+ * @date 21 Nov 2024
  * @author Einar Ólason <einar.olason@nersc.no>
  */
 
@@ -58,7 +58,7 @@ void ConstantHealing::updateElement(size_t i, const TimestepTime& tstep)
     /* 1. Lateral ice formation
      * A weighted average of the original damage, weighted by the old concentration, and the
      * undamaged new ice damage (1), weighted by the concentration of new ice. */
-    damage[i] = (damage[i] * (cice[i] - lateralGrowth) + lateralGrowth) / cice[i];
+    damage[i] = (oldDamage[i] * (cice[i] - lateralGrowth) + lateralGrowth) / cice[i];
 
     /* 2. Constant healing
      * Damage healing using a constant timescale. Originally conceived as an exponential decay, but

--- a/physics/src/modules/DamageHealingModule/include/NoHealing.hpp
+++ b/physics/src/modules/DamageHealingModule/include/NoHealing.hpp
@@ -26,14 +26,7 @@ public:
     ModelState getStateRecursive(const OutputSpec& os) const override { return ModelState(); };
 
     // Do nothing when update is called.
-    void update(const TimestepTime& tstep) override
-    {
-        overElements(std::bind(&NoHealing::updateElement, this, std::placeholders::_1,
-                         std::placeholders::_2),
-            tstep);
-    };
-
-    void updateElement(size_t i, const TimestepTime& tstep) { damage[i] = oldDamage[i]; };
+    void update(const TimestepTime& tstep) override { damage.data() = oldDamage.data(); }
 };
 
 }

--- a/physics/src/modules/DamageHealingModule/include/NoHealing.hpp
+++ b/physics/src/modules/DamageHealingModule/include/NoHealing.hpp
@@ -3,7 +3,7 @@
  *
  * This class has no corresponding implementation, just this header file
  *
- * @date 24 Sep 2024
+ * @date 21 Nov 2024
  * @author Einar Ólason <einar.olason@nersc.no>
  */
 
@@ -26,7 +26,14 @@ public:
     ModelState getStateRecursive(const OutputSpec& os) const override { return ModelState(); };
 
     // Do nothing when update is called.
-    void update(const TimestepTime& tstep) override {};
+    void update(const TimestepTime& tstep) override
+    {
+        overElements(std::bind(&NoHealing::updateElement, this, std::placeholders::_1,
+                         std::placeholders::_2),
+            tstep);
+    };
+
+    void updateElement(size_t i, const TimestepTime& tstep) { damage[i] = oldDamage[i]; };
 };
 
 }

--- a/physics/src/modules/include/IDamageHealing.hpp
+++ b/physics/src/modules/include/IDamageHealing.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IDamageHealing.hpp
  *
- * @date 24 Sep 2024
+ * @date 21 Nov 2024
  * @author Einar Ólason <einar.olason@nersc.no>
  */
 
@@ -37,12 +37,14 @@ protected:
         : cice(getStore())
         , deltaCi(getStore())
         , damage(getStore())
+        , oldDamage(getStore())
     {
     }
 
     ModelArrayRef<Shared::C_ICE, RO> cice; // From prognostic data
     ModelArrayRef<Shared::DELTA_CICE, RO> deltaCi; // From LateralIceSpread
     ModelArrayRef<Shared::DAMAGE, RW> damage; // From prognostic data
+    ModelArrayRef<Protected::DAMAGE, RO> oldDamage; // From prognostic data
 };
 
 } /* namespace Nextsim */

--- a/physics/test/DamageHealing_test.cpp
+++ b/physics/test/DamageHealing_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file DamageHealing_test.cpp
  *
- * @date 21 Nov 2024
+ * @date 22 Nov 2024
  * @author Einar Ólason <einar.olason@nersc.no>
  */
 
@@ -9,7 +9,6 @@
 #include <doctest/doctest.h>
 
 #include "include/IDamageHealing.hpp"
-#include "include/Module.hpp"
 #include "include/NextsimModule.hpp"
 
 extern template class Module::Module<Nextsim::IDamageHealing>;
@@ -45,7 +44,7 @@ TEST_CASE("Thermodynamic healing")
             getStore().registerArray(Shared::DELTA_CICE, &deltaCi, RO);
             getStore().registerArray(Shared::C_ICE, &cice, RO);
             getStore().registerArray(Shared::DAMAGE, &damage, RW);
-            getStore().registerArray(Protected::DAMAGE, &oldDamage, RW);
+            getStore().registerArray(Protected::DAMAGE, &oldDamage, RO);
         }
         std::string getName() const override { return "PrognosticData"; }
 
@@ -111,7 +110,7 @@ TEST_CASE("New ice formation")
             getStore().registerArray(Shared::DELTA_CICE, &deltaCi, RO);
             getStore().registerArray(Shared::C_ICE, &cice, RO);
             getStore().registerArray(Shared::DAMAGE, &damage, RW);
-            getStore().registerArray(Protected::DAMAGE, &oldDamage, RW);
+            getStore().registerArray(Protected::DAMAGE, &oldDamage, RO);
         }
         std::string getName() const override { return "PrognosticData"; }
 

--- a/physics/test/DamageHealing_test.cpp
+++ b/physics/test/DamageHealing_test.cpp
@@ -1,16 +1,16 @@
 /*!
  * @file DamageHealing_test.cpp
  *
- * @date 24 Sep 2024
+ * @date 21 Nov 2024
  * @author Einar Ólason <einar.olason@nersc.no>
  */
 
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
-#include "include/NextsimModule.hpp"
 #include "include/IDamageHealing.hpp"
 #include "include/Module.hpp"
+#include "include/NextsimModule.hpp"
 
 extern template class Module::Module<Nextsim::IDamageHealing>;
 namespace Nextsim {
@@ -45,6 +45,7 @@ TEST_CASE("Thermodynamic healing")
             getStore().registerArray(Shared::DELTA_CICE, &deltaCi, RO);
             getStore().registerArray(Shared::C_ICE, &cice, RO);
             getStore().registerArray(Shared::DAMAGE, &damage, RW);
+            getStore().registerArray(Protected::DAMAGE, &oldDamage, RW);
         }
         std::string getName() const override { return "PrognosticData"; }
 
@@ -53,12 +54,13 @@ TEST_CASE("Thermodynamic healing")
             noLandMask();
             cice = 0.5;
             deltaCi = 0.0;
-            damage = 0.5;
+            oldDamage = 0.5;
         }
 
         HField cice;
         HField deltaCi;
         HField damage;
+        HField oldDamage;
 
         ModelState getState() const override { return ModelState(); }
         ModelState getState(const OutputLevel&) const override { return getState(); }
@@ -73,11 +75,11 @@ TEST_CASE("Thermodynamic healing")
     TimestepTime tst = { TimePoint("2000-001"), Duration("P0-1T00:00:00") };
     double prec = 1e-8;
 
-    iceState.damage = 0.5;
+    iceState.oldDamage = 0.5;
     iHealing->update(tst);
     REQUIRE(iceState.damage[0] == doctest::Approx(0.55).epsilon(prec));
 
-    iceState.damage = 0.99;
+    iceState.oldDamage = 0.99;
     iHealing->update(tst);
     REQUIRE(iceState.damage[0] <= 1.);
     REQUIRE(iceState.damage[0] == doctest::Approx(1.).epsilon(prec));
@@ -109,6 +111,7 @@ TEST_CASE("New ice formation")
             getStore().registerArray(Shared::DELTA_CICE, &deltaCi, RO);
             getStore().registerArray(Shared::C_ICE, &cice, RO);
             getStore().registerArray(Shared::DAMAGE, &damage, RW);
+            getStore().registerArray(Protected::DAMAGE, &oldDamage, RW);
         }
         std::string getName() const override { return "PrognosticData"; }
 
@@ -117,12 +120,13 @@ TEST_CASE("New ice formation")
             noLandMask();
             cice = 0.5;
             deltaCi = 0.1;
-            damage = 0.5;
+            oldDamage = 0.5;
         }
 
         HField cice;
         HField deltaCi;
         HField damage;
+        HField oldDamage;
 
         ModelState getState() const override { return ModelState(); }
         ModelState getState(const OutputLevel&) const override { return getState(); }
@@ -137,32 +141,32 @@ TEST_CASE("New ice formation")
 
     iceState.cice = 0.6;
     iceState.deltaCi = 0.3;
-    iceState.damage = 0.;
+    iceState.oldDamage = 0.;
     iHealing->update(tst);
     REQUIRE(iceState.damage[0] == doctest::Approx(0.55).epsilon(prec));
 
     iceState.cice = 0.6;
     iceState.deltaCi = 0.3;
-    iceState.damage = 0.5;
+    iceState.oldDamage = 0.5;
     iHealing->update(tst);
     REQUIRE(iceState.damage[0] == doctest::Approx(0.80).epsilon(prec));
 
     iceState.cice = 0.5;
     iceState.deltaCi = 0.1;
-    iceState.damage = 0.5;
+    iceState.oldDamage = 0.5;
     iHealing->update(tst);
     REQUIRE(iceState.damage[0] == doctest::Approx(0.65).epsilon(prec));
 
     iceState.cice = 1.;
     iceState.deltaCi = 0.1;
-    iceState.damage = 1.;
+    iceState.oldDamage = 1.;
     iHealing->update(tst);
     REQUIRE(iceState.damage[0] <= 1.);
     REQUIRE(iceState.damage[0] <= doctest::Approx(1.).epsilon(prec));
 
     iceState.cice = 0.5;
     iceState.deltaCi = -0.5;
-    iceState.damage = 0.5;
+    iceState.oldDamage = 0.5;
     iHealing->update(tst);
     REQUIRE(iceState.damage[0] == doctest::Approx(0.55).epsilon(prec));
 }

--- a/physics/test/IceGrowth_test.cpp
+++ b/physics/test/IceGrowth_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file IceGrowth_test.cpp
  *
- * @date Apr 8, 2022
+ * @date 22 Nov 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -93,8 +93,10 @@ TEST_CASE("New ice formation")
     ocnBdy.setData(ModelState().data);
 
     HField damage(ModelArray::Type::H);
+    HField oldDamage(ModelArray::Type::H);
     damage = 1;
     ModelComponent::getStore().registerArray(Shared::DAMAGE, &damage, RW);
+    ModelComponent::getStore().registerArray(Protected::DAMAGE, &oldDamage, RO);
 
     TimestepTime tst = { TimePoint("2000-001"), Duration("P0-1") };
     IceGrowth ig;
@@ -177,8 +179,10 @@ TEST_CASE("Melting conditions")
     ocnBdy.setData(ModelState().data);
 
     HField damage(ModelArray::Type::H);
+    HField oldDamage(ModelArray::Type::H);
     damage = 1;
     ModelComponent::getStore().registerArray(Shared::DAMAGE, &damage, RW);
+    ModelComponent::getStore().registerArray(Protected::DAMAGE, &oldDamage, RO);
 
     TimestepTime tst = { TimePoint("2000-001"), Duration("P0-0T0:10:0") };
     IceGrowth ig;
@@ -269,8 +273,10 @@ TEST_CASE("Freezing conditions")
     ocnBdy.setData(ModelState().data);
 
     HField damage(ModelArray::Type::H);
+    HField oldDamage(ModelArray::Type::H);
     damage = 1;
     ModelComponent::getStore().registerArray(Shared::DAMAGE, &damage, RW);
+    ModelComponent::getStore().registerArray(Protected::DAMAGE, &oldDamage, RO);
 
     TimestepTime tst = { TimePoint("2000-001"), Duration("P0-0T0:10:0") };
     IceGrowth ig;
@@ -366,8 +372,10 @@ TEST_CASE("Dummy ice")
     ocnBdy.setData(ModelState().data);
 
     HField damage(ModelArray::Type::H);
+    HField oldDamage(ModelArray::Type::H);
     damage = 1;
     ModelComponent::getStore().registerArray(Shared::DAMAGE, &damage, RW);
+    ModelComponent::getStore().registerArray(Protected::DAMAGE, &oldDamage, RO);
 
     TimestepTime tst = { TimePoint("2000-001"), Duration("P0-0T0:10:0") };
 
@@ -464,8 +472,10 @@ TEST_CASE("Zero thickness")
     ocnBdy.setData(ModelState().data);
 
     HField damage(ModelArray::Type::H);
+    HField oldDamage(ModelArray::Type::H);
     damage = 1;
     ModelComponent::getStore().registerArray(Shared::DAMAGE, &damage, RW);
+    ModelComponent::getStore().registerArray(Protected::DAMAGE, &oldDamage, RO);
 
     class ZeroThicknessIce : public IIceThermodynamics {
         void setData(const ModelState::DataMap&) override { }
@@ -591,8 +601,10 @@ TEST_CASE("Turn off thermo")
     ocnBdy.setData(ModelState().data);
 
     HField damage(ModelArray::Type::H);
+    HField oldDamage(ModelArray::Type::H);
     damage = 1;
     ModelComponent::getStore().registerArray(Shared::DAMAGE, &damage, RW);
+    ModelComponent::getStore().registerArray(Protected::DAMAGE, &oldDamage, RO);
 
     TimestepTime tst = { TimePoint("2000-001"), Duration("P0-0T0:10:0") };
     IceGrowth ig;


### PR DESCRIPTION
#  Initialise Shared::DAMAGE in PrognosticData::update

Fixes #742 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

The ``Shared::DAMAGE`` variable must be updated at the start of ``PrognosticData::update``, otherwise the ``kernel.setData(damageName, damage)`` call in ``BBMDynamics.cpp`` (line 123) inserts nonsense into the damage field.

---
# Test Description


Use a modified config_benchmark.cfg file to test the update

```
[model]
init_file = init_benchmark_128x128.nc
start = 2023-01-01T00:00:00Z
stop = 2023-01-01T00:10:00Z
time_step = P0-0T00:02:00

[Modules]
DiagnosticOutputModule = Nextsim::ConfigOutput
DynamicsModule = Nextsim::BBMDynamics
IceThermodynamicsModule = Nextsim::DummyIceThermodynamics
LateralIceSpreadModule = Nextsim::DummyIceSpread
AtmosphereBoundaryModule = Nextsim::ConfiguredAtmosphere
OceanBoundaryModule = Nextsim::BenchmarkOcean

[ConfigOutput]
period = P0-0T00:02:00
start = 2010-01-01T12:00:00Z
field_names = hsnow,hice,cice,u,v,damage
filename = benchmark_32x32.diagnostic.nc
```

Before the fix, the damage field would have a uniform slope from x=0 to half way through the domain. After the fix, the damage field is uniform as it should be.

---
# Documentation Impact

N/A

---
# Other Details

N/A

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README