### PR TITLE
fixed inconsistent nSteps usage (#792)

### DIFF
--- a/dynamics/src/include/BBMDynamicsKernel.hpp
+++ b/dynamics/src/include/BBMDynamicsKernel.hpp
@@ -17,7 +17,6 @@ namespace Nextsim {
 
 template <int DGadvection> class BBMDynamicsKernel : public BrittleCGDynamicsKernel<DGadvection> {
 public:
-    using DynamicsKernel<DGadvection, DGstressComp>::nSteps;
     // using DynamicsKernel<DGadvection, DGstressComp>::momentum;
     using DynamicsKernel<DGadvection, DGstressComp>::hice;
     using DynamicsKernel<DGadvection, DGstressComp>::cice;

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -22,7 +22,6 @@ namespace Nextsim {
 // The brittle momentum solver for CG velocity fields
 template <int DGadvection> class BrittleCGDynamicsKernel : public CGDynamicsKernel<DGadvection> {
 protected:
-    using DynamicsKernel<DGadvection, DGstressComp>::nSteps;
     using DynamicsKernel<DGadvection, DGstressComp>::s11;
     using DynamicsKernel<DGadvection, DGstressComp>::s12;
     using DynamicsKernel<DGadvection, DGstressComp>::s22;
@@ -112,7 +111,7 @@ public:
         prepareIteration({ { hiceName, hice }, { ciceName, cice } });
 
         // The timestep for the brittle solver is the solver subtimestep
-        deltaT = tst.step.seconds() / nSteps;
+        deltaT = tst.step.seconds() / params.nSteps;
 
         avgU.zero();
         avgV.zero();
@@ -244,8 +243,8 @@ protected:
             v(i) *= rDenom;
 
             // Calculate the contribution to the average velocity
-            avgU(i) += u(i) / nSteps;
-            avgV(i) += v(i) / nSteps;
+            avgU(i) += u(i) / params.nSteps;
+            avgV(i) += v(i) / params.nSteps;
         }
     }
 };

--- a/dynamics/src/include/DynamicsKernel.hpp
+++ b/dynamics/src/include/DynamicsKernel.hpp
@@ -195,8 +195,6 @@ protected:
     DGVector<DGstress> e11, e12, e22;
     DGVector<DGstress> s11, s12, s22;
 
-    size_t nSteps = 100;
-
     size_t stepNumber = 0;
 
     double deltaT;

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -18,7 +18,6 @@
 namespace Nextsim {
 
 template <int DGadvection> class FreeDriftDynamicsKernel : public CGDynamicsKernel<DGadvection> {
-    using DynamicsKernel<DGadvection, DGstressComp>::nSteps;
     using DynamicsKernel<DGadvection, DGstressComp>::hice;
     using DynamicsKernel<DGadvection, DGstressComp>::cice;
     using DynamicsKernel<DGadvection, DGstressComp>::advectionAndLimits;


### PR DESCRIPTION
# fixed inconsistent nSteps usage

Fixes #792

---
# Change Description

Removed `DynamicsKernel::nSteps` and replaced it with `nSteps` from the parameter structs where it was still used in `BrittleCGDynamicsKernel`. This changes the behavior off BBM slightly since `avgU` and `avgV` are weighted differently now. 

