### PR TITLE
Update GH workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/docker.yml
       - Dockerfiles/Dockerfile.devenv
       - Dockerfiles/install-xios.sh
-      - Dockerfiles/spack_devenv.yaml
+      - Dockerfiles/spack.yaml
 
   # Build the Docker container at 00:00 on the first day of every 3 months
   schedule:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,9 @@ jobs:
   docker:
     name: Build Docker container
     runs-on: ubuntu-latest
+
+    timeout-minutes: 120
+
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -17,6 +17,8 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    timeout-minutes: 5
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,6 +16,9 @@ on:
 jobs:
   clang-format:
     runs-on: ubuntu-24.04
+
+    timeout-minutes: 5
+
     steps:
     - uses: actions/checkout@v2
     - name: clang-format
@@ -31,6 +34,9 @@ jobs:
 
   cmake-lint:
     runs-on: ubuntu-latest
+
+    timeout-minutes: 5
+
     steps:
     - uses: actions/checkout@v2
     - name: cmake-format

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   clang-format:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 5
 

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -33,6 +33,9 @@ jobs:
   test-ubuntu-serial:
 
     runs-on: ubuntu-22.04
+
+    timeout-minutes: 10
+
     container:
       image: ghcr.io/nextsimhub/nextsimdg-dev-env:latest
 
@@ -82,6 +85,9 @@ jobs:
   test-ubuntu-mpi:
 
     runs-on: ubuntu-22.04
+
+    timeout-minutes: 10
+
     container:
       image: ghcr.io/nextsimhub/nextsimdg-dev-env:latest
 
@@ -118,6 +124,8 @@ jobs:
   test-mac-serial:
 
     runs-on: macos-latest
+
+    timeout-minutes: 10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -32,7 +32,7 @@ jobs:
 
   test-ubuntu-serial:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 10
 
@@ -84,7 +84,7 @@ jobs:
 
   test-ubuntu-mpi:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     timeout-minutes: 10
 

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -52,7 +52,7 @@ jobs:
     - name: installs for python tests
       run: |
         apt -y update
-        apt install -y python3.12-venv
+        apt install -y python3-venv
         python3 -m venv ~/nextsim
         . $HOME/nextsim/bin/activate
         pip install numpy

--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -1,5 +1,5 @@
 # Build stage with Spack pre-installed and ready to be used
-FROM spack/ubuntu-jammy:0.21 AS builder
+FROM spack/ubuntu-noble:latest AS builder
 
 # Install software from spack_devenv.yaml
 RUN mkdir /opt/spack-environment
@@ -36,7 +36,7 @@ RUN cd /opt/spack-environment && \
     spack env activate --sh -d . > activate.sh
 
 # Bare OS image to run the installed executables
-FROM ubuntu:22.04
+FROM ubuntu:latest
 
 # Copy necessary files from the builder stage
 COPY --from=builder /opt/spack-environment /opt/spack-environment


### PR DESCRIPTION
fixes #810 
fixes #802 

This PR does 3 related things, updating the github workflows:
- Ubuntu-22.04 is being deprecated soon. This PR switches to Ubuntu-24 which is the new LTS version.
- add a timeout to the runners to prevent infinite loops running forever.
- fix a typo in `.github/workflows/docker.yml` that was 