### PR TITLE
Enable more numbers of MPI ranks in XIOS tests

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -2,7 +2,8 @@
  * @file    Xios.cpp
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    06 May 2025
+ * @author  Adeleke Bankole <ab3191@cam.ac.uk>
+ * @date    22 Apr 2025
  * @brief   XIOS interface implementation
  * @details
  *

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -2,7 +2,8 @@
  * @file    Xios.hpp
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    06 May 2025
+ * @author  Adeleke Bankole <ab3191@cam.ac.uk>
+ * @date    22 Apr 2025
  * @brief   XIOS interface header
  * @details
  *

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -47,13 +47,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosCalendar_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosAxis_MPI1 "XiosAxis_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosAxis_MPI1 PRIVATE USE_XIOS)
+        add_executable(testXiosAxis_MPI3 "XiosAxis_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosAxis_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosAxis_MPI1
+            testXiosAxis_MPI3
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosAxis_MPI1 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosAxis_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosDomain_MPI2 "XiosDomain_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosDomain_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -63,13 +63,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosDomain_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosGrid_MPI2 "XiosGrid_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosGrid_MPI2 PRIVATE USE_XIOS)
+        add_executable(testXiosGrid_MPI1 "XiosGrid_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosGrid_MPI1 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosGrid_MPI2
+            testXiosGrid_MPI1
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosGrid_MPI1 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosField_MPI2 "XiosField_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosField_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -63,13 +63,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosDomain_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosGrid_MPI1 "XiosGrid_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosGrid_MPI1 PRIVATE USE_XIOS)
+        add_executable(testXiosGrid_MPI3 "XiosGrid_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosGrid_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosGrid_MPI1
+            testXiosGrid_MPI3
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosGrid_MPI1 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosGrid_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosField_MPI2 "XiosField_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosField_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -39,13 +39,13 @@ if(ENABLE_MPI)
         )
         add_custom_target(generate_xios_input_file ALL DEPENDS xios_test_input.nc)
 
-        add_executable(testXiosCalendar_MPI1 "XiosCalendar_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosCalendar_MPI1 PRIVATE USE_XIOS)
+        add_executable(testXiosCalendar_MPI3 "XiosCalendar_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosCalendar_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosCalendar_MPI1
+            testXiosCalendar_MPI3
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosCalendar_MPI1 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosCalendar_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosAxis_MPI2 "XiosAxis_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosAxis_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -79,13 +79,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosField_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosFile_MPI1 "XiosFile_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosFile_MPI1 PRIVATE USE_XIOS)
+        add_executable(testXiosFile_MPI3 "XiosFile_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosFile_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosFile_MPI1
+            testXiosFile_MPI3
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosFile_MPI1 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosFile_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosRead_MPI2 "XiosRead_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosRead_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -55,13 +55,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosAxis_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosDomain_MPI1 "XiosDomain_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosDomain_MPI1 PRIVATE USE_XIOS)
+        add_executable(testXiosDomain_MPI3 "XiosDomain_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosDomain_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosDomain_MPI1
+            testXiosDomain_MPI3
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosDomain_MPI1 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosDomain_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosGrid_MPI2 "XiosGrid_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosGrid_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -47,13 +47,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosCalendar_MPI1 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosAxis_MPI4 "XiosAxis_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosAxis_MPI4 PRIVATE USE_XIOS)
+        add_executable(testXiosAxis_MPI3 "XiosAxis_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosAxis_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosAxis_MPI4
+            testXiosAxis_MPI3
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosAxis_MPI4 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosAxis_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosDomain_MPI4 "XiosDomain_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosDomain_MPI4 PRIVATE USE_XIOS)
@@ -71,13 +71,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosGrid_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosField_MPI4 "XiosField_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosField_MPI4 PRIVATE USE_XIOS)
+        add_executable(testXiosField_MPI3 "XiosField_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosField_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosField_MPI4
+            testXiosField_MPI3
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosField_MPI4 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosField_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosFile_MPI4 "XiosFile_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosFile_MPI4 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -79,13 +79,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosField_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosFile_MPI3 "XiosFile_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosFile_MPI3 PRIVATE USE_XIOS)
+        add_executable(testXiosFile_MPI4 "XiosFile_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosFile_MPI4 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosFile_MPI3
+            testXiosFile_MPI4
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosFile_MPI3 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosFile_MPI4 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosRead_MPI2 "XiosRead_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosRead_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -55,13 +55,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosAxis_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosDomain_MPI3 "XiosDomain_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosDomain_MPI3 PRIVATE USE_XIOS)
+        add_executable(testXiosDomain_MPI4 "XiosDomain_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosDomain_MPI4 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosDomain_MPI3
+            testXiosDomain_MPI4
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosDomain_MPI3 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosDomain_MPI4 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosGrid_MPI2 "XiosGrid_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosGrid_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -71,13 +71,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosGrid_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosField_MPI3 "XiosField_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosField_MPI3 PRIVATE USE_XIOS)
+        add_executable(testXiosField_MPI4 "XiosField_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosField_MPI4 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosField_MPI3
+            testXiosField_MPI4
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosField_MPI3 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosField_MPI4 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosFile_MPI2 "XiosFile_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -79,13 +79,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosField_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosFile_MPI2 "XiosFile_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS)
+        add_executable(testXiosFile_MPI1 "XiosFile_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosFile_MPI1 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosFile_MPI2
+            testXiosFile_MPI1
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosFile_MPI2 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosFile_MPI1 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosRead_MPI2 "XiosRead_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosRead_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -39,13 +39,13 @@ if(ENABLE_MPI)
         )
         add_custom_target(generate_xios_input_file ALL DEPENDS xios_test_input.nc)
 
-        add_executable(testXiosCalendar_MPI2 "XiosCalendar_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosCalendar_MPI2 PRIVATE USE_XIOS)
+        add_executable(testXiosCalendar_MPI1 "XiosCalendar_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosCalendar_MPI1 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosCalendar_MPI2
+            testXiosCalendar_MPI1
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosCalendar_MPI2 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosCalendar_MPI1 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosAxis_MPI2 "XiosAxis_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosAxis_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -79,13 +79,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosField_MPI3 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosFile_MPI4 "XiosFile_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosFile_MPI4 PRIVATE USE_XIOS)
+        add_executable(testXiosFile_MPI2 "XiosFile_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosFile_MPI4
+            testXiosFile_MPI2
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosFile_MPI4 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosFile_MPI2 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosRead_MPI2 "XiosRead_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosRead_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -47,13 +47,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosCalendar_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosAxis_MPI3 "XiosAxis_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosAxis_MPI3 PRIVATE USE_XIOS)
+        add_executable(testXiosAxis_MPI4 "XiosAxis_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosAxis_MPI4 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosAxis_MPI3
+            testXiosAxis_MPI4
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosAxis_MPI3 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosAxis_MPI4 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosDomain_MPI2 "XiosDomain_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosDomain_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -47,13 +47,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosCalendar_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosAxis_MPI2 "XiosAxis_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosAxis_MPI2 PRIVATE USE_XIOS)
+        add_executable(testXiosAxis_MPI1 "XiosAxis_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosAxis_MPI1 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosAxis_MPI2
+            testXiosAxis_MPI1
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosAxis_MPI2 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosAxis_MPI1 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosDomain_MPI2 "XiosDomain_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosDomain_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -55,13 +55,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosAxis_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosDomain_MPI2 "XiosDomain_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosDomain_MPI2 PRIVATE USE_XIOS)
+        add_executable(testXiosDomain_MPI1 "XiosDomain_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosDomain_MPI1 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosDomain_MPI2
+            testXiosDomain_MPI1
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosDomain_MPI2 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosDomain_MPI1 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosGrid_MPI2 "XiosGrid_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosGrid_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -63,13 +63,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosDomain_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosGrid_MPI3 "XiosGrid_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosGrid_MPI3 PRIVATE USE_XIOS)
+        add_executable(testXiosGrid_MPI4 "XiosGrid_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosGrid_MPI4 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosGrid_MPI3
+            testXiosGrid_MPI4
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosGrid_MPI3 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosGrid_MPI4 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosField_MPI2 "XiosField_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosField_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -39,13 +39,13 @@ if(ENABLE_MPI)
         )
         add_custom_target(generate_xios_input_file ALL DEPENDS xios_test_input.nc)
 
-        add_executable(testXiosCalendar_MPI4 "XiosCalendar_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosCalendar_MPI4 PRIVATE USE_XIOS)
+        add_executable(testXiosCalendar_MPI1 "XiosCalendar_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosCalendar_MPI1 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosCalendar_MPI4
+            testXiosCalendar_MPI1
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosCalendar_MPI4 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosCalendar_MPI1 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosAxis_MPI4 "XiosAxis_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosAxis_MPI4 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -71,13 +71,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosGrid_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosField_MPI1 "XiosField_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosField_MPI1 PRIVATE USE_XIOS)
+        add_executable(testXiosField_MPI3 "XiosField_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosField_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosField_MPI1
+            testXiosField_MPI3
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosField_MPI1 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosField_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosFile_MPI2 "XiosFile_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -39,13 +39,13 @@ if(ENABLE_MPI)
         )
         add_custom_target(generate_xios_input_file ALL DEPENDS xios_test_input.nc)
 
-        add_executable(testXiosCalendar_MPI3 "XiosCalendar_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosCalendar_MPI3 PRIVATE USE_XIOS)
+        add_executable(testXiosCalendar_MPI4 "XiosCalendar_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosCalendar_MPI4 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosCalendar_MPI3
+            testXiosCalendar_MPI4
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosCalendar_MPI3 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosCalendar_MPI4 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosAxis_MPI2 "XiosAxis_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosAxis_MPI2 PRIVATE USE_XIOS)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -71,13 +71,13 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosGrid_MPI4 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosField_MPI2 "XiosField_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosField_MPI2 PRIVATE USE_XIOS)
+        add_executable(testXiosField_MPI1 "XiosField_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosField_MPI1 PRIVATE USE_XIOS)
         target_include_directories(
-            testXiosField_MPI2
+            testXiosField_MPI1
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosField_MPI2 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosField_MPI1 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosFile_MPI2 "XiosFile_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS)

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -22,19 +22,19 @@ namespace Nextsim {
  * TestXiosAxis
  *
  * This function tests the axis functionality of the C++ interface for XIOS. It
- * needs to be run with 4 ranks i.e.,
+ * needs to be run with 3 ranks i.e.,
  *
- * `mpirun -n 4 ./testXiosAxis_MPI4`
+ * `mpirun -n 3 ./testXiosAxis_MPI3`
  *
  */
-MPI_TEST_CASE("TestXiosAxis", 4)
+MPI_TEST_CASE("TestXiosAxis", 3)
 {
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
-    REQUIRE(xiosHandler.getClientMPISize() == 4);
+    REQUIRE(xiosHandler.getClientMPISize() == 3);
 
     // --- Tests for axis API
     const std::string axisId = { "axis_A" };

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -1,7 +1,8 @@
 /*!
  * @file    XiosAxis_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    29 Apr 2025
+ * @author  Adeleke Bankole <ab3191@cam.ac.uk>
+ * @date    23 Apr 2025
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -22,19 +22,19 @@ namespace Nextsim {
  * TestXiosAxis
  *
  * This function tests the axis functionality of the C++ interface for XIOS. It
- * needs to be run with 1 rank i.e.,
+ * needs to be run with 3 ranks i.e.,
  *
- * `mpirun -n 1 ./testXiosAxis_MPI1`
+ * `mpirun -n 3 ./testXiosAxis_MPI3`
  *
  */
-MPI_TEST_CASE("TestXiosAxis", 1)
+MPI_TEST_CASE("TestXiosAxis", 3)
 {
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
-    REQUIRE(xiosHandler.getClientMPISize() == 1);
+    REQUIRE(xiosHandler.getClientMPISize() == 3);
 
     // --- Tests for axis API
     const std::string axisId = { "axis_A" };

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -22,19 +22,19 @@ namespace Nextsim {
  * TestXiosAxis
  *
  * This function tests the axis functionality of the C++ interface for XIOS. It
- * needs to be run with 2 ranks i.e.,
+ * needs to be run with 1 rank i.e.,
  *
- * `mpirun -n 2 ./testXiosAxis_MPI2`
+ * `mpirun -n 1 ./testXiosAxis_MPI1`
  *
  */
-MPI_TEST_CASE("TestXiosAxis", 2)
+MPI_TEST_CASE("TestXiosAxis", 1)
 {
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
-    REQUIRE(xiosHandler.getClientMPISize() == 2);
+    REQUIRE(xiosHandler.getClientMPISize() == 1);
 
     // --- Tests for axis API
     const std::string axisId = { "axis_A" };

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -22,19 +22,19 @@ namespace Nextsim {
  * TestXiosAxis
  *
  * This function tests the axis functionality of the C++ interface for XIOS. It
- * needs to be run with 3 ranks i.e.,
+ * needs to be run with 4 ranks i.e.,
  *
- * `mpirun -n 3 ./testXiosAxis_MPI3`
+ * `mpirun -n 4 ./testXiosAxis_MPI4`
  *
  */
-MPI_TEST_CASE("TestXiosAxis", 3)
+MPI_TEST_CASE("TestXiosAxis", 4)
 {
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
-    REQUIRE(xiosHandler.getClientMPISize() == 3);
+    REQUIRE(xiosHandler.getClientMPISize() == 4);
 
     // --- Tests for axis API
     const std::string axisId = { "axis_A" };

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -1,6 +1,7 @@
 /*!
  * @file    XiosCalendar_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @author  Adeleke Bankole <ab3191@cam.ac.uk>
  * @date    06 May 2025
  * @brief   Tests for XIOS calandars
  * @details

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -23,12 +23,12 @@ namespace Nextsim {
  * TestXiosCalendar
  *
  * This function tests the calendar functionality of the C++ interface for XIOS. It
- * needs to be run with 4 ranks i.e.,
+ * needs to be run with 1 rank i.e.,
  *
- * `mpirun -n 4 ./testXiosCalendar_MPI4`
+ * `mpirun -n 1 ./testXiosCalendar_MPI1`
  *
  */
-MPI_TEST_CASE("TestXiosCalendar", 4)
+MPI_TEST_CASE("TestXiosCalendar", 1)
 {
     // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
@@ -44,7 +44,7 @@ MPI_TEST_CASE("TestXiosCalendar", 4)
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
-    REQUIRE(xiosHandler.getClientMPISize() == 4);
+    REQUIRE(xiosHandler.getClientMPISize() == 1);
 
     // --- Tests for calendar API
     // Calendar type

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -3,7 +3,7 @@
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
  * @date    06 May 2025
- * @brief   Tests for XIOS calandars
+ * @brief   Tests for XIOS calendars
  * @details
  * This test is designed to test calendar functionality of the C++ interface
  * for XIOS.

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -23,12 +23,12 @@ namespace Nextsim {
  * TestXiosCalendar
  *
  * This function tests the calendar functionality of the C++ interface for XIOS. It
- * needs to be run with 1 rank i.e.,
+ * needs to be run with 3 ranks i.e.,
  *
- * `mpirun -n 1 ./testXiosCalendar_MPI1`
+ * `mpirun -n 3 ./testXiosCalendar_MPI3`
  *
  */
-MPI_TEST_CASE("TestXiosCalendar", 1)
+MPI_TEST_CASE("TestXiosCalendar", 3)
 {
     // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
@@ -44,7 +44,7 @@ MPI_TEST_CASE("TestXiosCalendar", 1)
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
-    REQUIRE(xiosHandler.getClientMPISize() == 1);
+    REQUIRE(xiosHandler.getClientMPISize() == 3);
 
     // --- Tests for calendar API
     // Calendar type

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -23,12 +23,12 @@ namespace Nextsim {
  * TestXiosCalendar
  *
  * This function tests the calendar functionality of the C++ interface for XIOS. It
- * needs to be run with 2 ranks i.e.,
+ * needs to be run with 1 rank i.e.,
  *
- * `mpirun -n 2 ./testXiosCalendar_MPI2`
+ * `mpirun -n 1 ./testXiosCalendar_MPI1`
  *
  */
-MPI_TEST_CASE("TestXiosCalendar", 2)
+MPI_TEST_CASE("TestXiosCalendar", 1)
 {
     // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
@@ -44,7 +44,7 @@ MPI_TEST_CASE("TestXiosCalendar", 2)
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
-    REQUIRE(xiosHandler.getClientMPISize() == 2);
+    REQUIRE(xiosHandler.getClientMPISize() == 1);
 
     // --- Tests for calendar API
     // Calendar type

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -23,12 +23,12 @@ namespace Nextsim {
  * TestXiosCalendar
  *
  * This function tests the calendar functionality of the C++ interface for XIOS. It
- * needs to be run with 3 ranks i.e.,
+ * needs to be run with 4 ranks i.e.,
  *
- * `mpirun -n 3 ./testXiosCalendar_MPI3`
+ * `mpirun -n 4 ./testXiosCalendar_MPI4`
  *
  */
-MPI_TEST_CASE("TestXiosCalendar", 3)
+MPI_TEST_CASE("TestXiosCalendar", 4)
 {
     // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
@@ -44,7 +44,7 @@ MPI_TEST_CASE("TestXiosCalendar", 3)
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
-    REQUIRE(xiosHandler.getClientMPISize() == 3);
+    REQUIRE(xiosHandler.getClientMPISize() == 4);
 
     // --- Tests for calendar API
     // Calendar type

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -1,6 +1,7 @@
 /*!
  * @file    XiosDomain_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @author  Adeleke Bankole <ab3191@cam.ac.uk>
  * @date    29 Apr 2025
  * @brief   Tests for XIOS domains
  * @details

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -22,12 +22,12 @@ namespace Nextsim {
  * TestXiosDomain
  *
  * This function tests the domain functionality of the C++ interface for XIOS. It
- * needs to be run with 3 ranks i.e.,
+ * needs to be run with 4 ranks i.e.,
  *
- * `mpirun -n 3 ./testXiosDomain_MPI3`
+ * `mpirun -n 4 ./testXiosDomain_MPI4`
  *
  */
-MPI_TEST_CASE("TestXiosDomain", 3)
+MPI_TEST_CASE("TestXiosDomain", 4)
 {
     enableXios();
 
@@ -35,7 +35,7 @@ MPI_TEST_CASE("TestXiosDomain", 3)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 3);
+    REQUIRE(size == 4);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // --- Tests for domain API

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -22,12 +22,12 @@ namespace Nextsim {
  * TestXiosDomain
  *
  * This function tests the domain functionality of the C++ interface for XIOS. It
- * needs to be run with 2 ranks i.e.,
+ * needs to be run with 1 rank i.e.,
  *
- * `mpirun -n 2 ./testXiosDomain_MPI2`
+ * `mpirun -n 1 ./testXiosDomain_MPI1`
  *
  */
-MPI_TEST_CASE("TestXiosDomain", 2)
+MPI_TEST_CASE("TestXiosDomain", 1)
 {
     enableXios();
 
@@ -35,7 +35,7 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 2);
+    REQUIRE(size == 1);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // --- Tests for domain API

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -22,12 +22,12 @@ namespace Nextsim {
  * TestXiosDomain
  *
  * This function tests the domain functionality of the C++ interface for XIOS. It
- * needs to be run with 1 rank i.e.,
+ * needs to be run with 3 ranks i.e.,
  *
- * `mpirun -n 1 ./testXiosDomain_MPI1`
+ * `mpirun -n 3 ./testXiosDomain_MPI3`
  *
  */
-MPI_TEST_CASE("TestXiosDomain", 1)
+MPI_TEST_CASE("TestXiosDomain", 3)
 {
     enableXios();
 
@@ -35,7 +35,7 @@ MPI_TEST_CASE("TestXiosDomain", 1)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 1);
+    REQUIRE(size == 3);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // --- Tests for domain API

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -22,12 +22,12 @@ namespace Nextsim {
  * TestXiosField
  *
  * This function tests the field functionality of the C++ interface for XIOS. It
- * needs to be run with 2 ranks i.e.,
+ * needs to be run with 1 rank i.e.,
  *
- * `mpirun -n 2 ./testXiosField_MPI2`
+ * `mpirun -n 1 ./testXiosField_MPI1`
  *
  */
-MPI_TEST_CASE("TestXiosField", 2)
+MPI_TEST_CASE("TestXiosField", 1)
 {
     enableXios();
 
@@ -35,7 +35,7 @@ MPI_TEST_CASE("TestXiosField", 2)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 2);
+    REQUIRE(size == 1);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create an axis with two points

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -22,12 +22,12 @@ namespace Nextsim {
  * TestXiosField
  *
  * This function tests the field functionality of the C++ interface for XIOS. It
- * needs to be run with 3 ranks i.e.,
+ * needs to be run with 4 ranks i.e.,
  *
- * `mpirun -n 3 ./testXiosField_MPI3`
+ * `mpirun -n 4 ./testXiosField_MPI4`
  *
  */
-MPI_TEST_CASE("TestXiosField", 3)
+MPI_TEST_CASE("TestXiosField", 4)
 {
     enableXios();
 
@@ -35,7 +35,7 @@ MPI_TEST_CASE("TestXiosField", 3)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 3);
+    REQUIRE(size == 4);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create an axis with two points

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -1,6 +1,7 @@
 /*!
  * @file    XiosField_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @author  Adeleke Bankole <ab3191@cam.ac.uk>
  * @date    29 Apr 2025
  * @brief   Tests for XIOS axes
  * @details

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -22,12 +22,12 @@ namespace Nextsim {
  * TestXiosField
  *
  * This function tests the field functionality of the C++ interface for XIOS. It
- * needs to be run with 1 rank i.e.,
+ * needs to be run with 3 ranks i.e.,
  *
- * `mpirun -n 1 ./testXiosField_MPI1`
+ * `mpirun -n 3 ./testXiosField_MPI3`
  *
  */
-MPI_TEST_CASE("TestXiosField", 1)
+MPI_TEST_CASE("TestXiosField", 3)
 {
     enableXios();
 
@@ -35,7 +35,7 @@ MPI_TEST_CASE("TestXiosField", 1)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 1);
+    REQUIRE(size == 3);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create an axis with two points

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -3,9 +3,9 @@
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
  * @date    29 Apr 2025
- * @brief   Tests for XIOS axes
+ * @brief   Tests for XIOS fields
  * @details
- * This test is designed to test axis functionality of the C++ interface
+ * This test is designed to test field functionality of the C++ interface
  * for XIOS.
  *
  */

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -22,12 +22,12 @@ namespace Nextsim {
  * TestXiosField
  *
  * This function tests the field functionality of the C++ interface for XIOS. It
- * needs to be run with 4 ranks i.e.,
+ * needs to be run with 3 ranks i.e.,
  *
- * `mpirun -n 4 ./testXiosField_MPI4`
+ * `mpirun -n 3 ./testXiosField_MPI3`
  *
  */
-MPI_TEST_CASE("TestXiosField", 4)
+MPI_TEST_CASE("TestXiosField", 3)
 {
     enableXios();
 
@@ -35,7 +35,7 @@ MPI_TEST_CASE("TestXiosField", 4)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 4);
+    REQUIRE(size == 3);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create an axis with two points

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -22,7 +22,7 @@ using namespace doctest;
 namespace Nextsim {
 
 /*!
- * TestXiosInitialization
+ * TestXiosFile
  *
  * This function tests the file functionality of the C++ interface for XIOS. It
  * needs to be run with 2 ranks i.e.,

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -25,12 +25,12 @@ namespace Nextsim {
  * TestXiosFile
  *
  * This function tests the file functionality of the C++ interface for XIOS. It
- * needs to be run with 2 ranks i.e.,
+ * needs to be run with 1 rank i.e.,
  *
- * `mpirun -n 2 ./testXiosFile_MPI2`
+ * `mpirun -n 1 ./testXiosFile_MPI1`
  *
  */
-MPI_TEST_CASE("TestXiosFile", 2)
+MPI_TEST_CASE("TestXiosFile", 1)
 {
     // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
@@ -48,7 +48,7 @@ MPI_TEST_CASE("TestXiosFile", 2)
     Xios& xiosHandler = Xios::getInstance("P0-0T01:30:00");
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 2);
+    REQUIRE(size == 1);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create a simple axis with two points

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -2,10 +2,10 @@
  * @file    XiosFile_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    06 May 2025
- * @brief   Tests for XIOS axes
+ * @date    23 Apr 2025
+ * @brief   Tests for XIOS file
  * @details
- * This test is designed to test axis functionality of the C++ interface
+ * This test is designed to test file functionality of the C++ interface
  * for XIOS.
  *
  */

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -25,12 +25,12 @@ namespace Nextsim {
  * TestXiosFile
  *
  * This function tests the file functionality of the C++ interface for XIOS. It
- * needs to be run with 3 ranks i.e.,
+ * needs to be run with 4 ranks i.e.,
  *
- * `mpirun -n 3 ./testXiosFile_MPI3`
+ * `mpirun -n 4 ./testXiosFile_MPI4`
  *
  */
-MPI_TEST_CASE("TestXiosFile", 3)
+MPI_TEST_CASE("TestXiosFile", 4)
 {
     // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
@@ -48,7 +48,7 @@ MPI_TEST_CASE("TestXiosFile", 3)
     Xios& xiosHandler = Xios::getInstance("P0-0T01:30:00");
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 3);
+    REQUIRE(size == 4);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create a simple axis with two points

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -25,12 +25,12 @@ namespace Nextsim {
  * TestXiosFile
  *
  * This function tests the file functionality of the C++ interface for XIOS. It
- * needs to be run with 1 rank i.e.,
+ * needs to be run with 3 ranks i.e.,
  *
- * `mpirun -n 1 ./testXiosFile_MPI1`
+ * `mpirun -n 3 ./testXiosFile_MPI3`
  *
  */
-MPI_TEST_CASE("TestXiosFile", 1)
+MPI_TEST_CASE("TestXiosFile", 3)
 {
     // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
@@ -48,7 +48,7 @@ MPI_TEST_CASE("TestXiosFile", 1)
     Xios& xiosHandler = Xios::getInstance("P0-0T01:30:00");
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 1);
+    REQUIRE(size == 3);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create a simple axis with two points

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -1,6 +1,7 @@
 /*!
  * @file    XiosFile_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @author  Adeleke Bankole <ab3191@cam.ac.uk>
  * @date    06 May 2025
  * @brief   Tests for XIOS axes
  * @details

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -25,12 +25,12 @@ namespace Nextsim {
  * TestXiosFile
  *
  * This function tests the file functionality of the C++ interface for XIOS. It
- * needs to be run with 4 ranks i.e.,
+ * needs to be run with 2 ranks i.e.,
  *
- * `mpirun -n 4 ./testXiosFile_MPI4`
+ * `mpirun -n 2 ./testXiosFile_MPI2`
  *
  */
-MPI_TEST_CASE("TestXiosFile", 4)
+MPI_TEST_CASE("TestXiosFile", 2)
 {
     // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
@@ -48,7 +48,7 @@ MPI_TEST_CASE("TestXiosFile", 4)
     Xios& xiosHandler = Xios::getInstance("P0-0T01:30:00");
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 4);
+    REQUIRE(size == 2);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create a simple axis with two points

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -1,6 +1,7 @@
 /*!
  * @file    XiosGrid_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @author  Adeleke Bankole <ab3191@cam.ac.uk>
  * @date    29 Apr 2025
  * @brief   Tests for XIOS axes
  * @details

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -21,12 +21,12 @@ namespace Nextsim {
  * TestXiosGrid
  *
  * This function tests the grid functionality of the C++ interface for XIOS. It
- * needs to be run with 1 rank i.e.,
+ * needs to be run with 3 ranks i.e.,
  *
- * `mpirun -n 1 ./testXiosGrid_MPI1`
+ * `mpirun -n 3 ./testXiosGrid_MPI3`
  *
  */
-MPI_TEST_CASE("TestXiosGrid", 1)
+MPI_TEST_CASE("TestXiosGrid", 3)
 {
     enableXios();
 
@@ -34,7 +34,7 @@ MPI_TEST_CASE("TestXiosGrid", 1)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 1);
+    REQUIRE(size == 3);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create a 4x2 horizontal domain with a partition halving the x-extent

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -21,12 +21,12 @@ namespace Nextsim {
  * TestXiosGrid
  *
  * This function tests the grid functionality of the C++ interface for XIOS. It
- * needs to be run with 2 ranks i.e.,
+ * needs to be run with 1 rank i.e.,
  *
- * `mpirun -n 2 ./testXiosGrid_MPI2`
+ * `mpirun -n 1 ./testXiosGrid_MPI1`
  *
  */
-MPI_TEST_CASE("TestXiosGrid", 2)
+MPI_TEST_CASE("TestXiosGrid", 1)
 {
     enableXios();
 
@@ -34,7 +34,7 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 2);
+    REQUIRE(size == 1);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create a 4x2 horizontal domain with a partition halving the x-extent

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -2,10 +2,10 @@
  * @file    XiosGrid_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    29 Apr 2025
- * @brief   Tests for XIOS axes
+ * @date    23 Apr 2025
+ * @brief   Tests for XIOS grid
  * @details
- * This test is designed to test axis functionality of the C++ interface
+ * This test is designed to test grid functionality of the C++ interface
  * for XIOS.
  *
  */

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -21,20 +21,20 @@ namespace Nextsim {
  * TestXiosGrid
  *
  * This function tests the grid functionality of the C++ interface for XIOS. It
- * needs to be run with 3 ranks i.e.,
+ * needs to be run with 4 ranks i.e.,
  *
- * `mpirun -n 3 ./testXiosGrid_MPI3`
+ * `mpirun -n 4 ./testXiosGrid_MPI4`
  *
  */
-MPI_TEST_CASE("TestXiosGrid", 3)
+MPI_TEST_CASE("TestXiosGrid", 4)
 {
     enableXios();
-
+D
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
-    REQUIRE(size == 3);
+    REQUIRE(size == 4);
     const size_t rank = xiosHandler.getClientMPIRank();
 
     // Create a 4x2 horizontal domain with a partition halving the x-extent

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -29,7 +29,6 @@ namespace Nextsim {
 MPI_TEST_CASE("TestXiosGrid", 4)
 {
     enableXios();
-D
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.isInitialized());


### PR DESCRIPTION
# Enable more numbers of MPI ranks in XIOS tests

Fixes #812 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

This PR attempts to change the number of MPI processors for some XIOS unit tests so that we can handle more cases that 2 MPI ranks.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README