### PR TITLE
Add ModelArraySlice.cpp to the ParametricMeshArea test.

### DIFF
--- a/dynamics/test/CMakeLists.txt
+++ b/dynamics/test/CMakeLists.txt
@@ -56,6 +56,7 @@ if(NOT ENABLE_MPI)
         "${SRC_DIR}/ParametricMesh.cpp"
         "${CoreDir}/ModelArray.cpp"
         "${CoreDir}/${ModelArrayStructure}/ModelArrayDetails.cpp"
+        "${CoreDir}/ModelArraySlice.cpp"
     )
     target_include_directories(
         testParametricMeshArea


### PR DESCRIPTION
# Add ModelArraySlice.cpp to the ParametricMeshArea test.

Fixes a link error that was not caught by the CI tests.
