### PR TITLE
The land mask is wrong in the restart file

### DIFF
--- a/core/src/ModelComponent.cpp
+++ b/core/src/ModelComponent.cpp
@@ -11,10 +11,15 @@
 
 namespace Nextsim {
 
-size_t ModelComponent::nOcean;
+size_t ModelComponent::nOcean = 0;
 std::vector<size_t> ModelComponent::oceanIndex;
 
-ModelComponent::ModelComponent() = default;
+ModelComponent::ModelComponent()
+{
+    // We only set no land mask if the mask hasn't been set by someone else.
+    if (nOcean == 0)
+        noLandMask();
+}
 
 /*
  * This assumes that the HField array size has already been set in the restart

--- a/core/src/ModelComponent.cpp
+++ b/core/src/ModelComponent.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ModelComponent.cpp
  *
- * @date Feb 28, 2022
+ * @date 25 Apr 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -14,7 +14,7 @@ namespace Nextsim {
 size_t ModelComponent::nOcean;
 std::vector<size_t> ModelComponent::oceanIndex;
 
-ModelComponent::ModelComponent() { noLandMask(); }
+ModelComponent::ModelComponent() = default;
 
 /*
  * This assumes that the HField array size has already been set in the restart

--- a/test/test_integration_test.py
+++ b/test/test_integration_test.py
@@ -80,4 +80,17 @@ if np.any(cice_dg0 <= cice_min) or np.any(cice_dg0 > cice_max):
     print(f"Error: ice concentration at at least one sample point is outside the range 0 ≤ c_ice ≤ 1.")
     sys.exit(8)
 
+# Test the land mask
+mask_name = "mask"
+mask = data_group[mask_name]
+print(f"mask={mask[y_lo:y_hi:y_lo, x_lo:x_hi:x_lo]}")
+
+if mask[50,50] != 1:
+    print(f"Error: Test point [50,50] is not wet.")
+    sys.exit(8)
+
+if mask[100,140] != 0:
+    print(f"Error: Test point [100,140] is not dry.")
+    sys.exit(8)
+
 print("Success: integration test passed.")


### PR DESCRIPTION
# The land mask is wrong in the restart file

Fixes #814 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

I fixed this by removing the call to ``noLandMask()`` in the ``ModelComponent()`` constructor (and making it a ``default`` constructor).

---
# Test Description

I added a test of the land mask to the realistic integration tests. That test now fails if two pre-defined points are not defined as land and ocean.

---
# Documentation Impact

N/A

---
# Other Details

None
---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README