### PR TITLE
Add the DynamicsParameters header, which was missing.

### DIFF
--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -13,6 +13,8 @@
 #define FREEDRIFTDYNAMICSKERNEL_HPP
 
 #include "CGDynamicsKernel.hpp"
+#include "DynamicsParameters.hpp"
+
 #include <cmath>
 
 namespace Nextsim {


### PR DESCRIPTION
# Pull Request Title

Fixes #798

---
# Change Description

Adds the header `DynamicsParameters.hpp` to the header for the class `FreeDriftDynamicsKernel`. Without this, the class will fail to build, outside the context of the full dynamics module, which includes the `DynamicsParameters.hpp` header from another class.
