### PR TITLE
ci: install pip manually and use venv for nextsim

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -48,12 +48,17 @@ jobs:
 
     - name: installs for python tests
       run: |
+        apt -y update
+        apt install -y python3.12-venv
+        python3 -m venv ~/nextsim
+        . $HOME/nextsim/bin/activate
         pip install numpy
         pip install netCDF4
 
     - name: run serial tests
       run: |
         . /opt/spack-environment/activate.sh
+        . $HOME/nextsim/bin/activate
         apt update
         apt install -y wget
         cd build


### PR DESCRIPTION
CI workflow `test-ubuntu-serial` was failing with error:

```
/__w/_temp/18dd53ca-94c3-4b64-a443-efe9613eb7c0.sh: 1: pip: not found
Error: Process completed with exit code 127.
```

This PR fixes this issue by manually installing `pip` and creating a `venv` to install nextsim's python dependencies.