### PR TITLE
Calculate correct gridd cell area on parametric meshes

### DIFF
--- a/dynamics/src/ParametricMesh.cpp
+++ b/dynamics/src/ParametricMesh.cpp
@@ -1,3 +1,9 @@
+/*!
+ * @file ParametricMesh.hpp
+ * @date 14 Jan 2025
+ * @author Thomas Richter <thomas.richter@ovgu.de>
+ */
+
 #include "ParametricMesh.hpp"
 
 #include "ParametricTools.hpp"
@@ -330,24 +336,6 @@ double ParametricMesh::area(const size_t eid) const
             * EarthRadius * EarthRadius;
     } else
         abort();
-
-    // const size_t nid = eid2nid(eid);
-
-    // const double a = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + 1, 0))
-    //   .squaredNorm(); // lower
-    // const double b = (vertices.block<1, 2>(nid + 1, 0) - vertices.block<1, 2>(nid + nx + 2, 0))
-    //   .squaredNorm(); // right
-    // const double c
-    //   = (vertices.block<1, 2>(nid + 1 + nx, 0) - vertices.block<1, 2>(nid + 2 + nx, 0))
-    //   .squaredNorm(); // top
-    // const double d = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + nx + 1, 0))
-    //   .squaredNorm(); // left
-    // const double e = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + nx + 2, 0))
-    //   .squaredNorm(); // diag 1
-    // const double f = (vertices.block<1, 2>(nid + 1, 0) - vertices.block<1, 2>(nid + nx + 1, 0))
-    //   .squaredNorm(); // diag 2
-
-    // return 0.25 * sqrt(4.0 * e * f - SQR(b + d - a - c));
 }
 
 /*!

--- a/dynamics/src/ParametricMesh.cpp
+++ b/dynamics/src/ParametricMesh.cpp
@@ -1,5 +1,7 @@
 #include "ParametricMesh.hpp"
 
+#include "ParametricTools.hpp"
+
 #include <fstream>
 #include <iostream>
 
@@ -302,6 +304,56 @@ double ParametricMesh::hmin() const
     return hmin;
 }
 
+  /*!
+   * return the area of the mesh element with index eid
+   */
+double ParametricMesh::area(const size_t eid) const
+  {
+    // the element area is computed by transforming the reference element K = [0,1]^2 onto the element T
+    // Hence, Area(T) = \int_T dx = \int_K J(z) dz
+    // The integral is computed with Gauss-Quadrature
+    // Strangely, 1-point Gauss seems to be exact. But I am not sure if this must be the case.
+    // As J = det( nabla A ) I expect that 2 points must be used. A is bi-linear, hence, nabla A
+    // has linear parts and det( nabla A) can be quadratic.
+    // I am using 2 to make it safe :-) 
+    //
+    // In Spherical Coordinates, the cosine of the lat must be added. This increases the error
+    // Machine precision is only achieved for 3 GP. I propose to use only two, which still gives
+    // 10^-9 rel. error. 
+    if (CoordinateSystem == CARTESIAN)
+      {
+	return (ParametricTools::J<2>((*this),eid).array() * GAUSSWEIGHTS<2>.array()).sum();
+      }
+    else if (CoordinateSystem == SPHERICAL)
+      {
+	// In spherical coordinates cosine of the latitude and the square of the radius must be added
+	return (ParametricTools::J<2>((*this),eid).array()
+		* GAUSSWEIGHTS<2>.array()
+		* (ParametricTools::getGaussPointsInElement<2>((*this), eid).row(1).array()).cos()).sum()
+	  * EarthRadius * EarthRadius;
+	
+      }
+    else abort();
+    
+    // const size_t nid = eid2nid(eid);
+    
+    // const double a = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + 1, 0))
+    //   .squaredNorm(); // lower
+    // const double b = (vertices.block<1, 2>(nid + 1, 0) - vertices.block<1, 2>(nid + nx + 2, 0))
+    //   .squaredNorm(); // right
+    // const double c
+    //   = (vertices.block<1, 2>(nid + 1 + nx, 0) - vertices.block<1, 2>(nid + 2 + nx, 0))
+    //   .squaredNorm(); // top
+    // const double d = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + nx + 1, 0))
+    //   .squaredNorm(); // left
+    // const double e = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + nx + 2, 0))
+    //   .squaredNorm(); // diag 1
+    // const double f = (vertices.block<1, 2>(nid + 1, 0) - vertices.block<1, 2>(nid + nx + 1, 0))
+    //   .squaredNorm(); // diag 2
+    
+    // return 0.25 * sqrt(4.0 * e * f - SQR(b + d - a - c));
+    }
+  
 /*!
  * returns are of domain
  */

--- a/dynamics/src/ParametricMesh.cpp
+++ b/dynamics/src/ParametricMesh.cpp
@@ -309,20 +309,17 @@ double ParametricMesh::hmin() const
    */
 double ParametricMesh::area(const size_t eid) const
   {
-    // the element area is computed by transforming the reference element K = [0,1]^2 onto the element T
+    // The element area is computed by transforming the reference element K = [0,1]^2 onto the element T
     // Hence, Area(T) = \int_T dx = \int_K J(z) dz
     // The integral is computed with Gauss-Quadrature
-    // Strangely, 1-point Gauss seems to be exact. But I am not sure if this must be the case.
-    // As J = det( nabla A ) I expect that 2 points must be used. A is bi-linear, hence, nabla A
-    // has linear parts and det( nabla A) can be quadratic.
-    // I am using 2 to make it safe :-) 
+    // For Cartesian meshes, 1 Gauss point is sufficient as J is a bi-linear function. 
     //
     // In Spherical Coordinates, the cosine of the lat must be added. This increases the error
     // Machine precision is only achieved for 3 GP. I propose to use only two, which still gives
     // 10^-9 rel. error. 
     if (CoordinateSystem == CARTESIAN)
       {
-	return (ParametricTools::J<2>((*this),eid).array() * GAUSSWEIGHTS<2>.array()).sum();
+	return (ParametricTools::J<1>((*this),eid).array() * GAUSSWEIGHTS<1>.array()).sum();
       }
     else if (CoordinateSystem == SPHERICAL)
       {

--- a/dynamics/src/ParametricMesh.cpp
+++ b/dynamics/src/ParametricMesh.cpp
@@ -6,7 +6,6 @@
 #include <iostream>
 
 namespace Nextsim {
-
 void ParametricMesh::readmesh(std::string fname)
 {
     reset();
@@ -292,6 +291,7 @@ void ParametricMesh::sortDirichlet(Edge edge)
 {
     std::sort(dirichlet[edge].begin(), dirichlet[edge].end());
 }
+
 /*!
  * returns minimum mesh size.
  *
@@ -304,36 +304,35 @@ double ParametricMesh::hmin() const
     return hmin;
 }
 
-  /*!
-   * return the area of the mesh element with index eid
-   */
+/*!
+ * return the area of the mesh element with index eid
+ */
 double ParametricMesh::area(const size_t eid) const
-  {
-    // The element area is computed by transforming the reference element K = [0,1]^2 onto the element T
-    // Hence, Area(T) = \int_T dx = \int_K J(z) dz
+{
+    // The element area is computed by transforming the reference element K = [0,1]^2 onto the
+    // element T. Hence, Area(T) = \int_T dx = \int_K J(z) dz
     // The integral is computed with Gauss-Quadrature
-    // For Cartesian meshes, 1 Gauss point is sufficient as J is a bi-linear function. 
+    // For Cartesian meshes, 1 Gauss point is sufficient as J is a bi-linear
+    // function.
     //
     // In Spherical Coordinates, the cosine of the lat must be added. This increases the error
     // Machine precision is only achieved for 3 GP. I propose to use only two, which still gives
-    // 10^-9 rel. error. 
-    if (CoordinateSystem == CARTESIAN)
-      {
-	return (ParametricTools::J<1>((*this),eid).array() * GAUSSWEIGHTS<1>.array()).sum();
-      }
-    else if (CoordinateSystem == SPHERICAL)
-      {
-	// In spherical coordinates cosine of the latitude and the square of the radius must be added
-	return (ParametricTools::J<2>((*this),eid).array()
-		* GAUSSWEIGHTS<2>.array()
-		* (ParametricTools::getGaussPointsInElement<2>((*this), eid).row(1).array()).cos()).sum()
-	  * EarthRadius * EarthRadius;
-	
-      }
-    else abort();
-    
+    // 10^-9 rel. error.
+    if (CoordinateSystem == CARTESIAN) {
+        return (ParametricTools::J<1>((*this), eid).array() * GAUSSWEIGHTS<1>.array()).sum();
+    } else if (CoordinateSystem == SPHERICAL) {
+        // In spherical coordinates cosine of the latitude and the square of the radius must be
+        // added
+        return (ParametricTools::J<2>((*this), eid).array() * GAUSSWEIGHTS<2>.array()
+                   * (ParametricTools::getGaussPointsInElement<2>((*this), eid).row(1).array())
+                         .cos())
+                   .sum()
+            * EarthRadius * EarthRadius;
+    } else
+        abort();
+
     // const size_t nid = eid2nid(eid);
-    
+
     // const double a = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + 1, 0))
     //   .squaredNorm(); // lower
     // const double b = (vertices.block<1, 2>(nid + 1, 0) - vertices.block<1, 2>(nid + nx + 2, 0))
@@ -347,10 +346,10 @@ double ParametricMesh::area(const size_t eid) const
     //   .squaredNorm(); // diag 1
     // const double f = (vertices.block<1, 2>(nid + 1, 0) - vertices.block<1, 2>(nid + nx + 1, 0))
     //   .squaredNorm(); // diag 2
-    
+
     // return 0.25 * sqrt(4.0 * e * f - SQR(b + d - a - c));
-    }
-  
+}
+
 /*!
  * returns are of domain
  */
@@ -361,5 +360,4 @@ double ParametricMesh::area() const
         a += area(i);
     return a;
 }
-
 }

--- a/dynamics/src/include/ParametricMesh.hpp
+++ b/dynamics/src/include/ParametricMesh.hpp
@@ -1,6 +1,6 @@
 /*!
  * @file ParametricMesh.hpp
- * @date 9 Juli 2022
+ * @date 09 Jan 2025
  * @author Thomas Richter <thomas.richter@ovgu.de>
  */
 
@@ -19,7 +19,6 @@
 #include <vector>
 
 namespace Nextsim {
-
 inline constexpr double SQR(double x) { return x * x; }
 
 /*!
@@ -155,6 +154,7 @@ public:
             vertices(i, 0) = atan2(y2, x2);
         }
     }
+
     //! Rotation back to normal
     void RotatePoleFromGreenland()
     {
@@ -253,6 +253,7 @@ public:
 
         return ecoords;
     }
+
     const Eigen::Matrix<Nextsim::FloatType, 2, 2> coordinatesOfEdgeY(const size_t eid) const
     {
         const size_t ex = eid % (nx + 1); //! x-index of the corresponding element (possibly nx+1)
@@ -274,6 +275,7 @@ public:
      * return the area of the mesh element with index eid
      */
     double area(const size_t eid) const;
+
     /*!
      * return the mesh size (as square root of area)  of the mesh element eid
      */
@@ -351,7 +353,6 @@ public:
                 return Vertex({ vertices(nnodes - 1, 0), vertices(nnodes - 1, 1) });
             }
             abort();
-
         } else
             abort();
     }
@@ -421,7 +422,6 @@ public:
     double hmin() const; //! returns the minimum mesh size
     double area() const; //! returns the area of the domain
 };
-
 } /* namespace Nextsim */
 
 #endif /* __MESH_HPP */

--- a/dynamics/src/include/ParametricMesh.hpp
+++ b/dynamics/src/include/ParametricMesh.hpp
@@ -273,26 +273,7 @@ public:
     /*!
      * return the area of the mesh element with index eid
      */
-    double area(const size_t eid) const
-    {
-        const size_t nid = eid2nid(eid);
-
-        const double a = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + 1, 0))
-                             .squaredNorm(); // lower
-        const double b = (vertices.block<1, 2>(nid + 1, 0) - vertices.block<1, 2>(nid + nx + 2, 0))
-                             .squaredNorm(); // right
-        const double c
-            = (vertices.block<1, 2>(nid + 1 + nx, 0) - vertices.block<1, 2>(nid + 2 + nx, 0))
-                  .squaredNorm(); // top
-        const double d = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + nx + 1, 0))
-                             .squaredNorm(); // left
-        const double e = (vertices.block<1, 2>(nid, 0) - vertices.block<1, 2>(nid + nx + 2, 0))
-                             .squaredNorm(); // diag 1
-        const double f = (vertices.block<1, 2>(nid + 1, 0) - vertices.block<1, 2>(nid + nx + 1, 0))
-                             .squaredNorm(); // diag 2
-
-        return 0.25 * sqrt(4.0 * e * f - SQR(b + d - a - c));
-    }
+    double area(const size_t eid) const;
     /*!
      * return the mesh size (as square root of area)  of the mesh element eid
      */

--- a/dynamics/test/CMakeLists.txt
+++ b/dynamics/test/CMakeLists.txt
@@ -60,8 +60,6 @@ if(NOT ENABLE_MPI)
     )
     target_link_libraries(testParametricMeshArea LINK_PUBLIC doctest::doctest Eigen3::Eigen)
 
-
-
     add_executable(
         testAdvection
         Advection_test.cpp

--- a/dynamics/test/CMakeLists.txt
+++ b/dynamics/test/CMakeLists.txt
@@ -48,6 +48,21 @@ if(NOT ENABLE_MPI)
     target_link_libraries(testParametricMesh LINK_PUBLIC doctest::doctest Eigen3::Eigen)
 
     add_executable(
+        testParametricMeshArea
+        "ParametricMeshArea_test.cpp"
+        "${SRC_DIR}/ParametricMesh.cpp"
+        "${CoreDir}/ModelArray.cpp"
+        "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
+    )
+    target_include_directories(
+        testParametricMeshArea
+        PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}"
+    )
+    target_link_libraries(testParametricMeshArea LINK_PUBLIC doctest::doctest Eigen3::Eigen)
+
+
+
+    add_executable(
         testAdvection
         Advection_test.cpp
         "${SRC_DIR}/Interpolations.cpp"

--- a/dynamics/test/ParametricMeshArea_test.cpp
+++ b/dynamics/test/ParametricMeshArea_test.cpp
@@ -1,0 +1,143 @@
+/*!
+ * @file ParametricMesh_test.cpp
+ *
+ * @brief Test the ParametricMesh class, especially processing from ModelArray files.
+ *
+ * @date Dec 15, 2023
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include "include/ParametricMesh.hpp"
+
+#include "../test/FakeSmeshData.hpp"
+#include "include/gridNames.hpp"
+
+#include <filesystem>
+
+namespace Nextsim {
+
+#define TO_STR(s) TO_STRI(s)
+#define TO_STRI(s) #s
+#ifndef TEST_FILE_SOURCE
+#define TEST_FILE_SOURCE .
+#endif
+
+static const size_t nx = 154;
+static const size_t ny = 121;
+static const double dx = 25000;
+static const double dy = 25000;
+
+TEST_SUITE_BEGIN("ParametricMeshArea");
+
+  
+TEST_CASE("Test area cartesian")
+{
+    ParametricMesh smesh(CARTESIAN);
+
+    // define mesh
+    smesh.nx = nx;
+    smesh.ny = ny;
+    smesh.nelements = nx*ny;
+    smesh.nnodes = (nx+1)*(ny+1);
+    smesh.vertices.resize(smesh.nnodes,2);
+    for (int iy=0;iy<=ny;++iy)
+      for (int ix=0;ix<=nx;++ix)
+	{
+	  smesh.vertices((nx+1)*iy+ix,0) = dx * ix/nx;
+	  smesh.vertices((nx+1)*iy+ix,1) = dy * iy/ny;
+	}
+    smesh.landmask.resize(nx*ny, true);
+
+    // exact area
+    double exact = dx*dy;
+
+    
+    // check mesh area
+    double totalarea = 0.0;
+    for (int i=0;i<nx*ny;++i)
+      {
+	REQUIRE(smesh.area(i)>0);
+	totalarea += smesh.area(i); // area must be positive
+      }
+
+    // total area must match domain dimension up to machine accuracy
+    REQUIRE( fabs(1.0 - totalarea/exact) < 1.e-12);
+
+    //////// next, distort the inner vertices of the mesh
+    double h = std::min(dx/nx,dy/ny); // min. mesh size in x/y-direction
+    for (int iy=1;iy<ny;++iy)
+      for (int ix=1;ix<nx;++ix)
+	{
+	  smesh.vertices((nx+1)*iy+ix,0) += 0.2*h*sin(ix+iy); // distort by 20%
+	  smesh.vertices((nx+1)*iy+ix,1) += 0.2*h*cos(ix+iy);
+	}
+
+    // check mesh area
+    totalarea = 0.0;
+    for (int i=0;i<nx*ny;++i)
+      {
+	REQUIRE(smesh.area(i)>0);
+	totalarea += smesh.area(i); // area must be positive
+      }
+    // total area must match domain dimension up to machine accuracy
+    REQUIRE( fabs(1.0 - totalarea/exact) < 1.e-12);
+}
+
+
+TEST_CASE("Test area spherical")
+{
+    ParametricMesh smesh(SPHERICAL);
+
+    // define mesh
+    smesh.nx = nx;
+    smesh.ny = ny;
+    smesh.nelements = nx*ny;
+    smesh.nnodes = (nx+1)*(ny+1);
+    smesh.vertices.resize(smesh.nnodes,2);
+    for (int iy=0;iy<=ny;++iy)
+      for (int ix=0;ix<=nx;++ix)
+	{
+	  smesh.vertices((nx+1)*iy+ix,0) = -1.0 * M_PI + 2.0 * M_PI * ix/nx;
+	  smesh.vertices((nx+1)*iy+ix,1) = -0.5 * M_PI + 1.0 * M_PI * iy/ny;
+	}
+    smesh.landmask.resize(nx*ny, true);
+
+    // exact radius (surface of earth)
+    double exact = 4.0 * M_PI * EarthRadius * EarthRadius;
+
+    // check mesh area
+    double totalarea = 0.0;
+    for (int i=0;i<nx*ny;++i)
+      {
+	REQUIRE(smesh.area(i)>0);
+	totalarea += smesh.area(i); // area must be positive
+      }
+    
+
+    // total area must match domain dimension up to machine accuracy
+    REQUIRE( fabs(1.0 - totalarea/exact) < 1.e-9);
+
+    //////// next, distort the inner vertices of the mesh
+    double h = std::min(2.0*M_PI/nx,M_PI/ny); // min. mesh size in x/y-direction
+    for (int iy=1;iy<ny;++iy)
+      for (int ix=1;ix<nx;++ix)
+	{
+	  smesh.vertices((nx+1)*iy+ix,0) += 0.2*h*sin(ix+iy); // distort by 20%
+	  smesh.vertices((nx+1)*iy+ix,1) += 0.2*h*cos(ix+iy);
+	}
+
+    // check mesh area
+    totalarea = 0.0;
+    for (int i=0;i<nx*ny;++i)
+      {
+	REQUIRE(smesh.area(i)>0);
+	totalarea += smesh.area(i); // area must be positive
+      }
+    // total area must match domain dimension up to machine accuracy
+    REQUIRE( fabs(1.0 - totalarea/exact) < 1.e-9);
+}
+  
+}

--- a/dynamics/test/ParametricMeshArea_test.cpp
+++ b/dynamics/test/ParametricMeshArea_test.cpp
@@ -3,7 +3,7 @@
  *
  * @brief Test the ParametricMesh class, especially processing from ModelArray files.
  *
- * @date Dec 15, 2023
+ * @date 09 Jan 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -18,7 +18,6 @@
 #include <filesystem>
 
 namespace Nextsim {
-
 #define TO_STR(s) TO_STRI(s)
 #define TO_STRI(s) #s
 #ifndef TEST_FILE_SOURCE
@@ -32,7 +31,6 @@ static const double dy = 25000;
 
 TEST_SUITE_BEGIN("ParametricMeshArea");
 
-  
 TEST_CASE("Test area cartesian")
 {
     ParametricMesh smesh(CARTESIAN);
@@ -40,52 +38,46 @@ TEST_CASE("Test area cartesian")
     // define mesh
     smesh.nx = nx;
     smesh.ny = ny;
-    smesh.nelements = nx*ny;
-    smesh.nnodes = (nx+1)*(ny+1);
-    smesh.vertices.resize(smesh.nnodes,2);
-    for (int iy=0;iy<=ny;++iy)
-      for (int ix=0;ix<=nx;++ix)
-	{
-	  smesh.vertices((nx+1)*iy+ix,0) = dx * ix/nx;
-	  smesh.vertices((nx+1)*iy+ix,1) = dy * iy/ny;
-	}
-    smesh.landmask.resize(nx*ny, true);
+    smesh.nelements = nx * ny;
+    smesh.nnodes = (nx + 1) * (ny + 1);
+    smesh.vertices.resize(smesh.nnodes, 2);
+    for (int iy = 0; iy <= ny; ++iy)
+        for (int ix = 0; ix <= nx; ++ix) {
+            smesh.vertices((nx + 1) * iy + ix, 0) = dx * ix / nx;
+            smesh.vertices((nx + 1) * iy + ix, 1) = dy * iy / ny;
+        }
+    smesh.landmask.resize(nx * ny, true);
 
     // exact area
-    double exact = dx*dy;
+    double exact = dx * dy;
 
-    
     // check mesh area
     double totalarea = 0.0;
-    for (int i=0;i<nx*ny;++i)
-      {
-	REQUIRE(smesh.area(i)>0);
-	totalarea += smesh.area(i); // area must be positive
-      }
+    for (int i = 0; i < nx * ny; ++i) {
+        REQUIRE(smesh.area(i) > 0);
+        totalarea += smesh.area(i); // area must be positive
+    }
 
     // total area must match domain dimension up to machine accuracy
-    REQUIRE( fabs(1.0 - totalarea/exact) < 1.e-12);
+    REQUIRE(fabs(1.0 - totalarea / exact) < 1.e-12);
 
     //////// next, distort the inner vertices of the mesh
-    double h = std::min(dx/nx,dy/ny); // min. mesh size in x/y-direction
-    for (int iy=1;iy<ny;++iy)
-      for (int ix=1;ix<nx;++ix)
-	{
-	  smesh.vertices((nx+1)*iy+ix,0) += 0.2*h*sin(ix+iy); // distort by 20%
-	  smesh.vertices((nx+1)*iy+ix,1) += 0.2*h*cos(ix+iy);
-	}
+    double h = std::min(dx / nx, dy / ny); // min. mesh size in x/y-direction
+    for (int iy = 1; iy < ny; ++iy)
+        for (int ix = 1; ix < nx; ++ix) {
+            smesh.vertices((nx + 1) * iy + ix, 0) += 0.2 * h * sin(ix + iy); // distort by 20%
+            smesh.vertices((nx + 1) * iy + ix, 1) += 0.2 * h * cos(ix + iy);
+        }
 
     // check mesh area
     totalarea = 0.0;
-    for (int i=0;i<nx*ny;++i)
-      {
-	REQUIRE(smesh.area(i)>0);
-	totalarea += smesh.area(i); // area must be positive
-      }
+    for (int i = 0; i < nx * ny; ++i) {
+        REQUIRE(smesh.area(i) > 0);
+        totalarea += smesh.area(i); // area must be positive
+    }
     // total area must match domain dimension up to machine accuracy
-    REQUIRE( fabs(1.0 - totalarea/exact) < 1.e-12);
+    REQUIRE(fabs(1.0 - totalarea / exact) < 1.e-12);
 }
-
 
 TEST_CASE("Test area spherical")
 {
@@ -94,50 +86,44 @@ TEST_CASE("Test area spherical")
     // define mesh
     smesh.nx = nx;
     smesh.ny = ny;
-    smesh.nelements = nx*ny;
-    smesh.nnodes = (nx+1)*(ny+1);
-    smesh.vertices.resize(smesh.nnodes,2);
-    for (int iy=0;iy<=ny;++iy)
-      for (int ix=0;ix<=nx;++ix)
-	{
-	  smesh.vertices((nx+1)*iy+ix,0) = -1.0 * M_PI + 2.0 * M_PI * ix/nx;
-	  smesh.vertices((nx+1)*iy+ix,1) = -0.5 * M_PI + 1.0 * M_PI * iy/ny;
-	}
-    smesh.landmask.resize(nx*ny, true);
+    smesh.nelements = nx * ny;
+    smesh.nnodes = (nx + 1) * (ny + 1);
+    smesh.vertices.resize(smesh.nnodes, 2);
+    for (int iy = 0; iy <= ny; ++iy)
+        for (int ix = 0; ix <= nx; ++ix) {
+            smesh.vertices((nx + 1) * iy + ix, 0) = -1.0 * M_PI + 2.0 * M_PI * ix / nx;
+            smesh.vertices((nx + 1) * iy + ix, 1) = -0.5 * M_PI + 1.0 * M_PI * iy / ny;
+        }
+    smesh.landmask.resize(nx * ny, true);
 
     // exact radius (surface of earth)
     double exact = 4.0 * M_PI * EarthRadius * EarthRadius;
 
     // check mesh area
     double totalarea = 0.0;
-    for (int i=0;i<nx*ny;++i)
-      {
-	REQUIRE(smesh.area(i)>0);
-	totalarea += smesh.area(i); // area must be positive
-      }
-    
+    for (int i = 0; i < nx * ny; ++i) {
+        REQUIRE(smesh.area(i) > 0);
+        totalarea += smesh.area(i); // area must be positive
+    }
 
     // total area must match domain dimension up to machine accuracy
-    REQUIRE( fabs(1.0 - totalarea/exact) < 1.e-9);
+    REQUIRE(fabs(1.0 - totalarea / exact) < 1.e-9);
 
     //////// next, distort the inner vertices of the mesh
-    double h = std::min(2.0*M_PI/nx,M_PI/ny); // min. mesh size in x/y-direction
-    for (int iy=1;iy<ny;++iy)
-      for (int ix=1;ix<nx;++ix)
-	{
-	  smesh.vertices((nx+1)*iy+ix,0) += 0.2*h*sin(ix+iy); // distort by 20%
-	  smesh.vertices((nx+1)*iy+ix,1) += 0.2*h*cos(ix+iy);
-	}
+    double h = std::min(2.0 * M_PI / nx, M_PI / ny); // min. mesh size in x/y-direction
+    for (int iy = 1; iy < ny; ++iy)
+        for (int ix = 1; ix < nx; ++ix) {
+            smesh.vertices((nx + 1) * iy + ix, 0) += 0.2 * h * sin(ix + iy); // distort by 20%
+            smesh.vertices((nx + 1) * iy + ix, 1) += 0.2 * h * cos(ix + iy);
+        }
 
     // check mesh area
     totalarea = 0.0;
-    for (int i=0;i<nx*ny;++i)
-      {
-	REQUIRE(smesh.area(i)>0);
-	totalarea += smesh.area(i); // area must be positive
-      }
+    for (int i = 0; i < nx * ny; ++i) {
+        REQUIRE(smesh.area(i) > 0);
+        totalarea += smesh.area(i); // area must be positive
+    }
     // total area must match domain dimension up to machine accuracy
-    REQUIRE( fabs(1.0 - totalarea/exact) < 1.e-9);
+    REQUIRE(fabs(1.0 - totalarea / exact) < 1.e-9);
 }
-  
 }


### PR DESCRIPTION
# Calculate correct grid cell area on parametric meshes

Fixes #762 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

We do all our calculations on the unit square K of size (0,1) x (0,1). This has area one.

Integrals over a real element, let’s call it T, are transformed back onto the unit square with a map A: K -> T. The formula for the intergral over any function f(x) is just

int_T f(x) dx = int_K J(z) f(A(z)) dz.

The J you will find several times in the code. It is computed in dynamics/src/include/ParamatricTools.hpp
Rather much effort as it is the determinate of the gradient of A (one of the reasons why precomputing it is helpful)

The exact area would be given for f(x) = 1 as

area(T) = int_K J(z) dz.

In terms of our code, to compute the area of element ‘eid’ of the mesh it should simply be

double area = ParametricTools::J<2>(mesh, eid).sum()


An alternative would be some geometry, e.g. given here in the section “Related formulae”:

https://en.wikipedia.org/wiki/Bretschneider%27s_formula

In ‘my version’ of the develop branch this seems to be implemented in src/include/ParametricMesh.hpp. But I would prefer using the mapings determinant J.

---
# Test Description

Added a unit test in dynamcs/tests

The Spherical version I tested with the full Earth and checked that all elements sum up to 4 * Pi *  R^2.

The test is also distorting the meshes to check that the accuracy is good.


---
# Documentation Impact

N/A

---
# Other Details

N/A

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README