### PR TITLE
bugfix: add fortran-runtime-lib to xios build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ endif()
 
 target_include_directories(nextsimlib PUBLIC "${netCDF_INCLUDE_DIR}")
 target_link_directories(nextsimlib PUBLIC "${netCDF_LIB_DIR}")
-target_link_libraries(nextsimlib PUBLIC "${NSDG_NetCDF_Library}" "${FORTRAN_RUNTIME_LIB}")
+target_link_libraries(nextsimlib PUBLIC "${NSDG_NetCDF_Library}")
 
 if(BUILD_TESTS)
     # Add the doctest header library
@@ -146,6 +146,12 @@ if(ENABLE_XIOS)
         nextsimlib
         PRIVATE ${xios_INCLUDES} ${xios_EXTERNS}/blitz/ ${xios_EXTERNS}/rapidxml/include
     )
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        set(FORTRAN_RUNTIME_LIB "-lgfortran")
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+        set(FORTRAN_RUNTIME_LIB "-lifcore")
+    endif()
+    target_link_libraries(nextsimlib PUBLIC "${FORTRAN_RUNTIME_LIB}")
 endif()
 
 # OpenMP


### PR DESCRIPTION
Building `nextsim` with `-DENABLE_XIOS=ON` with intel compilers leads to a link time error:

```
[100%] Linking CXX executable nextsim
libnextsimlib.so: undefined reference to `for_write_seq_lis_xmit'
libnextsimlib.so: undefined reference to `for_write_seq_lis'
make[3]: *** [CMakeFiles/nextsim.dir/build.make:111: nextsim] Error 1
make[2]: *** [CMakeFiles/Makefile2:413: CMakeFiles/nextsim.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:420: CMakeFiles/nextsim.dir/rule] Error 2
make: *** [Makefile:137: nextsim] Error 2
```

Adding the Intel-specific Fortran run-time library `-lifcore` fixes this. As it is only required for XIOS build I have added it to the XIOS section in the `CMakeLists.txt`

It now builds on CSD3.