### PR TITLE
fixed NH generation scripts

### DIFF
--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -51,18 +51,18 @@ def create_topaz_times(start_tm, stop_tm):
     return (unix_times, hour_times - topaz4_hours)
 
 # Returns the file name that holds the ERA5 data for a given field at a given time
-def era5_source_file_name(field, unix_time):
+def era5_source_file_name(field, unix_time, path):
     file_year = time.gmtime(unix_time).tm_year
-    return f"ERA5_{field}_y{file_year}.nc"
+    return f"{path}/ERA5_{field}_y{file_year}.nc"
 
 # Returns the file name that holds the TOPAZ data for a given field at a given time
-def topaz4_source_file_name(field, unix_time):
+def topaz4_source_file_name(field, unix_time, path):
     unix_tm = time.gmtime(unix_time)
     if field in ("u", "v", "ssh"):
         # Ocean currents come from the 30 m files
-        return f"TP4DAILY_{unix_tm.tm_year}{unix_tm.tm_mon:02}_30m.nc"
+        return f"{path}/TP4DAILY_{unix_tm.tm_year}{unix_tm.tm_mon:02}_30m.nc"
     else:
-        return f"TP4DAILY_{unix_tm.tm_year}{unix_tm.tm_mon:02}_3m.nc"
+        return f"{path}/TP4DAILY_{unix_tm.tm_year}{unix_tm.tm_mon:02}_3m.nc"
 
 # Returns bilinearly interpolated data given array of fractional indices
 # 2023-03-28 Add a wrap-around for the ERA longitude. This is formally
@@ -176,6 +176,7 @@ if __name__ == "__main__":
     parser.add_argument("--start", dest = "start", required = True, help = "The ISO start date for the forcing file.")
     parser.add_argument("--stop", dest = "stop", required = True, help = "The ISO end date for the forcing file.")
     parser.add_argument("--prefix", dest = "prefix", required = False, help = "A string to prefix the created files with.")
+    parser.add_argument("--forcing_path", default="", help="Path for the forcing files")
     args = parser.parse_args()
     # read the date range
     start_time = time.strptime(args.start, "%Y-%m-%d")
@@ -186,6 +187,8 @@ if __name__ == "__main__":
         filepfx = args.prefix + "."
     else:
         filepfx = ""
+
+    forcing_path = args.forcing_path
 
     # read a grid spec (from a restart file)
     root = netCDF4.Dataset(args.file, "r", format = "NETCDF4")
@@ -213,8 +216,13 @@ if __name__ == "__main__":
     element_y = 0.25 * (node_y[0:-1, 0:-1] + node_y[1:, 0:-1] + node_y[0:-1, 1:] + node_y[1:, 1:])
     element_z = 0.25 * (node_z[0:-1, 0:-1] + node_z[1:, 0:-1] + node_z[0:-1, 1:] + node_z[1:, 1:])
     
-    element_lon = np.degrees(np.arctan2(element_y, element_x))
-    element_lat = np.degrees(np.arctan2(element_z, np.hypot(element_x, element_y)))
+    # take grid coordinates out of the init file
+    element_lon[:, :] = datagrp["longitude"][:,:]
+    element_lat[:, :] = datagrp["latitude"][:,:]
+    # manual computation is slightly off and can create inconsistent forcings
+#    element_lon = np.degrees(np.arctan2(element_y, element_x))
+#    element_lat = np.degrees(np.arctan2(element_z, np.hypot(element_x, element_y)))
+
 
     # azimuth of the +y grid direction in radians
     element_azimuth = np.radians(element_lon * 0 + 45)
@@ -274,7 +282,7 @@ if __name__ == "__main__":
             era5_field = era5_translation[field_name]
             for target_t_index in range(len(unix_times_e)):
                 # get the source data
-                source_file = netCDF4.Dataset(era5_source_file_name(era5_field, unix_times_e[target_t_index]), "r")
+                source_file = netCDF4.Dataset(era5_source_file_name(era5_field, unix_times_e[target_t_index], forcing_path), "r")
                 source_lons = source_file["longitude"]
                 source_lats = source_file["latitude"]
                 target_time = era5_times[target_t_index]
@@ -293,8 +301,8 @@ if __name__ == "__main__":
             v_var = datagrp.createVariable("v", "f8", timefield_dims)
             for target_t_index in range(len(unix_times_e)):
                 # get the source data
-                u_file = netCDF4.Dataset(era5_source_file_name("u10", unix_times_e[target_t_index]), "r")
-                v_file = netCDF4.Dataset(era5_source_file_name("v10", unix_times_e[target_t_index]), "r")
+                u_file = netCDF4.Dataset(era5_source_file_name("u10", unix_times_e[target_t_index], forcing_path), "r")
+                v_file = netCDF4.Dataset(era5_source_file_name("v10", unix_times_e[target_t_index], forcing_path), "r")
                 source_lons = u_file["longitude"]
                 source_lats = u_file["latitude"]
                 target_time = era5_times[target_t_index]
@@ -361,7 +369,7 @@ if __name__ == "__main__":
     
     (unix_times_t, topaz4_times) = create_topaz_times(start_time, stop_time)
 
-    source_file = netCDF4.Dataset(topaz4_source_file_name("mlp", unix_times_t[0]), "r")
+    source_file = netCDF4.Dataset(topaz4_source_file_name("mlp", unix_times_t[0], forcing_path), "r")
     source_lats = source_file["latitude"][:, :]
     lat_array = source_lats[550:, 380]
     source_file.close()
@@ -383,13 +391,13 @@ if __name__ == "__main__":
     # For each field and time, get the corresponding file name for each dataset
     for field_name in ocean_fields:
         data = datagrp.createVariable(field_name, "f8", timefield_dims)
-        if not field_name in skip_ocean_fields:
+        if field_name not in skip_ocean_fields:
             topaz_field = topaz_translation[field_name]
             for target_t_index in range(len(unix_times_t)):
                 if field_name == ocean_fields[0]:
                     nc_times[target_t_index] = unix_times_t[target_t_index]
                 # get the source data
-                source_file = netCDF4.Dataset(topaz4_source_file_name(topaz_field, unix_times_t[target_t_index]), "r")
+                source_file = netCDF4.Dataset(topaz4_source_file_name(topaz_field, unix_times_t[target_t_index], forcing_path), "r")
                 target_time = topaz4_times[target_t_index]
                 source_times = source_file["time"]
                 time_index = (target_time - source_times[0]) // hr_per_day
@@ -411,8 +419,8 @@ if __name__ == "__main__":
     udata = datagrp.createVariable("u", "f8", timefield_dims)
     vdata = datagrp.createVariable("v", "f8", timefield_dims)
     for target_t_index in range (len(unix_times_t)):
-        u_source_file = netCDF4.Dataset(topaz4_source_file_name("u", unix_times_t[target_t_index]), "r")
-        v_source_file = netCDF4.Dataset(topaz4_source_file_name("v", unix_times_t[target_t_index]), "r")
+        u_source_file = netCDF4.Dataset(topaz4_source_file_name("u", unix_times_t[target_t_index], forcing_path), "r")
+        v_source_file = netCDF4.Dataset(topaz4_source_file_name("v", unix_times_t[target_t_index], forcing_path), "r")
         target_time = topaz4_times[target_t_index]
         source_times = u_source_file["time"]
         time_index = (target_time - source_times[0]) // hr_per_day

--- a/run/make_initNH.py
+++ b/run/make_initNH.py
@@ -3,6 +3,7 @@ import numpy as np
 import numpy.ma as ma
 import time
 import math
+from pathlib import Path
 
 topaz_mdi = -32767
 
@@ -10,9 +11,9 @@ topaz_mdi = -32767
 def topaz4_source_file_name(field, unix_time):
     unix_tm = time.gmtime(unix_time)
     if field in ["u", "v"]:
-        return f"TP4DAILY_{unix_tm.tm_year}{unix_tm.tm_mon:02}_30m.nc"
+        return f"{topaz_path}/TP4DAILY_{unix_tm.tm_year}{unix_tm.tm_mon:02}_30m.nc"
     else:
-        return f"TP4DAILY_{unix_tm.tm_year}{unix_tm.tm_mon:02}_3m.nc"
+        return f"{topaz_path}/TP4DAILY_{unix_tm.tm_year}{unix_tm.tm_mon:02}_3m.nc"
 
 # Returns bilinearly interpolated data given array of fractional indices, when some of the data missing
 def bilinear_missing(eyes, jays, data, missing):
@@ -39,6 +40,7 @@ def bilinear_missing(eyes, jays, data, missing):
     
     return weighted_sum / sum_of_weights
 
+
 # Returns TOPAZ data interpolated from the data grid and coordinates to the target grid and coordinates
 def topaz4_interpolate(target_lon_deg, target_lat_deg, data, lat_array):
     # The TOPAZ grid is assumed and hard coded
@@ -46,10 +48,10 @@ def topaz4_interpolate(target_lon_deg, target_lat_deg, data, lat_array):
     jc = 550
     
     # Scale of the map and zero longitude
-    two_r = 1 / math.radians(0.08982849)
+ #   two_r = 1 / math.radians(0.08982849)
     lon0 = math.radians(315.)
 
-    target_lat = np.radians(target_lat_deg)
+#    target_lat = np.radians(target_lat_deg)
     target_lon = np.radians(target_lon_deg)
 #    k = two_r * np.cos(target_lat) / np.sqrt(1 + np.sin(target_lat))
     # Use linear interpolation to get the target indices on the topaz grid
@@ -65,22 +67,36 @@ def topaz4_interpolate(target_lon_deg, target_lat_deg, data, lat_array):
 
 # Creates a 128 x 128 ParaGrid restart file filled with data from TOPAZ on 2010-01-01
 if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description = "Generate an initial state file from TOPAZ4 data")
+    parser.add_argument("--grid-file", dest = "grid_file", default="25km_NH.nc", help = "Path of the NH grid file.")
+    parser.add_argument("--topaz-path", dest = "topaz_path", default=".", help = "Path containing the TOPAZ4 files.")
+    parser.add_argument("--land-mask", dest = "land_mask", default='data', help='One of "data" or "data_closed_boundary"')
+    parser.add_argument("--out-suffix", dest = "out_suffix", default='', help='Added to the name of the output file before the ending"')
+    
+    args = parser.parse_args()
+    grid_file = args.grid_file
+    topaz_path = args.topaz_path
+    land_mask = args.land_mask
+    out_suffix = args.out_suffix
 
-    grid = netCDF4.Dataset("25km_NH.nc", "r")
+    grid = netCDF4.Dataset(f"{grid_file}", "r")
     
     # Grid dimensions. Since x and y are switched between the source grid file
     # and the target restart file, the grid dimensions are nfirst and nsecond.
     # nsecond is the size of the dimension that varies fastest.
     nfirst = grid.dimensions["x"].size
     nsecond = grid.dimensions["y"].size
+    print(f"grid size: {nfirst} x {nsecond}")
     nLayers = 3
     ncg = 1
     n_dg = 1
     n_dgstress = 3
     n_coords = 2
     
-    
-    root = netCDF4.Dataset("init_25km_NH.nc", "w", format="NETCDF4")
+    grid_name = Path(grid_file).stem
+    out_name = f"init_{grid_name}{out_suffix}.nc"
+    root = netCDF4.Dataset(out_name, "w", format="NETCDF4")
     
     structure_name = "parametric_rectangular"
     structgrp = root.createGroup("structure")
@@ -145,9 +161,9 @@ if __name__ == "__main__":
     grid_azimuth_data -= 180
     grid_azimuth[:, :] = grid_azimuth_data
     
-    # Access the TOPAZ data, initally to get latitudes
+    # Access the TOPAZ data, initially to get latitudes
     source_file_name = topaz4_source_file_name("hice", data_time)
-    source_file = netCDF4.Dataset(topaz4_source_file_name("hice", data_time), "r")
+    source_file = netCDF4.Dataset(source_file_name, "r")
     source_lats = source_file["latitude"][:, :]
     lat_array = source_lats[550:, 380]
     
@@ -160,11 +176,16 @@ if __name__ == "__main__":
     mask = datagrp.createVariable("mask", "f8", field_dims)
     sst_data = topaz4_interpolate(element_lon, element_lat, source_file["temperature"][0, :, :].squeeze(), lat_array)
     mask[:, :] = 1 - ma.getmask(sst_data)
-    # Despite having the same data source, the restart file generation script 
-    # and forcing generation script have a consistent, one pixel difference
-    # at the western tip of the New Siberian Islands (100, 95).
-    # Force the land mask to be consistent.
-    mask[100, 95] = 0.0
+    
+    land_ratio = np.count_nonzero(mask) / mask.size
+    print(f"ratio of sea (active) cells to total: {land_ratio}")
+    if land_mask in ['data_closed_boundary']:
+        mask[:,0] = 0.0
+        mask[:,-1] = 0.0
+        mask[0,:] = 0.0
+        mask[-1,:] = 0.0
+        land_ratio = np.count_nonzero(mask) / mask.size
+        print(f"ratio after adjustment: {land_ratio}")
     
     # Ice concentration and thickness
     cice_data = topaz4_interpolate(element_lon, element_lat, source_file["fice"][0, :, :].squeeze(), lat_array)
@@ -206,9 +227,10 @@ if __name__ == "__main__":
 
     # Ice temperature
     tice = datagrp.createVariable("tice", "f8", zfield_dims)
-    ice_melt = mu * 5 # Melting point of sea ice (salinity = 5) in ˚C
+    #ice_melt = mu * 5 # Melting point of sea ice (salinity = 5) in ˚C
+    ice_melt = mu
     # Tice outside the ice pack is the melting point of pure water ice, which is conveniently 0˚C
-    ice_temp2d = np.fmin(sst_data, ice_melt) * isice
+    ice_temp2d = np.fmin(sst_data, ice_melt)
     tice[0, :, :] = ice_temp2d
     tice[1, :, :] = ice_temp2d
     tice[2, :, :] = ice_temp2d
@@ -223,3 +245,4 @@ if __name__ == "__main__":
     v[:, :] = 0
     
     root.close()
+    print(f'Created init file "{out_name}"')


### PR DESCRIPTION
# Pull Request Title

Fixes #770

---
# Change Description

The script `era5_topaz4_maker.py` now uses the mesh coordinates from the init file, ensuring that the grid is the same. The generated forcing files therefore no longer have undefined values on sea-ice cells for any grid spacing and the manual fix with hard-coded indices was removed.

Furthermore, both scripts feature more cmd args such as the paths of the required files, making them more flexible.

---
# Test Description

The generated files where tested manually. The simulation no longer becomes unstable instantly. I am not sure if this impacts the integration test which is based on these scripts.

---
# Documentation Impact

The script `make_init25kmNH.py` was replaced with `make_initNH.py`. I am not sure if this  script is mentioned anywhere.


