### PR TITLE
Copy ModelArraySlice to Eigen objects

### DIFF
--- a/core/src/ModelArraySlice.cpp
+++ b/core/src/ModelArraySlice.cpp
@@ -49,6 +49,39 @@ ModelArraySlice& ModelArraySlice::operator=(ModelArray& ma)
     return *this;
 }
 
+ModelArraySlice& ModelArraySlice::operator=(const ModelArray::DataType& buffer)
+{
+    SliceIter thisIter(slice, data.dimensions());
+    // The iterator for the buffer must have the same dimensions as the target slice.
+    Slice::VBounds bufferBounds(data.nDimensions(), Slice::Bounds());
+    ModelArray::MultiDim bufferDims(data.nDimensions());
+    for (size_t dim = 0; dim < data.nDimensions(); ++dim) {
+        bufferDims[dim] = thisIter.nElements(dim);
+    }
+    SliceIter bufferIter(bufferBounds, bufferDims);
+    copySliceWithIters(buffer, bufferIter, data.m_data, thisIter);
+
+    return *this;
+}
+
+ModelArraySlice::operator ModelArray::DataType()
+{
+    SliceIter thisIter(slice, data.dimensions());
+    Slice::VBounds bufferBounds(data.nDimensions(), Slice::Bounds());
+    ModelArray::MultiDim bufferDims(data.nDimensions());
+    size_t nElements = 1;
+    for (size_t dim = 0; dim < data.nDimensions(); ++dim) {
+        bufferDims[dim] = thisIter.nElements(dim);
+        nElements *= bufferDims[dim];
+    }
+    SliceIter bufferIter(bufferBounds, bufferDims);
+    ModelArray::DataType buffer;
+    buffer.resize(nElements, data.nComponents());
+    copySliceWithIters(data.m_data, thisIter, buffer, bufferIter);
+
+    return buffer;
+}
+
 ModelArray& ModelArraySlice::copyToModelArray(ModelArray& target) const
 {
     copyBetweenMAandMASlice(target, *this, false, "ModelArraySlice::copyToModelArray(ModelArray)");

--- a/core/src/include/ModelArraySlice.hpp
+++ b/core/src/include/ModelArraySlice.hpp
@@ -152,6 +152,32 @@ public:
     }
 
     /*!
+     * @brief Assigns to a slice from a instance of ModelArray::DataType.
+     *
+     * @details Fills the slice with data from an instance of ModelArray::DataType. The data source
+     * should be sufficiently sized that the data is copied without being indexed out-of-bounds.
+     * The number of components of the slice ModelArray and the size of the second dimension of the
+     * source array should match. The spatial dimensions of the slice will copy from the first
+     * dimension of the source array, treating it as a flattened one-dimensional version of the
+     * slice, with the first spatial dimension of the slice varying fastest.
+     *
+     * @params dataBuffer The source of the data to be copied into the slice.
+     */
+    ModelArraySlice& operator=(const ModelArray::DataType& dataBuffer);
+
+    /*!
+     * @brief Returns the contents of this slice as an instance of ModelArray::DataType.
+     *
+     * @details Creates an instance of ModelArray::DataType with the contents of the slice,
+     * including all components. Current ModelArray::DataType is Eigen::Array. In this case all
+     * spatial dimensions are flattened to one dimension, as they are internally in ModelArray,
+     * and occupy the first dimension of the Eigen::Array. Any components of the sliced array take
+     * up the second dimension. That is, a 4 x 5 slice with 3 components will create a (20, 3)
+     * Eigen::Array.
+     */
+    operator ModelArray::DataType();
+
+    /*!
      * Copies the contents of a slice to a ModelArray with an equal number of elements.
      * @param target The ModelArray object to copy the contents of the slice to.
      * @return A reference to the updated ModelArray object.

--- a/core/src/include/Slice.hpp
+++ b/core/src/include/Slice.hpp
@@ -122,7 +122,7 @@ public:
         Index stop;
         Int step;
         Bounds()
-            : Bounds(0, {}, 1)
+            : Bounds(0, Index(), 1)
         {
         }
         Bounds(Index i)
@@ -144,7 +144,10 @@ public:
         }
         std::ostream& print(std::ostream& os) const
         {
-            return os << start << ":" << stop << ":" << step;
+            start.print(os);
+            os << ":";
+            stop.print(os);
+            return os << ":" << step;
         }
         friend SliceIter;
     };

--- a/core/test/ModelArraySlice_test.cpp
+++ b/core/test/ModelArraySlice_test.cpp
@@ -21,7 +21,6 @@ const auto nz = 5;
 
 namespace Nextsim {
 TEST_SUITE_BEGIN("ModelArraySlice");
-#if false
 TEST_CASE("Assign scalar to slice")
 {
     ModelArray::setDimension(ModelArray::Dimension::X, nx);
@@ -500,7 +499,7 @@ TEST_CASE("Eigen copying")
     // Check the copied values
     REQUIRE(eig1(Indexer::indexer(eig1Dim, {iTest + oneWrap, 0}), 0) == source(iTest, ny-1));
 }
-#endif
+
 TEST_CASE("Eigen (ModelArray::DataType) buffers")
 {
     ModelArray::setDimension(ModelArray::Dimension::X, nx);
@@ -551,8 +550,6 @@ TEST_CASE("Eigen (ModelArray::DataType) buffers")
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 0) == 0);
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 5) == 5);
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {3, 5}), 2) == 2 + xMul * (3 + yMul * 5));
-
-
 }
 TEST_SUITE_END();
 } // namespace Nextsim

--- a/core/test/ModelArraySlice_test.cpp
+++ b/core/test/ModelArraySlice_test.cpp
@@ -551,5 +551,88 @@ TEST_CASE("Eigen (ModelArray::DataType) buffers")
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 5) == 5);
     REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {3, 5}), 2) == 2 + xMul * (3 + yMul * 5));
 }
+
+TEST_CASE("Eigen (ModelArray::DataType) subscripted buffers")
+{
+    ModelArray::setDimension(ModelArray::Dimension::X, nx);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny);
+
+    const size_t DG = 6;
+    ModelArray::setDimension(ModelArray::Dimension::COMP, DG);
+
+    double xMul = 100;
+    double yMul = 100;
+
+    // Buffer of the array perimeter
+    ModelArray maSrc(ModelArray::Type::TWOCOMP);
+    maSrc.resize();
+
+    for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+            double spatial = xMul * (i + yMul * j);
+            for (size_t c = 0; c < DG; ++c) {
+                maSrc.components({i, j})[c] = spatial + c;
+            }
+        }
+    }
+    REQUIRE(maSrc.components({2, 3})[4] == 4 + xMul * (2 + yMul * 3));
+
+    ModelArray::DataType perimeterBuffer;
+    perimeterBuffer.resize(2*nx + 2*ny, DG);
+    Slice left {{{0}, {}}};
+    Slice right {{{nx-1},{}}};
+    Slice bottom {{{},{0}}};
+    Slice top {{{}, {ny-1}}};
+    // bottom 0, nx points
+    perimeterBuffer(Eigen::seqN(0, nx), Eigen::all) = static_cast<ModelArray::DataType>(maSrc[bottom]);
+    // right nx, ny points
+    perimeterBuffer(Eigen::seqN(nx, ny), Eigen::all) = static_cast<ModelArray::DataType>(maSrc[right]);
+    // top nx + ny, nx points
+    perimeterBuffer(Eigen::seqN(nx+ny, nx), Eigen::all) = static_cast<ModelArray::DataType>(maSrc[top]);
+    // left 2nx + ny, ny points
+    perimeterBuffer(Eigen::seqN(2*nx+ny, ny), Eigen::all) = static_cast<ModelArray::DataType>(maSrc[left]);
+
+    // bottom check
+    for (size_t i = 0; i < nx; ++i) {
+        REQUIRE(perimeterBuffer(i, i % DG) == (i % DG) + xMul * i);
+    }
+    // right check
+    for (size_t j = 0; j < ny; ++j) {
+        REQUIRE(perimeterBuffer(j + nx, j % DG) == (j % DG) + xMul * (nx-1 + yMul * j));
+    }
+    // top check
+    for (size_t i = 0; i < nx; ++i) {
+        REQUIRE(perimeterBuffer(i + nx + ny, i % DG) == (i % DG) + xMul * (i + yMul * (ny -1)));
+    }
+    // left check
+    for (size_t j = 0; j < ny; ++j) {
+        REQUIRE(perimeterBuffer(j + 2 * nx + ny, j % DG) == (j % DG) + xMul * (0 + yMul * j));
+    }
+
+    ModelArray maSnk(ModelArray::Type::TWOCOMP);
+    maSnk.resize();
+    maSnk[bottom] = ModelArray::DataType(perimeterBuffer(Eigen::seqN(0, nx), Eigen::all));
+    maSnk[right] = ModelArray::DataType(perimeterBuffer(Eigen::seqN(nx, ny), Eigen::all));
+    maSnk[top] = ModelArray::DataType(perimeterBuffer(Eigen::seqN(nx + ny, nx), Eigen::all));
+    maSnk[left] = ModelArray::DataType(perimeterBuffer(Eigen::seqN(2*nx + ny, ny), Eigen::all));
+
+    // bottom check
+    for (size_t i = 0; i < nx; ++i) {
+        REQUIRE(maSnk.components({i, 0})[i % DG] == (i % DG) + xMul * i);
+    }
+    // right check
+    for (size_t j = 0; j < ny; ++j) {
+        REQUIRE(maSnk.components({nx-1, j})[j % DG] == (j % DG) + xMul * (nx-1 + yMul * j));
+    }
+    // top check
+    for (size_t i = 0; i < nx; ++i) {
+        REQUIRE(maSnk.components({i, ny-1})[i % DG] == (i % DG) + xMul * (i + yMul * (ny -1)));
+    }
+    // left check
+    for (size_t j = 0; j < ny; ++j) {
+        REQUIRE(maSnk.components({0, j})[j % DG] == (j % DG) + xMul * (0 + yMul * j));
+    }
+
+}
 TEST_SUITE_END();
 } // namespace Nextsim

--- a/core/test/ModelArraySlice_test.cpp
+++ b/core/test/ModelArraySlice_test.cpp
@@ -21,6 +21,7 @@ const auto nz = 5;
 
 namespace Nextsim {
 TEST_SUITE_BEGIN("ModelArraySlice");
+#if false
 TEST_CASE("Assign scalar to slice")
 {
     ModelArray::setDimension(ModelArray::Dimension::X, nx);
@@ -498,6 +499,60 @@ TEST_CASE("Eigen copying")
     source[topRow2].copyToSlicedBuffer(eig1_0, eig1BottomRowBlock);
     // Check the copied values
     REQUIRE(eig1(Indexer::indexer(eig1Dim, {iTest + oneWrap, 0}), 0) == source(iTest, ny-1));
+}
+#endif
+TEST_CASE("Eigen (ModelArray::DataType) buffers")
+{
+    ModelArray::setDimension(ModelArray::Dimension::X, nx);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny);
+
+    const size_t DG = 6;
+    ModelArray::setDimension(ModelArray::Dimension::COMP, DG);
+
+    size_t sliceNx = 7;
+    size_t sliceNy = 11;
+    size_t sliceX0 = 3;
+    size_t sliceY0 = 5;
+
+    double xMul = 100;
+    double yMul = 100;
+    ModelArray::DataType eaSrc;
+    eaSrc.resize(sliceNx * sliceNy, DG);
+    for (size_t j = 0; j < sliceNy; ++j) {
+        for (size_t i = 0; i < sliceNx; ++i) {
+            size_t ii = Indexer::indexer({sliceNx, sliceNy}, {i, j});
+            for (size_t c = 0; c < DG; ++c) {
+                eaSrc(ii, c) = c + xMul * (i + yMul * j);
+            }
+        }
+    }
+    REQUIRE(eaSrc(Indexer::indexer({sliceNx, sliceNy}, {2, 3}), 4) == 4 + xMul*(2 + yMul * 3));
+
+    ModelArray maInter(ModelArray::Type::TWOCOMP);
+    maInter = -1.;
+    REQUIRE(maInter.components({sliceX0+2, sliceY0+3})[4] == -1.);
+    Slice maSlice {{{sliceX0, sliceX0 + sliceNx}, {sliceY0, sliceY0 + sliceNy}}};
+    maInter[maSlice] = eaSrc;
+    REQUIRE(maInter.components({sliceX0-1, sliceY0-1})[0] == -1.);
+    REQUIRE(maInter.components({sliceX0-1, sliceY0-1})[DG-1] == -1.);
+    REQUIRE(maInter.components({sliceX0+0, sliceY0+0})[0] == 0.);
+    REQUIRE(maInter.components({sliceX0+0, sliceY0+0})[DG-1] == DG-1);
+    REQUIRE(maInter.components({sliceX0+1, sliceY0+0})[0] == xMul);
+    REQUIRE(maInter.components({sliceX0+1, sliceY0+0})[DG-1] == xMul + DG-1);
+    REQUIRE(maInter.components({sliceX0+0, sliceY0+1})[0] == xMul * yMul);
+    REQUIRE(maInter.components({sliceX0+0, sliceY0+1})[DG-1] == xMul  * yMul + DG-1);
+
+    REQUIRE(maInter.components({sliceX0+2, sliceY0+3})[4] == 4 + xMul*(2 + yMul * 3));
+
+    ModelArray::DataType eaSink;
+    eaSink.resize(sliceNx * sliceNy, DG);
+    eaSink = -1;
+    eaSink = maInter[maSlice];
+    REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 0) == 0);
+    REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {0, 0}), 5) == 5);
+    REQUIRE(eaSink(Indexer::indexer({sliceNx, sliceNy}, {3, 5}), 2) == 2 + xMul * (3 + yMul * 5));
+
+
 }
 TEST_SUITE_END();
 } // namespace Nextsim


### PR DESCRIPTION
# Copy ModelArraySlice to Eigen objects

Fixes #735 

---
# Change Description

Copy the data in a `ModelArraySlice` directly to and from a buffer that is an object of type `ModelArray::DataType=Eigen::Array`. The size of the slice and the buffer must match.

---
# Test Description

Test that data can be written and read directly into both an `Eigen::Array` buffer and a sliced `Eigen::Array` buffer. The data is check that the round-trip was completed successfully.
