### PR TITLE
Handle higher DG components at restart

### DIFF
--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -54,7 +54,7 @@ void PrognosticData::configure()
 }
 
 // Copies an HField from a source ModelArray that is either an HField or a DGField.
-void copyFiniteDifference(const ModelArray& source, ModelArray& sink)
+void copyMeanComponent(const ModelArray& source, ModelArray& sink)
 {
     if (source.nComponents() > 1) {
         sink.setData(source.data().col(0));
@@ -72,13 +72,13 @@ void PrognosticData::setData(const ModelState::DataMap& ms)
         noLandMask();
     }
 
-    copyFiniteDifference(ms.at(hiceName), m_thick);
-    copyFiniteDifference(ms.at(ciceName), m_conc);
-    copyFiniteDifference(ms.at(ticeName), m_tice);
-    copyFiniteDifference(ms.at(hsnowName), m_snow);
+    copyMeanComponent(ms.at(hiceName), m_thick);
+    copyMeanComponent(ms.at(ciceName), m_conc);
+    copyMeanComponent(ms.at(ticeName), m_tice);
+    copyMeanComponent(ms.at(hsnowName), m_snow);
     // Damage is an optional field, and defaults to 1, if absent
     if (ms.count(damageName) > 0) {
-        copyFiniteDifference(ms.at(damageName), m_damage);
+        copyMeanComponent(ms.at(damageName), m_damage);
     } else {
         m_damage.resize();
         m_damage = 1.;

--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -53,22 +53,32 @@ void PrognosticData::configure()
     tryConfigure(iceGrowth);
 }
 
+// Copies an HField from a source ModelArray that is either an HField or a DGField.
+void copyFiniteDifference(const ModelArray& source, ModelArray& sink)
+{
+    if (source.nComponents() > 1) {
+        sink.setData(source.data().col(0));
+    } else {
+        sink = source;
+    }
+}
+
 void PrognosticData::setData(const ModelState::DataMap& ms)
 {
 
-    if (ms.count("mask")) {
-        setOceanMask(ms.at("mask"));
+    if (ms.count(maskName)) {
+        setOceanMask(ms.at(maskName));
     } else {
         noLandMask();
     }
 
-    m_thick = ms.at("hice");
-    m_conc = ms.at("cice");
-    m_tice = ms.at("tice");
-    m_snow = ms.at("hsnow");
+    copyFiniteDifference(ms.at(hiceName), m_thick);
+    copyFiniteDifference(ms.at(ciceName), m_conc);
+    copyFiniteDifference(ms.at(ticeName), m_tice);
+    copyFiniteDifference(ms.at(hsnowName), m_snow);
     // Damage is an optional field, and defaults to 1, if absent
     if (ms.count(damageName) > 0) {
-        m_damage = ms.at(damageName);
+        copyFiniteDifference(ms.at(damageName), m_damage);
     } else {
         m_damage.resize();
         m_damage = 1.;

--- a/core/test/DynamicsModuleForPDtest.cpp
+++ b/core/test/DynamicsModuleForPDtest.cpp
@@ -8,18 +8,18 @@
 #include "include/IDynamics.hpp"
 #include "include/NextsimModule.hpp"
 
-#include "include/DummyDynamics.hpp"
+#include "PDTestDynamics.hpp"
 
 #include <string>
 
 namespace Module {
-const std::string DUMMYDYNAMICS = "Nextsim::DummyDynamics";
+const std::string PDTESTDYNAMICS = "Nextsim::PDTestDynamics";
 
 template <>
 const Module<Nextsim::IDynamics>::Map& Module<Nextsim::IDynamics>::functionMap()
 {
     static const Map theMap = {
-            { DUMMYDYNAMICS, newImpl<Nextsim::IDynamics, Nextsim::DummyDynamics> },
+            { PDTESTDYNAMICS, newImpl<Nextsim::IDynamics, Nextsim::PDTestDynamics> },
     };
     return theMap;
 }
@@ -27,7 +27,7 @@ const Module<Nextsim::IDynamics>::Map& Module<Nextsim::IDynamics>::functionMap()
 template <>
 Module<Nextsim::IDynamics>::Fn& Module<Nextsim::IDynamics>::getGenerationFunction()
 {
-    static Fn thePtr = functionMap().at(DUMMYDYNAMICS);
+    static Fn thePtr = functionMap().at(PDTESTDYNAMICS);
     return thePtr;
 }
 

--- a/core/test/DynamicsModuleForPDtest.cpp
+++ b/core/test/DynamicsModuleForPDtest.cpp
@@ -33,6 +33,11 @@ Module<Nextsim::IDynamics>::Fn& Module<Nextsim::IDynamics>::getGenerationFunctio
 
 template <> std::string Module<Nextsim::IDynamics>::moduleName() { return "Nextsim::IDynamics"; }
 
+template <> Nextsim::IDynamics& getImplementation<Nextsim::IDynamics>()
+{
+    return Module<Nextsim::IDynamics>::getImplementation();
+}
+
 template <> HelpMap& getHelpRecursive<Nextsim::IDynamics>(HelpMap& map, bool getAll) { return map; }
 
 } /* namespace Module */

--- a/core/test/PDTestDynamics.hpp
+++ b/core/test/PDTestDynamics.hpp
@@ -1,0 +1,37 @@
+/*!
+ * @file PDTestDynamics.hpp
+ *
+ * @date Jan 21, 2025
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef PDTESTDYNAMICS_HPP
+#define PDTESTDYNAMICS_HPP
+
+#include "include/DummyDynamics.hpp"
+
+namespace Nextsim {
+class PDTestDynamics : public DummyDynamics {
+public:
+    std::string getName() const override { return "PDTestDynamics"; }
+
+    void setData (const ModelState::DataMap& ms) override
+    {
+        dataMap = ms;
+    }
+    ModelState getState(const OutputLevel&) const override { return getState(); }
+    ModelState getState() const override
+    {
+        return { dataMap, {} };
+    }
+
+    ModelState getStateRecursive(const OutputSpec& os) const override
+    {
+        return { dataMap, {} };
+    }
+private:
+    ModelState::DataMap dataMap;
+};
+}
+
+#endif /* PDTESTDYNAMICS_HPP */

--- a/core/test/PrognosticDataIO_test.cpp
+++ b/core/test/PrognosticDataIO_test.cpp
@@ -5,8 +5,6 @@
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
-#include "include/PrognosticData.hpp"
-
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 

--- a/core/test/PrognosticData_test.cpp
+++ b/core/test/PrognosticData_test.cpp
@@ -5,8 +5,6 @@
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
-#include "include/PrognosticData.hpp"
-
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -62,37 +62,6 @@ void CGDynamicsKernel<DGadvection>::setData(const std::string& name, const Model
     };
     if (targetMap.count(name)) {
         ma2cg(data, *targetMap.at(name));
-        /*    if (name == uName) {
-                // FIXME take into account possibility to restart form CG
-                // CGModelArray::ma2cg(data, u);
-                DGVector<DGadvection> utmp(*smesh);
-                DGModelArray::ma2dg(data, utmp);
-                Nextsim::Interpolations::DG2CG(*smesh, u, utmp);
-            } else if (name == vName) {
-                // CGModelArray::ma2cg(data, v);
-                DGVector<DGadvection> vtmp(*smesh);
-                DGModelArray::ma2dg(data, vtmp);
-                Nextsim::Interpolations::DG2CG(*smesh, v, vtmp);
-            } else if (name == uWindName) {
-                DGVector<DGadvection> utmp(*smesh);
-                utmp.zero();
-                DGModelArray::ma2dg(data, utmp);
-                Nextsim::Interpolations::DG2CG(*smesh, uAtmos, utmp);
-            } else if (name == vWindName) {
-                DGVector<DGadvection> vtmp(*smesh);
-                vtmp.zero();
-                DGModelArray::ma2dg(data, vtmp);
-                Nextsim::Interpolations::DG2CG(*smesh, vAtmos, vtmp);
-            } else if (name == uOceanName) {
-                DGVector<DGadvection> utmp(*smesh);
-                utmp.zero();
-                DGModelArray::ma2dg(data, utmp);
-                Nextsim::Interpolations::DG2CG(*smesh, uOcean, utmp);
-            } else if (name == vOceanName) {
-                DGVector<DGadvection> vtmp(*smesh);
-                vtmp.zero();
-                DGModelArray::ma2dg(data, vtmp);
-                Nextsim::Interpolations::DG2CG(*smesh, vOcean, vtmp);*/
     } else {
         DynamicsKernel<DGadvection, DGstressComp>::setData(name, data);
     }

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -52,7 +52,17 @@ void CGDynamicsKernel<DGadvection>::initialise(
 template <int DGadvection>
 void CGDynamicsKernel<DGadvection>::setData(const std::string& name, const ModelArray& data)
 {
-    if (name == uName) {
+    const std::map<std::string, CGVector<CGdegree>*> targetMap = {
+            {uName, &u},
+            {vName, &v},
+            {uWindName, &uAtmos},
+            {vWindName, &vAtmos},
+            {uOceanName, &uOcean},
+            {vOceanName, &vOcean},
+    };
+    if (targetMap.count(name)) {
+        ma2cg(data, *targetMap.at(name));
+/*    if (name == uName) {
         // FIXME take into account possibility to restart form CG
         // CGModelArray::ma2cg(data, u);
         DGVector<DGadvection> utmp(*smesh);
@@ -82,7 +92,7 @@ void CGDynamicsKernel<DGadvection>::setData(const std::string& name, const Model
         DGVector<DGadvection> vtmp(*smesh);
         vtmp.zero();
         DGModelArray::ma2dg(data, vtmp);
-        Nextsim::Interpolations::DG2CG(*smesh, vOcean, vtmp);
+        Nextsim::Interpolations::DG2CG(*smesh, vOcean, vtmp);*/
     } else {
         DynamicsKernel<DGadvection, DGstressComp>::setData(name, data);
     }

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -53,46 +53,46 @@ template <int DGadvection>
 void CGDynamicsKernel<DGadvection>::setData(const std::string& name, const ModelArray& data)
 {
     const std::map<std::string, CGVector<CGdegree>*> targetMap = {
-            {uName, &u},
-            {vName, &v},
-            {uWindName, &uAtmos},
-            {vWindName, &vAtmos},
-            {uOceanName, &uOcean},
-            {vOceanName, &vOcean},
+        { uName, &u },
+        { vName, &v },
+        { uWindName, &uAtmos },
+        { vWindName, &vAtmos },
+        { uOceanName, &uOcean },
+        { vOceanName, &vOcean },
     };
     if (targetMap.count(name)) {
         ma2cg(data, *targetMap.at(name));
-/*    if (name == uName) {
-        // FIXME take into account possibility to restart form CG
-        // CGModelArray::ma2cg(data, u);
-        DGVector<DGadvection> utmp(*smesh);
-        DGModelArray::ma2dg(data, utmp);
-        Nextsim::Interpolations::DG2CG(*smesh, u, utmp);
-    } else if (name == vName) {
-        // CGModelArray::ma2cg(data, v);
-        DGVector<DGadvection> vtmp(*smesh);
-        DGModelArray::ma2dg(data, vtmp);
-        Nextsim::Interpolations::DG2CG(*smesh, v, vtmp);
-    } else if (name == uWindName) {
-        DGVector<DGadvection> utmp(*smesh);
-        utmp.zero();
-        DGModelArray::ma2dg(data, utmp);
-        Nextsim::Interpolations::DG2CG(*smesh, uAtmos, utmp);
-    } else if (name == vWindName) {
-        DGVector<DGadvection> vtmp(*smesh);
-        vtmp.zero();
-        DGModelArray::ma2dg(data, vtmp);
-        Nextsim::Interpolations::DG2CG(*smesh, vAtmos, vtmp);
-    } else if (name == uOceanName) {
-        DGVector<DGadvection> utmp(*smesh);
-        utmp.zero();
-        DGModelArray::ma2dg(data, utmp);
-        Nextsim::Interpolations::DG2CG(*smesh, uOcean, utmp);
-    } else if (name == vOceanName) {
-        DGVector<DGadvection> vtmp(*smesh);
-        vtmp.zero();
-        DGModelArray::ma2dg(data, vtmp);
-        Nextsim::Interpolations::DG2CG(*smesh, vOcean, vtmp);*/
+        /*    if (name == uName) {
+                // FIXME take into account possibility to restart form CG
+                // CGModelArray::ma2cg(data, u);
+                DGVector<DGadvection> utmp(*smesh);
+                DGModelArray::ma2dg(data, utmp);
+                Nextsim::Interpolations::DG2CG(*smesh, u, utmp);
+            } else if (name == vName) {
+                // CGModelArray::ma2cg(data, v);
+                DGVector<DGadvection> vtmp(*smesh);
+                DGModelArray::ma2dg(data, vtmp);
+                Nextsim::Interpolations::DG2CG(*smesh, v, vtmp);
+            } else if (name == uWindName) {
+                DGVector<DGadvection> utmp(*smesh);
+                utmp.zero();
+                DGModelArray::ma2dg(data, utmp);
+                Nextsim::Interpolations::DG2CG(*smesh, uAtmos, utmp);
+            } else if (name == vWindName) {
+                DGVector<DGadvection> vtmp(*smesh);
+                vtmp.zero();
+                DGModelArray::ma2dg(data, vtmp);
+                Nextsim::Interpolations::DG2CG(*smesh, vAtmos, vtmp);
+            } else if (name == uOceanName) {
+                DGVector<DGadvection> utmp(*smesh);
+                utmp.zero();
+                DGModelArray::ma2dg(data, utmp);
+                Nextsim::Interpolations::DG2CG(*smesh, uOcean, utmp);
+            } else if (name == vOceanName) {
+                DGVector<DGadvection> vtmp(*smesh);
+                vtmp.zero();
+                DGModelArray::ma2dg(data, vtmp);
+                Nextsim::Interpolations::DG2CG(*smesh, vOcean, vtmp);*/
     } else {
         DynamicsKernel<DGadvection, DGstressComp>::setData(name, data);
     }

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -80,6 +80,11 @@ public:
         avgU.resize_by_mesh(*smesh);
         avgV.resize_by_mesh(*smesh);
 
+        // Set the fields to zero. Prognostic fields will be filled from the restart file.
+        damage.zero();
+        avgU.zero();
+        avgV.zero();
+
         cosOceanAngle = std::cos(radians(params.oceanTurningAngle));
         sinOceanAngle = std::sin(radians(params.oceanTurningAngle));
     }

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -94,6 +94,14 @@ protected:
     CGVector<CGdegree> vAtmos;
 
     std::unique_ptr<ParametricMomentumMap<CGdegree, DGadvection>> pmap;
+
+    CGVector<CGdegree>& ma2cg(const ModelArray& maData, CGVector<CGdegree>& cgData) {
+        DGVector<DGadvection> dgtmp(*smesh);
+        dgtmp.zero();
+        DGModelArray::ma2dg(maData, dgtmp);
+        Nextsim::Interpolations::DG2CG(*smesh, cgData, dgtmp);
+        return cgData;
+    }
 };
 
 } /* namespace Nextsim */

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -95,7 +95,8 @@ protected:
 
     std::unique_ptr<ParametricMomentumMap<CGdegree, DGadvection>> pmap;
 
-    CGVector<CGdegree>& ma2cg(const ModelArray& maData, CGVector<CGdegree>& cgData) {
+    CGVector<CGdegree>& ma2cg(const ModelArray& maData, CGVector<CGdegree>& cgData)
+    {
         DGVector<DGadvection> dgtmp(*smesh);
         dgtmp.zero();
         DGModelArray::ma2dg(maData, dgtmp);

--- a/dynamics/src/include/DGModelArray.hpp
+++ b/dynamics/src/include/DGModelArray.hpp
@@ -19,13 +19,10 @@ class DGModelArray {
 public:
     template <int N> static DGVector<N>& ma2dg(const ModelArray& ma, DGVector<N>& dg)
     {
-        dg.zero();
         if (N == ma.components(0).size()) {
-            //            assert(N == ma.components(0).size());
             dg = ma.data().matrix();
         } else {
             // Assign only to the 0 component.
-            // dg(Eigen::all, 0) = ma.data().matrix();
             dg.col(0) = ma.data().matrix();
         }
         return dg;
@@ -40,8 +37,6 @@ public:
              * takes a pointer to continuous data, the data needs to be copied
              * from the DGVector initially.
              */
-            // Eigen::Matrix<double, Eigen::Dynamic, 1, Eigen::ColMajor> dg0Data = dg(Eigen::all,
-            // 0); ma.setData(dg0Data.data());
             ma.setData(dg.col(0));
         }
         return ma;

--- a/dynamics/src/include/DynamicsKernel.hpp
+++ b/dynamics/src/include/DynamicsKernel.hpp
@@ -74,6 +74,16 @@ public:
         s11.resize_by_mesh(*smesh);
         s12.resize_by_mesh(*smesh);
         s22.resize_by_mesh(*smesh);
+
+        // Set initial values to zero. Prognostic fields will be filled from the restart file.
+        hice.zero();
+        cice.zero();
+        e11.zero();
+        e12.zero();
+        e22.zero();
+        s11.zero();
+        s12.zero();
+        s22.zero();
     }
 
     /*!

--- a/dynamics/test/DGModelArray_test.cpp
+++ b/dynamics/test/DGModelArray_test.cpp
@@ -100,6 +100,7 @@ TEST_CASE("DGVector from ModelArray::Type::H")
         }
     }
     DGVector<DG> dest(smesh);
+    dest.zero();
     DGModelArray::ma2dg<DG>(source, dest);
 
     // Did it work?

--- a/run/config_june23.cfg
+++ b/run/config_june23.cfg
@@ -1,5 +1,5 @@
 [model]
-init_file = init_25km_NH.nc
+init_file = init_25km_NH_border.nc
 start = 2010-01-01T00:00:00Z
 stop = 2011-01-01T00:00:00Z
 time_step = P0-0T00:15:00
@@ -7,7 +7,7 @@ time_step = P0-0T00:15:00
 
 [Modules]
 DiagnosticOutputModule = Nextsim::ConfigOutput
-DynamicsModule = Nextsim::MEVPDynamics
+DynamicsModule = Nextsim::BBMDynamics
 IceThermodynamicsModule = Nextsim::ThermoWinton
 AtmosphereBoundaryModule = Nextsim::ERA5Atmosphere
 OceanBoundaryModule = Nextsim::TOPAZOcean

--- a/run/config_june23.cfg
+++ b/run/config_june23.cfg
@@ -23,4 +23,3 @@ file = 25km_NH.ERA5_2010-01-01_2011-01-01.nc
 
 [TOPAZOcean]
 file = 25km_NH.TOPAZ4_2010-01-01_2011-01-01.nc
-

--- a/run/config_june23.cfg
+++ b/run/config_june23.cfg
@@ -1,5 +1,5 @@
 [model]
-init_file = init_25km_NH_border.nc
+init_file = init_25km_NH.nc
 start = 2010-01-01T00:00:00Z
 stop = 2011-01-01T00:00:00Z
 time_step = P0-0T00:15:00


### PR DESCRIPTION
# Handle higher DG components at restart

Fixes #777

---
# Change Description

Makes the necessary changes to support reading the full DG components from a restart file.

- Explicitly copy only the DG0 component of the initial `ModelState` data into the arrays of `PrognosticData`.
- Consolidate the setting of data for `CGDynamicsKernel` is a single function called with several different arguments, rather than copying the same (small) code fragment over and over.
- Remove the line of code that zeroes out the higher DG components whenever data is copied.
  - Tidy up commented-out code in `DGModelArray`.
- Initialize dynamics prognostic fields to 0 (all components).
- Update the default dynamics to BBM.
- Make the mock dynamics module class used in the Prognostic data tests persist data (especially higher DG components) like the real dynamics modules do.
- Make the DGModelArray test zero the higher DG components, rather than it automatically happen on assignment from the ModelArray to the DG vector.