### PR TITLE
Fix pre-commit hook; add CMake formatting pre-commit

### DIFF
--- a/.cmake-lint-config.py
+++ b/.cmake-lint-config.py
@@ -1,0 +1,241 @@
+# ----------------------------------
+# Options affecting listfile parsing
+# ----------------------------------
+with section("parse"):
+
+  # Specify structure for custom cmake functions
+  additional_commands = { 'foo': { 'flags': ['BAR', 'BAZ'],
+             'kwargs': {'DEPENDS': '*', 'HEADERS': '*', 'SOURCES': '*'}}}
+
+  # Override configurations per-command where available
+  override_spec = {}
+
+  # Specify variable tags.
+  vartags = []
+
+  # Specify property tags.
+  proptags = []
+
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section("format"):
+
+  # Disable formatting entirely, making cmake-format a no-op
+  disable = False
+
+  # How wide to allow formatted cmake files
+  line_width = 100
+
+  # How many spaces to tab for indent
+  tab_size = 4
+
+  # If true, lines are indented using tab characters (utf-8 0x09) instead of
+  # <tab_size> space characters (utf-8 0x20). In cases where the layout would
+  # require a fractional tab character, the behavior of the  fractional
+  # indentation is governed by <fractional_tab_policy>
+  use_tabchars = False
+
+  # If <use_tabchars> is True, then the value of this variable indicates how
+  # fractional indentions are handled during whitespace replacement. If set to
+  # 'use-space', fractional indentation is left as spaces (utf-8 0x20). If set
+  # to `round-up` fractional indentation is replaced with a single tab character
+  # (utf-8 0x09) effectively shifting the column to the next tabstop
+  fractional_tab_policy = 'use-space'
+
+  # If an argument group contains more than this many sub-groups (parg or kwarg
+  # groups) then force it to a vertical layout.
+  max_subgroups_hwrap = 2
+
+  # If a positional argument group contains more than this many arguments, then
+  # force it to a vertical layout.
+  max_pargs_hwrap = 6
+
+  # If a cmdline positional group consumes more than this many lines without
+  # nesting, then invalidate the layout (and nest)
+  max_rows_cmdline = 2
+
+  # If true, separate flow control names from their parentheses with a space
+  separate_ctrl_name_with_space = False
+
+  # If true, separate function names from parentheses with a space
+  separate_fn_name_with_space = False
+
+  # If a statement is wrapped to more than one line, than dangle the closing
+  # parenthesis on its own line.
+  dangle_parens = False
+
+  # If the trailing parenthesis must be 'dangled' on its on line, then align it
+  # to this reference: `prefix`: the start of the statement,  `prefix-indent`:
+  # the start of the statement, plus one indentation  level, `child`: align to
+  # the column of the arguments
+  dangle_align = 'prefix'
+
+  # If the statement spelling length (including space and parenthesis) is
+  # smaller than this amount, then force reject nested layouts.
+  min_prefix_chars = 4
+
+  # If the statement spelling length (including space and parenthesis) is larger
+  # than the tab width by more than this amount, then force reject un-nested
+  # layouts.
+  max_prefix_chars = 10
+
+  # If a candidate layout is wrapped horizontally but it exceeds this many
+  # lines, then reject the layout.
+  max_lines_hwrap = 2
+
+  # What style line endings to use in the output.
+  line_ending = 'unix'
+
+  # Format command names consistently as 'lower' or 'upper' case
+  command_case = 'canonical'
+
+  # Format keywords consistently as 'lower' or 'upper' case
+  keyword_case = 'unchanged'
+
+  # A list of command names which should always be wrapped
+  always_wrap = []
+
+  # If true, the argument lists which are known to be sortable will be sorted
+  # lexicographicall
+  enable_sort = True
+
+  # If true, the parsers may infer whether or not an argument list is sortable
+  # (without annotation).
+  autosort = False
+
+  # By default, if cmake-format cannot successfully fit everything into the
+  # desired linewidth it will apply the last, most agressive attempt that it
+  # made. If this flag is True, however, cmake-format will print error, exit
+  # with non-zero status code, and write-out nothing
+  require_valid_layout = False
+
+  # A dictionary mapping layout nodes to a list of wrap decisions. See the
+  # documentation for more information.
+  layout_passes = {}
+
+# ------------------------------------------------
+# Options affecting comment reflow and formatting.
+# ------------------------------------------------
+with section("markup"):
+
+  # What character to use for bulleted lists
+  bullet_char = '*'
+
+  # What character to use as punctuation after numerals in an enumerated list
+  enum_char = '.'
+
+  # If comment markup is enabled, don't reflow the first comment block in each
+  # listfile. Use this to preserve formatting of your copyright/license
+  # statements.
+  first_comment_is_literal = False
+
+  # If comment markup is enabled, don't reflow any comment block which matches
+  # this (regex) pattern. Default is `None` (disabled).
+  literal_comment_pattern = None
+
+  # Regular expression to match preformat fences in comments default=
+  # ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+  fence_pattern = '^\\s*([`~]{3}[`~]*)(.*)$'
+
+  # Regular expression to match rulers in comments default=
+  # ``r'^\s*[^\w\s]{3}.*[^\w\s]{3}$'``
+  ruler_pattern = '^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$'
+
+  # If a comment line matches starts with this pattern then it is explicitly a
+  # trailing comment for the preceeding argument. Default is '#<'
+  explicit_trailing_pattern = '#<'
+
+  # If a comment line starts with at least this many consecutive hash
+  # characters, then don't lstrip() them off. This allows for lazy hash rulers
+  # where the first hash char is not separated by space
+  hashruler_min_length = 10
+
+  # If true, then insert a space between the first hash char and remaining hash
+  # chars in a hash ruler, and normalize its length to fill the column
+  canonicalize_hashrulers = True
+
+  # enable comment markup parsing and reflow
+  enable_markup = True
+
+# ----------------------------
+# Options affecting the linter
+# ----------------------------
+with section("lint"):
+
+  # a list of lint codes to disable
+  disabled_codes = ['C0103', 'C0113']
+
+  # regular expression pattern describing valid function names
+  function_pattern = '[0-9a-z_]+'
+
+  # regular expression pattern describing valid macro names
+  macro_pattern = '[0-9A-Z_]+'
+
+  # regular expression pattern describing valid names for variables with global
+  # (cache) scope
+  global_var_pattern = '[A-Z][0-9A-Z_]+'
+
+  # regular expression pattern describing valid names for variables with global
+  # scope (but internal semantic)
+  internal_var_pattern = '_[A-Z][0-9A-Z_]+'
+
+  # regular expression pattern describing valid names for variables with local
+  # scope
+  local_var_pattern = '[a-z][a-z0-9_]+'
+
+  # regular expression pattern describing valid names for privatedirectory
+  # variables
+  private_var_pattern = '_[0-9a-z_]+'
+
+  # regular expression pattern describing valid names for public directory
+  # variables
+  public_var_pattern = '[A-Z][0-9A-Z_]+'
+
+  # regular expression pattern describing valid names for function/macro
+  # arguments and loop variables.
+  argument_var_pattern = '[a-z][a-z0-9_]+'
+
+  # regular expression pattern describing valid names for keywords used in
+  # functions or macros
+  keyword_pattern = '[A-Z][0-9A-Z_]+'
+
+  # In the heuristic for C0201, how many conditionals to match within a loop in
+  # before considering the loop a parser.
+  max_conditionals_custom_parser = 2
+
+  # Require at least this many newlines between statements
+  min_statement_spacing = 1
+
+  # Require no more than this many newlines between statements
+  max_statement_spacing = 2
+  max_returns = 6
+  max_branches = 12
+  max_arguments = 5
+  max_localvars = 15
+  max_statements = 50
+
+# -------------------------------
+# Options affecting file encoding
+# -------------------------------
+with section("encode"):
+
+  # If true, emit the unicode byte-order mark (BOM) at the start of the file
+  emit_byteorder_mark = False
+
+  # Specify the encoding of the input file. Defaults to utf-8
+  input_encoding = 'utf-8'
+
+  # Specify the encoding of the output file. Defaults to utf-8. Note that cmake
+  # only claims to support utf-8 so be careful when using anything else
+  output_encoding = 'utf-8'
+
+# -------------------------------------
+# Miscellaneous configurations options.
+# -------------------------------------
+with section("misc"):
+
+  # A dictionary containing any per-command configuration overrides. Currently
+  # only `command_case` is supported.
+  per_command = {}
+

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   clang-formatter:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
     - name: clang-format

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,14 +8,11 @@ on:
 
 jobs:
   clang-formatter:
-
-    runs-on: ubuntu-24.04
-
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: clang-format
       run: |
-
         sudo apt update
         sudo apt install clang-format
         for component in core dynamics physics
@@ -24,3 +21,12 @@ jobs:
           clang-format --dry-run -Werror *cpp include/*hpp
           cd -
         done
+
+  cmake-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: clang-format
+      run: |
+        pip install cmakelang
+        cmake-lint $(find . -name CMakeLists.txt) --disabled {C0103,C0113}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -30,3 +30,5 @@ jobs:
       run: |
         pip install cmakelang
         cmake-lint $(find . -name CMakeLists.txt) --disabled {C0103,C0113}
+        # NOTE: We ignore C0103, which would enforce that variables are all-caps
+        # NOTE: We ignore C0113, which would enforce that comments are used

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  clang-formatter:
+  clang-format:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,7 +29,8 @@ jobs:
     - name: clang-format
       run: |
         pip install cmakelang
-        cmake-lint $(find . -name CMakeLists.txt) \
-          --disabled {C0103,C0113} --line-width 100 --tab-size 4
+        cmake-lint $(find . -name CMakeLists.txt) -c .cmake-lint-config.py
         # NOTE: We ignore C0103, which would enforce that variables are all-caps
         # NOTE: We ignore C0113, which would enforce that comments are used
+        # NOTE: We set the tab size to 4
+        # NOTE: We set the maximum line length to 100

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -29,6 +29,7 @@ jobs:
     - name: clang-format
       run: |
         pip install cmakelang
-        cmake-lint $(find . -name CMakeLists.txt) --disabled {C0103,C0113}
+        cmake-lint $(find . -name CMakeLists.txt) \
+          --disabled {C0103,C0113} --line-width 100 --tab-size 4
         # NOTE: We ignore C0103, which would enforce that variables are all-caps
         # NOTE: We ignore C0113, which would enforce that comments are used

--- a/.pre-commit
+++ b/.pre-commit
@@ -26,7 +26,7 @@ done
 
 # Apply cmake-lint for linting
 for FILE in $(git diff --cached --name-only | grep -i 'CMakeLists.txt'); do
-  cmake-lint ${FILE} --disabled {C0103,C0113} --line-width 100 --tab-size 4
+  cmake-lint ${FILE} -c .cmake-lint-config.py
 done
 
 # Abort commit if formatting was applied

--- a/.pre-commit
+++ b/.pre-commit
@@ -3,7 +3,7 @@
 # An example pre-commit file for nextSIM-DG development
 
 BEFORE=$(mktemp)
-git diff > ${BEFORE}
+git diff >${BEFORE}
 
 for FILE in $(git diff --cached --name-only | grep -iE '\.(cpp|cc|h|hpp)$'); do
   # Apply clang-format for linting
@@ -17,8 +17,8 @@ done
 
 # Abort commit if formatting was applied
 AFTER=$(mktemp)
-git diff > ${AFTER}
-if [ "$(diff nextsim_precommit_before.patch nextsim_precommit_after.patch)" ]; then
+git diff >${AFTER}
+if [ "$(diff ${BEFORE} ${AFTER})" ]; then
   echo "Aborting git commit because the pre-commit hook made changes."
   rm ${BEFORE} ${AFTER}
   exit 1

--- a/.pre-commit
+++ b/.pre-commit
@@ -1,6 +1,15 @@
 #!/bin/bash
 
 # An example pre-commit file for nextSIM-DG development
+#
+# To use this pre-commit hook, you will need to install:
+# * clang-format (see https://clang.llvm.org/docs/ClangFormat.html)
+# * cmake-format (see https://github.com/cheshirekow/cmake_format)
+#
+# Then copy this file as `.git/hooks/pre-commit` to set the pre-commit hook up.
+#
+# If changes are made by the pre-commit hook then the commit will abort and you
+# will need to re-run the commit command.
 
 BEFORE=$(mktemp)
 git diff >${BEFORE}

--- a/.pre-commit
+++ b/.pre-commit
@@ -24,6 +24,11 @@ for FILE in $(git diff --cached --name-only | grep -iE '\.(cpp|cc|h|hpp)$'); do
   sed -i~ "s/${LINE}/${NEWLINE}/" ${FILE}
 done
 
+# Apply cmake-lint for linting
+for FILE in $(git diff --cached --name-only | grep -i 'CMakeLists.txt'); do
+  cmake-lint ${FILE} --disabled {C0103,C0113} --line-width 100
+done
+
 # Abort commit if formatting was applied
 AFTER=$(mktemp)
 git diff >${AFTER}

--- a/.pre-commit
+++ b/.pre-commit
@@ -4,7 +4,7 @@
 #
 # To use this pre-commit hook, you will need to install:
 # * clang-format (see https://clang.llvm.org/docs/ClangFormat.html)
-# * cmake-format (see https://github.com/cheshirekow/cmake_format)
+# * cmake-lint (see https://github.com/cheshirekow/cmake_format)
 #
 # Then copy this file as `.git/hooks/pre-commit` to set the pre-commit hook up.
 #

--- a/.pre-commit
+++ b/.pre-commit
@@ -26,7 +26,7 @@ done
 
 # Apply cmake-lint for linting
 for FILE in $(git diff --cached --name-only | grep -i 'CMakeLists.txt'); do
-  cmake-lint ${FILE} --disabled {C0103,C0113} --line-width 100
+  cmake-lint ${FILE} --disabled {C0103,C0113} --line-width 100 --tab-size 4
 done
 
 # Abort commit if formatting was applied


### PR DESCRIPTION
# Fix pre-commit hook; add CMake formatting pre-commit

There was a minor issue in the pre-commit hook because the final lines checked for differences in `nextsim_precommit_before.patch` and `nextsim_precommit_after.patch` but these were replaced with calls to `mktemp`.

While fixing this, I realised we aren't currently formatting `CMakeLists.txt` files but tools for this exist. Let me know if this is something we'd like to include.

I also added some docs on how to get the pre-commit hook set up.

(Almost all of the changes in this PR are auto-formatting.)