### PR TITLE
Workflow handling

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ main, develop ]
     paths:
+      - '.github/workflows/linting.yml'
       - '**.cpp'
       - '**.hpp'
       - '**CMakeLists.txt'

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+    paths:
+      - '**.cpp'
+      - '**.hpp'
+      - '**CMakeLists.txt'
 
 jobs:
   clang-format:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
-    - name: clang-format
+    - name: cmake-format
       run: |
         sudo apt update
         sudo apt install clang-format

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v2
-    - name: cmake-format
+    - name: clang-format
       run: |
         sudo apt update
         sudo apt install clang-format
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: clang-format
+    - name: cmake-format
       run: |
         pip install cmakelang
         cmake-lint $(find . -name CMakeLists.txt) -c .cmake-lint-config.py

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ main, develop ]
     paths:
+      - '.github/workflows/test_suite.yml'
       - '**.cdl'
       - '**.cfg'
       - '**.cpp'

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -5,6 +5,15 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+    paths:
+      - '**.cdl'
+      - '**.cfg'
+      - '**.cpp'
+      - '**.hpp'
+      - '**.py'
+      - '**.sh'
+      - '**.xml'
+      - '**CMakeLists.txt'
 
 jobs:
 


### PR DESCRIPTION
# Workflow handling

In the interests of green computing, development efficiency and avoiding unnecessary CI runs, this PR sets up paths for workflow handling, so that the linters are only run if the source code or build code change and the test suite is only run if the test suite, build system, or config files change.

The PR also fixes a copy-paste error in the linting workflow (introduced in #759).