### PR TITLE
Ice ocean stress computation

### DIFF
--- a/core/src/modules/DynamicsModule/include/BBMDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/BBMDynamics.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file BBMDynamics.hpp
  *
- * @date 19 Nov 2024
+ * @date 27 Mar 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -56,8 +56,8 @@ public:
     static HelpMap& getHelpRecursive(HelpMap&, bool getAll);
 
 private:
-    BBMDynamicsKernel<DGCOMP> kernel;
     BBMParameters params;
+    BBMDynamicsKernel<DGCOMP> kernel;
 };
 
 } /* namespace Nextsim */

--- a/core/src/modules/DynamicsModule/include/MEVPDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/MEVPDynamics.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file MEVPDynamics.hpp
  *
- * @date 19 Nov 2024
+ * @date 27 Mar 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Piotr Minakowski <piotr.minakowski@ovgu.de>
  * @author Einar Ólason <einar.olason@nersc.no>
@@ -55,8 +55,8 @@ public:
     static HelpMap& getHelpRecursive(HelpMap&, bool getAll);
 
 private:
-    MEVPDynamicsKernel<DGCOMP> kernel;
     VPParameters params;
+    MEVPDynamicsKernel<DGCOMP> kernel;
 };
 }
 

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -11,6 +11,7 @@
 
 #include "include/CGDynamicsKernel.hpp"
 #include "include/ModelArray.hpp"
+#include "include/constants.hpp"
 
 #include "include/Interpolations.hpp"
 #include "include/ParametricMap.hpp"
@@ -18,6 +19,14 @@
 #include "include/cgVector.hpp"
 
 namespace Nextsim {
+
+template <int DGadvection>
+CGDynamicsKernel<DGadvection>::CGDynamicsKernel(const DynamicsParameters& params)
+    : cosOceanAngle(std::cos(radians(params.oceanTurningAngle)))
+    , sinOceanAngle(std::sin(radians(params.oceanTurningAngle)))
+    , FOcean(params.COcean * params.rhoOcean)
+{
+}
 
 template <int DGadvection>
 void CGDynamicsKernel<DGadvection>::initialise(
@@ -47,6 +56,9 @@ void CGDynamicsKernel<DGadvection>::initialise(
 
     uAtmos.resize_by_mesh(*smesh);
     vAtmos.resize_by_mesh(*smesh);
+
+    uIceOceanStress.resize_by_mesh(*smesh);
+    vIceOceanStress.resize_by_mesh(*smesh);
 }
 
 template <int DGadvection>
@@ -83,12 +95,12 @@ ModelArray CGDynamicsKernel<DGadvection>::getDG0Data(const std::string& name) co
     } else if (name == uIOStressName) {
         ModelArray data(ModelArray::Type::U);
         DGVector<DGadvection> utmp(*smesh);
-        Nextsim::Interpolations::CG2DG(*smesh, utmp, getIceOceanStress(name));
+        Nextsim::Interpolations::CG2DG(*smesh, utmp, uIceOceanStress);
         return DGModelArray::dg2ma(utmp, data);
     } else if (name == vIOStressName) {
         ModelArray data(ModelArray::Type::V);
         DGVector<DGadvection> vtmp(*smesh);
-        Nextsim::Interpolations::CG2DG(*smesh, vtmp, getIceOceanStress(name));
+        Nextsim::Interpolations::CG2DG(*smesh, vtmp, vIceOceanStress);
         return DGModelArray::dg2ma(vtmp, data);
     } else {
         return DynamicsKernel<DGadvection, DGstressComp>::getDG0Data(name);
@@ -292,7 +304,7 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::projectVelocityTo
         int cgi = CGdegree * cgshift * row; //!< Lower left index of cg vector
 
         for (size_t col = 0; col < smesh->nx;
-             ++col, ++dgi, cgi += CGdegree) { // loop over all elements
+            ++col, ++dgi, cgi += CGdegree) { // loop over all elements
 
             if (smesh->landmask[dgi] == 0) // only on ice
                 continue;
@@ -423,6 +435,20 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::applyBoundaries()
     dirichletZero(u);
     dirichletZero(v);
     // TODO Periodic boundary conditions.
+}
+
+template <int DGadvection>
+void CGDynamicsKernel<DGadvection>::updateIceOceanStress(
+    const CGVector<CGdegree>& uIce, const CGVector<CGdegree>& vIce)
+{
+#pragma omp parallel for
+    for (int i = 0; i < uIceOceanStress.rows(); ++i) {
+        const FloatType uOceanRel = uOcean(i) - uIce(i);
+        const FloatType vOceanRel = vOcean(i) - vIce(i);
+        const FloatType cPrime = FOcean * std::hypot(uOceanRel, vOceanRel);
+        uIceOceanStress(i) = cPrime * (uOceanRel * cosOceanAngle - vOceanRel * sinOceanAngle);
+        vIceOceanStress(i) = cPrime * (vOceanRel * cosOceanAngle + uOceanRel * sinOceanAngle);
+    }
 }
 
 // Instantiate the templates for all (1, 3, 6) degrees of DGadvection

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -23,9 +23,7 @@ namespace Nextsim {
 
 template <int DGadvection>
 CGDynamicsKernel<DGadvection>::CGDynamicsKernel(const DynamicsParameters& params)
-    : cosOceanAngle(std::cos(radians(params.oceanTurningAngle)))
-    , sinOceanAngle(std::sin(radians(params.oceanTurningAngle)))
-    , FOcean(params.COcean * params.rhoOcean)
+    : baseParams(params)
 {
 }
 
@@ -60,6 +58,9 @@ void CGDynamicsKernel<DGadvection>::initialise(
 
     uIceOceanStress.resize_by_mesh(*smesh);
     vIceOceanStress.resize_by_mesh(*smesh);
+
+    cosOceanAngle = std::cos(radians(baseParams.oceanTurningAngle));
+    sinOceanAngle = std::sin(radians(baseParams.oceanTurningAngle));
 }
 
 template <int DGadvection>
@@ -442,6 +443,8 @@ template <int DGadvection>
 void CGDynamicsKernel<DGadvection>::updateIceOceanStress(
     const CGVector<CGdegree>& uIce, const CGVector<CGdegree>& vIce)
 {
+    const double FOcean = baseParams.COcean * baseParams.rhoOcean;
+
 #pragma omp parallel for
     for (int i = 0; i < uIceOceanStress.rows(); ++i) {
         const FloatType uOceanRel = uOcean(i) - uIce(i);

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -1,8 +1,9 @@
 /*!
  * @file CGDynamicsKernel.cpp
  *
- * @date 14 Jan 2025
+ * @date 27 Mar 2025
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Robert Jendersie <robert.jendersie@ovgu.de>
  */
 
 /*
@@ -113,7 +114,7 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::prepareAdvection(
 }
 
 template <int DGadvection>
-void CGDynamicsKernel<DGadvection>::ComputeGradientOfSeaSurfaceHeight(
+void CGDynamicsKernel<DGadvection>::computeGradientOfSeaSurfaceHeight(
     const DGVector<1>& seaSurfaceHeight)
 {
     // First transform to CG1 Vector and do all computations in CG1
@@ -193,7 +194,7 @@ void CGDynamicsKernel<DGadvection>::ComputeGradientOfSeaSurfaceHeight(
     vGrad((smesh->ny + 1) * cg1row - 1) = vGrad((smesh->ny) * cg1row - 1 - 1);
 
     // Interpolate to CG2 (maybe own function in interpolation?)
-    if (CGDEGREE == 1) {
+    if constexpr (CGDEGREE == 1) {
         xGradSeaSurfaceHeight = uGrad;
         yGradSeaSurfaceHeight = vGrad;
     } else {
@@ -257,7 +258,7 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::prepareIteration(
 
     // Reinit the gradient of the sea surface height. Not done by
     // DataMap as seaSurfaceHeight is always dG(0)
-    ComputeGradientOfSeaSurfaceHeight(DynamicsKernel<DGadvection, DGstressComp>::seaSurfaceHeight);
+    computeGradientOfSeaSurfaceHeight(DynamicsKernel<DGadvection, DGstressComp>::seaSurfaceHeight);
 
     /* limit A to [0,1] and H to [5 cm, ...)
      * This limit on H is equivalent to assuming that ice thinner than 5 cm is always in free drift,
@@ -304,7 +305,7 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::projectVelocityTo
         int cgi = CGdegree * cgshift * row; //!< Lower left index of cg vector
 
         for (size_t col = 0; col < smesh->nx;
-            ++col, ++dgi, cgi += CGdegree) { // loop over all elements
+             ++col, ++dgi, cgi += CGdegree) { // loop over all elements
 
             if (smesh->landmask[dgi] == 0) // only on ice
                 continue;

--- a/dynamics/src/include/BBMDynamicsKernel.hpp
+++ b/dynamics/src/include/BBMDynamicsKernel.hpp
@@ -23,7 +23,7 @@ public:
     using CGDynamicsKernel<DGadvection>::pmap;
     using BrittleCGDynamicsKernel<DGadvection>::damage;
     using CGDynamicsKernel<DGadvection>::initialise;
-    BBMDynamicsKernel(const DynamicsParameters& paramsIn)
+    BBMDynamicsKernel(const BBMParameters& paramsIn)
         : BrittleCGDynamicsKernel<DGadvection>(bbmStressStep, paramsIn)
     {
     }
@@ -36,8 +36,6 @@ public:
     }
 
 private:
-    //! Brittle rheology parameters
-    BBMParameters mebParams;
     // BBM stress update class
     BBMStressUpdateStep<DGadvection, DGstressComp, CGdegree> bbmStressStep;
 };

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -53,15 +53,16 @@ protected:
     using CGDynamicsKernel<DGadvection>::dStressX;
     using CGDynamicsKernel<DGadvection>::dStressY;
     using CGDynamicsKernel<DGadvection>::pmap;
-
-    double cosOceanAngle, sinOceanAngle;
+    using CGDynamicsKernel<DGadvection>::updateIceOceanStress;
+    using CGDynamicsKernel<DGadvection>::cosOceanAngle;
+    using CGDynamicsKernel<DGadvection>::sinOceanAngle;
 
 public:
     BrittleCGDynamicsKernel(StressUpdateStep<DGadvection, DGstressComp>& stressStepIn,
-        const DynamicsParameters& paramsIn)
-        : CGDynamicsKernel<DGadvection>()
+        const BBMParameters& paramsIn)
+        : CGDynamicsKernel<DGadvection>(paramsIn)
         , stressStep(stressStepIn)
-        , params(reinterpret_cast<const BBMParameters&>(paramsIn))
+        , params(paramsIn)
         , stresstransport(nullptr)
     {
     }
@@ -83,9 +84,6 @@ public:
         damage.zero();
         avgU.zero();
         avgV.zero();
-
-        cosOceanAngle = std::cos(radians(params.oceanTurningAngle));
-        sinOceanAngle = std::sin(radians(params.oceanTurningAngle));
     }
 
     // The brittle rheologies use avgU and avgV to do the advection, not u and v, like mEVP
@@ -134,6 +132,9 @@ public:
 
             // Land mask
         }
+
+        updateIceOceanStress(avgU, avgV);
+
         // Finally, do the base class update
         DynamicsKernel<DGadvection, DGstressComp>::update(tst);
     }
@@ -168,28 +169,12 @@ public:
         }
     }
 
-    double getIceOceanStressElement(const std::string& name, const int i) const override
-    {
-        const double FOcean = params.COcean * params.rhoOcean;
-
-        const double uOceanRel = uOcean(i) - avgU(i);
-        const double vOceanRel = vOcean(i) - avgV(i);
-        const double cPrime = FOcean * std::hypot(uOceanRel, vOceanRel);
-
-        if (name == uIOStressName)
-            return cPrime * (uOceanRel * cosOceanAngle - vOceanRel * sinOceanAngle);
-        else if (name == vIOStressName)
-            return cPrime * (vOceanRel * cosOceanAngle + uOceanRel * sinOceanAngle);
-        else
-            return std::numeric_limits<double>::quiet_NaN();
-    }
-
 protected:
     CGVector<CGdegree> avgU;
     CGVector<CGdegree> avgV;
 
     StressUpdateStep<DGadvection, DGstressComp>& stressStep;
-    const BBMParameters& params;
+    const BBMParameters params;
 
     std::unique_ptr<DGTransport<DGstressComp>> stresstransport;
 

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -1,9 +1,10 @@
 /*!
  * @file BrittleCGDynamicsKernel.hpp
  *
- * @date 06 Dec 2024
+ * @date 27 Mar 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
+ * @author Robert Jendersie <robert.jendersie@ovgu.de>
  */
 
 #ifndef BRITTLECGDYNAMICSKERNEL_HPP
@@ -58,8 +59,8 @@ protected:
     using CGDynamicsKernel<DGadvection>::sinOceanAngle;
 
 public:
-    BrittleCGDynamicsKernel(StressUpdateStep<DGadvection, DGstressComp>& stressStepIn,
-        const BBMParameters& paramsIn)
+    BrittleCGDynamicsKernel(
+        StressUpdateStep<DGadvection, DGstressComp>& stressStepIn, const BBMParameters& paramsIn)
         : CGDynamicsKernel<DGadvection>(paramsIn)
         , stressStep(stressStepIn)
         , params(paramsIn)
@@ -91,7 +92,6 @@ public:
 
     void update(const TimestepTime& tst) override
     {
-
         // Let DynamicsKernel handle the advection step
         advectionAndLimits(tst);
 

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -174,7 +174,7 @@ protected:
     CGVector<CGdegree> avgV;
 
     StressUpdateStep<DGadvection, DGstressComp>& stressStep;
-    const BBMParameters params;
+    const BBMParameters& params;
 
     std::unique_ptr<DGTransport<DGstressComp>> stresstransport;
 

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -8,6 +8,7 @@
 #ifndef CGDYNAMICSKERNEL_HPP
 #define CGDYNAMICSKERNEL_HPP
 
+#include "DynamicsParameters.hpp"
 #include "DynamicsKernel.hpp"
 
 #ifndef CGDEGREE
@@ -36,7 +37,7 @@ protected:
     using typename DynamicsKernel<DGadvection, DGstressComp>::DataMap;
 
 public:
-    CGDynamicsKernel() { }
+    CGDynamicsKernel(const DynamicsParameters& params);
     virtual ~CGDynamicsKernel() = default;
     void initialise(const ModelArray& coords, bool isSpherical, const ModelArray& mask) override;
 
@@ -49,26 +50,11 @@ public:
     void applyBoundaries() override;
     void prepareAdvection() override;
 
-    virtual inline double getIceOceanStressElement(const std::string& name, const int i) const = 0;
-    CGVector<CGdegree> getIceOceanStress(const std::string& name) const
-    {
-        if (name != uIOStressName && name != vIOStressName)
-            throw std::logic_error(std::string(__func__) + " called with an unknown argument "
-                + name + ". Only " + uIOStressName + " and " + vIOStressName + " are supported\n");
-
-        CGVector<CGdegree> tau;
-        tau.resizeLike(u);
-
-#pragma omp parallel for
-        for (int i = 0; i < tau.rows(); ++i)
-            tau(i) = getIceOceanStressElement(name, i);
-
-        return tau;
-    }
-
 protected:
     void addStressTensorCell(const size_t eid, const size_t cx, const size_t cy);
     void dirichletZero(CGVector<CGdegree>&) const;
+    void updateIceOceanStress(const CGVector<CGdegree>& uIce, const CGVector<CGdegree>& vIce);
+
     // CG ice velocity
     CGVector<CGdegree> u;
     CGVector<CGdegree> v;
@@ -92,6 +78,14 @@ protected:
     // Atmospheric wind velocity
     CGVector<CGdegree> uAtmos;
     CGVector<CGdegree> vAtmos;
+
+    // ice ocean stresses
+    CGVector<CGdegree> uIceOceanStress;
+    CGVector<CGdegree> vIceOceanStress;
+
+    double cosOceanAngle;
+    double sinOceanAngle;
+    double FOcean;
 
     std::unique_ptr<ParametricMomentumMap<CGdegree, DGadvection>> pmap;
 

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -84,9 +84,9 @@ protected:
     CGVector<CGdegree> uIceOceanStress;
     CGVector<CGdegree> vIceOceanStress;
 
-    double cosOceanAngle;
-    double sinOceanAngle;
-    double FOcean;
+    double cosOceanAngle = std::numeric_limits<double>::quiet_NaN();
+    double sinOceanAngle = std::numeric_limits<double>::quiet_NaN();
+    const DynamicsParameters& baseParams;
 
     std::unique_ptr<ParametricMomentumMap<CGdegree, DGadvection>> pmap;
 

--- a/dynamics/src/include/CGDynamicsKernel.hpp
+++ b/dynamics/src/include/CGDynamicsKernel.hpp
@@ -1,15 +1,16 @@
 /*!
  * @file CGDynamicsKernel.hpp
  *
- * @date 06 Dec 2024
+ * @date 27 Mar 2025
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Robert Jendersie <robert.jendersie@ovgu.de>
  */
 
 #ifndef CGDYNAMICSKERNEL_HPP
 #define CGDYNAMICSKERNEL_HPP
 
-#include "DynamicsParameters.hpp"
 #include "DynamicsKernel.hpp"
+#include "DynamicsParameters.hpp"
 
 #ifndef CGDEGREE
 #define CGDEGREE 2
@@ -43,7 +44,7 @@ public:
 
     void setData(const std::string& name, const ModelArray& data) override;
     ModelArray getDG0Data(const std::string& name) const override;
-    void ComputeGradientOfSeaSurfaceHeight(const DGVector<1>& seaSurfaceHeight);
+    void computeGradientOfSeaSurfaceHeight(const DGVector<1>& seaSurfaceHeight);
     void prepareIteration(const DataMap& data) override;
     void projectVelocityToStrain() override;
     void stressDivergence() override;

--- a/dynamics/src/include/DynamicsKernel.hpp
+++ b/dynamics/src/include/DynamicsKernel.hpp
@@ -33,7 +33,7 @@
 
 namespace Nextsim {
 
-// forward define the class holding the potentially non-DG parts
+// forward declare the class holding the potentially non-DG parts
 template <int DGdegree> class DynamicsInternals;
 
 template <int DGadvection, int DGstress> class DynamicsKernel {

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -36,18 +36,24 @@ template <int DGadvection> class FreeDriftDynamicsKernel : public CGDynamicsKern
     using CGDynamicsKernel<DGadvection>::updateIceOceanStress;
     using CGDynamicsKernel<DGadvection>::cosOceanAngle;
     using CGDynamicsKernel<DGadvection>::sinOceanAngle;
-    using CGDynamicsKernel<DGadvection>::FOcean;
+    using CGDynamicsKernel<DGadvection>::baseParams;
 
 public:
     FreeDriftDynamicsKernel(const DynamicsParameters& paramsIn)
         : CGDynamicsKernel<DGadvection>(paramsIn)
         , params(paramsIn)
-        , FAtm(params.CAtm * params.rhoAtm)
-        , NansenNumber(std::sqrt(FAtm / FOcean))
     {
     }
 
-    virtual ~FreeDriftDynamicsKernel() = default;
+    void initialise(const ModelArray& coords, bool isSpherical, const ModelArray& mask) override
+    {
+        DynamicsKernel<DGadvection, DGstressComp>::initialise(coords, isSpherical, mask);
+
+        // can't be done in the constructor since the param values are configured after construction
+        FOcean = baseParams.COcean * baseParams.rhoOcean;
+        FAtm = params.CAtm * params.rhoAtm;
+        NansenNumber = std::sqrt(FAtm / FOcean);
+    }
 
     void update(const TimestepTime& tst) override
     {
@@ -61,9 +67,10 @@ public:
     };
 
 protected:
-    const DynamicsParameters params;
-    const double FAtm;
-    const double NansenNumber;
+    const DynamicsParameters& params;
+    double FAtm = std::numeric_limits<double>::quiet_NaN();
+    double NansenNumber = std::numeric_limits<double>::quiet_NaN();
+    double FOcean = std::numeric_limits<double>::quiet_NaN();
 
     void updateMomentum(const TimestepTime& tst) override
     {

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -4,9 +4,10 @@
  * Implementation of "classic free drift", where we ignore all \rho h terms in the momentum
  * equation. This is equivalent to assuming that the ice is very thin.
  *
- * @date 06 Dec 2024
+ * @date 27 Mar 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
+ * @author Robert Jendersie <robert.jendersie@ovgu.de>
  */
 
 #ifndef FREEDRIFTDYNAMICSKERNEL_HPP
@@ -56,7 +57,7 @@ public:
         // Let DynamicsKernel handle the advection step
         advectionAndLimits(tst);
 
-        updateIceOceanStress(u,v);
+        updateIceOceanStress(u, v);
     };
 
 protected:

--- a/dynamics/src/include/FreeDriftDynamicsKernel.hpp
+++ b/dynamics/src/include/FreeDriftDynamicsKernel.hpp
@@ -32,11 +32,17 @@ template <int DGadvection> class FreeDriftDynamicsKernel : public CGDynamicsKern
     using CGDynamicsKernel<DGadvection>::uAtmos;
     using CGDynamicsKernel<DGadvection>::vAtmos;
     using CGDynamicsKernel<DGadvection>::applyBoundaries;
+    using CGDynamicsKernel<DGadvection>::updateIceOceanStress;
+    using CGDynamicsKernel<DGadvection>::cosOceanAngle;
+    using CGDynamicsKernel<DGadvection>::sinOceanAngle;
+    using CGDynamicsKernel<DGadvection>::FOcean;
 
 public:
     FreeDriftDynamicsKernel(const DynamicsParameters& paramsIn)
-        : CGDynamicsKernel<DGadvection>()
+        : CGDynamicsKernel<DGadvection>(paramsIn)
         , params(paramsIn)
+        , FAtm(params.CAtm * params.rhoAtm)
+        , NansenNumber(std::sqrt(FAtm / FOcean))
     {
     }
 
@@ -49,16 +55,14 @@ public:
 
         // Let DynamicsKernel handle the advection step
         advectionAndLimits(tst);
+
+        updateIceOceanStress(u,v);
     };
 
 protected:
-    const DynamicsParameters& params;
-
-    const double cosOceanAngle = std::cos(radians(params.oceanTurningAngle));
-    const double sinOceanAngle = std::sin(radians(params.oceanTurningAngle));
-    const double FOcean = params.COcean * params.rhoOcean;
-    const double FAtm = params.CAtm * params.rhoAtm;
-    const double NansenNumber = std::sqrt(FAtm / FOcean);
+    const DynamicsParameters params;
+    const double FAtm;
+    const double NansenNumber;
 
     void updateMomentum(const TimestepTime& tst) override
     {
@@ -70,22 +74,6 @@ protected:
             v(i) = vOcean(i)
                 + NansenNumber * (-uAtmos(i) * sinOceanAngle + vAtmos(i) * cosOceanAngle);
         }
-    }
-
-    double getIceOceanStressElement(const std::string& name, const int i) const override
-    {
-        const double FOcean = params.COcean * params.rhoOcean;
-
-        const double uOceanRel = uOcean(i) - u(i);
-        const double vOceanRel = vOcean(i) - v(i);
-        const double cPrime = FOcean * std::hypot(uOceanRel, vOceanRel);
-
-        if (name == uIOStressName)
-            return cPrime * (uOceanRel * cosOceanAngle - vOceanRel * sinOceanAngle);
-        else if (name == vIOStressName)
-            return cPrime * (vOceanRel * cosOceanAngle + uOceanRel * sinOceanAngle);
-        else
-            return std::numeric_limits<double>::quiet_NaN();
     }
 };
 } /* namespace Nextsim */

--- a/dynamics/src/include/MEVPDynamicsKernel.hpp
+++ b/dynamics/src/include/MEVPDynamicsKernel.hpp
@@ -19,7 +19,7 @@ template <int DGadvection> class MEVPDynamicsKernel : public VPCGDynamicsKernel<
 public:
     using CGDynamicsKernel<DGadvection>::pmap;
     using CGDynamicsKernel<DGadvection>::initialise;
-    MEVPDynamicsKernel(const DynamicsParameters& paramsIn)
+    MEVPDynamicsKernel(const VPParameters& paramsIn)
         : VPCGDynamicsKernel<DGadvection>(MEVPStressStep, paramsIn)
     {
     }
@@ -31,8 +31,6 @@ public:
     }
 
 private:
-    //! Rheology-Parameters
-    Nextsim::VPParameters VP;
     MEVPStressUpdateStep<DGadvection, DGstressComp, CGdegree> MEVPStressStep;
 };
 

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -49,13 +49,14 @@ protected:
     using CGDynamicsKernel<DGadvection>::dStressX;
     using CGDynamicsKernel<DGadvection>::dStressY;
     using CGDynamicsKernel<DGadvection>::pmap;
+    using CGDynamicsKernel<DGadvection>::updateIceOceanStress;
 
 public:
     VPCGDynamicsKernel(StressUpdateStep<DGadvection, DGstressComp>& stressStepIn,
-        const DynamicsParameters& paramsIn)
-        : CGDynamicsKernel<DGadvection>()
+        const VPParameters& paramsIn)
+        : CGDynamicsKernel<DGadvection>(paramsIn)
         , stressStep(stressStepIn)
-        , params(reinterpret_cast<const VPParameters&>(paramsIn))
+        , params(paramsIn)
     {
     }
     virtual ~VPCGDynamicsKernel() = default;
@@ -88,29 +89,16 @@ public:
 
             applyBoundaries();
         }
+
+        updateIceOceanStress(u, v);
+
         // Finally, do the base class update
         DynamicsKernel<DGadvection, DGstressComp>::update(tst);
     }
 
-    double getIceOceanStressElement(const std::string& name, const int i) const override
-    {
-        const double FOcean = params.COcean * params.rhoOcean;
-
-        double uOcnRel = u(i) - uOcean(i);
-        double vOcnRel = v(i) - vOcean(i);
-        double absocn = sqrt(SQR(uOcnRel) + SQR(vOcnRel));
-
-        if (name == uIOStressName)
-            return FOcean * absocn * uOcnRel;
-        else if (name == vIOStressName)
-            return FOcean * absocn * vOcnRel;
-        else
-            return std::numeric_limits<double>::quiet_NaN();
-    }
-
 protected:
     StressUpdateStep<DGadvection, DGstressComp>& stressStep;
-    const VPParameters& params;
+    const VPParameters params;
     const double alpha = 1500.;
     const double beta = 1500.;
 

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -101,7 +101,7 @@ public:
 
 protected:
     StressUpdateStep<DGadvection, DGstressComp>& stressStep;
-    const VPParameters params;
+    const VPParameters& params;
     const double alpha = 1500.;
     const double beta = 1500.;
 

--- a/dynamics/src/include/VPCGDynamicsKernel.hpp
+++ b/dynamics/src/include/VPCGDynamicsKernel.hpp
@@ -1,8 +1,9 @@
 /*!
  * @file VPCGDynamicsKernel.hpp
  *
- * @date 06 Dec 2024
+ * @date 27 Mar 2025
  * @author Tim Spain <timothy.spain@nersc.no>
+ * @author Robert Jendersie <robert.jendersie@ovgu.de>
  */
 
 #ifndef VPCGDYNAMICSKERNEL_HPP
@@ -52,14 +53,16 @@ protected:
     using CGDynamicsKernel<DGadvection>::updateIceOceanStress;
 
 public:
-    VPCGDynamicsKernel(StressUpdateStep<DGadvection, DGstressComp>& stressStepIn,
-        const VPParameters& paramsIn)
+    VPCGDynamicsKernel(
+        StressUpdateStep<DGadvection, DGstressComp>& stressStepIn, const VPParameters& paramsIn)
         : CGDynamicsKernel<DGadvection>(paramsIn)
         , stressStep(stressStepIn)
         , params(paramsIn)
     {
     }
+
     virtual ~VPCGDynamicsKernel() = default;
+
     void update(const TimestepTime& tst) override
     {
         // Let DynamicsKernel handle the advection step
@@ -108,7 +111,6 @@ protected:
 
     void updateMomentum(const TimestepTime& tst) override
     {
-
         // Update the velocity
 
         const double FOcean = params.COcean * params.rhoOcean;
@@ -149,9 +151,6 @@ protected:
                     + dStressY(i) / pmap->lumpedcgmass(i)); // Internal stress term
         }
     }
-
-private:
-    VPCGDynamicsKernel();
 };
 
 } /* namespace Nextsim */


### PR DESCRIPTION
# Ice ocean stress computation

Fixes #791

---
# Change Description

Reworked the ice ocean stress computation to facilitate greater reuse. The implementation is similar to the [previous one](https://github.com/nextsimhub/nextsimdg/pull/664) by @timspainNERSC, with some important differences:

1. **Persistent buffers** Previously, the ice ocean stresses where computed just-in-time in `getDG0Data`. This is not ideal since most of the computations are shared between the u and v fields. Now they are computed as part of  the kernel `update` and stored as `CGDynamicsKernel::uIceOceanStress` and `CGDynamicsKernel::vIceOceanStress`. If this is not desired, I think we should change the kernel-interface to get these fields instead. Alternatively, we could also do the interpolation right away and only store the `DGModelArray`. Is the full `CGVector` every needed?
2. **No virtual function** The only function I introduced is `CGDynamicsKernel::updateIceOceanStress` which contains the implementation and is called by the concrete kernels with the correct velocities. The only reason for introducing a virtual function for this computation is, in my mind, if we want to introduce additional logic around it to only compute ice-ocean stresses some of the time. This could then be implemented in the base class `DynamicsKernel`.
3. **Parameter initialization** There is a pitfall with the initialization of the parameter structs. They are being passed to the kernel constructors before being properly initialized by `configure`. I changed the initialization order in the modules so that the param structs are at least default initialized before being passed to the kernel constructors, elliminating the undefined behavior. Still, since the proper parameter configuration happens later, computations based on the parameters should be be done in `initialise()`. Where I noticed the incorrect usage (e.g. `FreeDriftDynamicsKernel`) I delayed the initialization and set the defaults to NaN so that improper usage is detected quickly. However, the overall design still has the potential for subtle bugs later on, when there are actual user provided parameters that differ from the default values. Ideally, initialization of the struct would be finished by the point it becomes accessible to the kernel but I guess this is not possible with the overall structure. Alternatively, such inconsistencies could be prevented by passing the parameter structs to `initialise` instead of the constructors which in turn would necessitate the use of pointers which have their own shortcomings. So I guess, one just has to be careful.

Furthermore, I did some minor cosmetic changes in the files I touched.

---
# Test Description

I checked that `taux` and `tauy` are the same for `BBMDynamics`. For `MEVPDynamics` the results are not expected to be the same since the ocean angle is used now, which is not yet properly implemented in the other computations.