### PR TITLE
Print help

### DIFF
--- a/core/src/CommandLineParser.cpp
+++ b/core/src/CommandLineParser.cpp
@@ -59,6 +59,15 @@ CommandLineParser::CommandLineParser(int argc, char* argv[])
 
     // Print help and exit
     if (m_arguments.count("help") || m_arguments.empty()) {
+        std::cout << "\nUsage:\n";
+        std::cout << "\nRun model with one config file only:\n";
+        std::cout << "    nextsim --config-file=CONFIG_FILE\n";
+        std::cout << "\nRun model with multiple config files:\n";
+        std::cout << "    nextsim --config-files=CONFIG_FILE1 CONFIG_FILE2 ...\n";
+        std::cout << "\nGet help on all config options\n";
+        std::cout << "    nextsim --help-config\n";
+        std::cout << "\nGet help on options for section SECTION\n";
+        std::cout << "    nextsim --help-config SECTION\n\n";
         std::exit(EXIT_SUCCESS);
     }
 

--- a/core/src/CommandLineParser.cpp
+++ b/core/src/CommandLineParser.cpp
@@ -1,8 +1,9 @@
 /*!
  * @file CommandLineParser.cpp
  *
- * @date Oct 8, 2021
+ * @date Jan 29, 2025
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Tim Williams <timothy.williams@nersc.no>
  */
 
 #include "include/CommandLineParser.hpp"
@@ -64,9 +65,9 @@ CommandLineParser::CommandLineParser(int argc, char* argv[])
         std::cout << "    nextsim --config-file=CONFIG_FILE\n";
         std::cout << "\nRun model with multiple config files:\n";
         std::cout << "    nextsim --config-files=CONFIG_FILE1 CONFIG_FILE2 ...\n";
-        std::cout << "\nGet help on all config options\n";
+        std::cout << "\nGet help on all config options:\n";
         std::cout << "    nextsim --help-config\n";
-        std::cout << "\nGet help on options for section SECTION\n";
+        std::cout << "\nGet help on options for section SECTION:\n";
         std::cout << "    nextsim --help-config SECTION\n\n";
         std::exit(EXIT_SUCCESS);
     }

--- a/core/src/CommandLineParser.cpp
+++ b/core/src/CommandLineParser.cpp
@@ -60,15 +60,7 @@ CommandLineParser::CommandLineParser(int argc, char* argv[])
 
     // Print help and exit
     if (m_arguments.count("help") || m_arguments.empty()) {
-        std::cout << "\nUsage:\n";
-        std::cout << "\nRun model with one config file only:\n";
-        std::cout << "    nextsim --config-file=CONFIG_FILE\n";
-        std::cout << "\nRun model with multiple config files:\n";
-        std::cout << "    nextsim --config-files=CONFIG_FILE1 CONFIG_FILE2 ...\n";
-        std::cout << "\nGet help on all config options:\n";
-        std::cout << "    nextsim --help-config\n";
-        std::cout << "\nGet help on options for section SECTION:\n";
-        std::cout << "    nextsim --help-config SECTION\n\n";
+        opt.print(std::cout);
         std::exit(EXIT_SUCCESS);
     }
 


### PR DESCRIPTION
# Print help

Fixes #781

### Task List
- Print help if running nextsim with no arguments, -h or --help (or unrecognized)

---
# Change Description
`nextsim`  or `nextsim -h` or `nextsim --help` prints this text
```

Usage:

Run model with one config file only:
    nextsim --config-file=CONFIG_FILE

Run model with multiple config files:
    nextsim --config-files=CONFIG_FILE1 CONFIG_FILE2 ...

Get help on all config options:
    nextsim --help-config

Get help on options for section SECTION:
    nextsim --help-config SECTION

```
---
# Test Description

* compiled and checked it works

---
# Documentation Impact

* None

---
---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [ x] No new warnings are generated
- [ x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [ x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x ] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [ x] File dates have been updated to reflect modification date
- [ ?] This change conforms to the conventions described in the README (v simple so prob not relevant)