### PR TITLE
Use overElements in IOceanBoundary and derived classes

### DIFF
--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file SlabOcean.cpp
  *
- * @date 10 Feb 2025
+ * @date 29 Apr 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -71,22 +71,28 @@ ModelState SlabOcean::getState(const OutputLevel&) const { return getState(); }
 
 void SlabOcean::update(const TimestepTime& tst)
 {
-    const double dt = tst.step.seconds();
+    dt = tst.step.seconds();
+    overElements(
+        std::bind(&SlabOcean::updateElement, this, std::placeholders::_1, std::placeholders::_2),
+        tst);
+}
 
+void SlabOcean::updateElement(size_t i, const TimestepTime& tst)
+{
     // Slab SST update
-    qdw = (sstExt - sst) * cpml / relaxationTimeT;
-    sstSlab = sst - dt * (qswNet + qNoSun - qdw) / cpml;
+    qdw[i] = (sstExt[i] - sst[i]) * cpml[i] / relaxationTimeT;
+    sstSlab[i] = sst[i] - dt * (qswNet[i] + qNoSun[i] - qdw[i]) / cpml[i];
 
     // Slab SSS update
-    const HField arealDensity = cpml / Water::cp; // density times depth, or cpml divided by cp
+    const double arealDensity = cpml[i] / Water::cp; // density times depth, or cpml divided by cp
     // This is simplified compared to the finiteelement.cpp calculation
     // Fdw = delS * mld * physical::rhow /(timeS*M_sss[i] - ddt*delS) where delS = sssSlab - sssExt
-    fdw = (1 - sssExt / sss) * arealDensity / relaxationTimeS;
+    fdw[i] = (1 - sssExt[i] / sss[i]) * arealDensity / relaxationTimeS;
 
     // Mass per unit area after all the changes in water volume
     // Clamp the denominator to be at least 1 m deep, i.e. at least Water::rho kg m⁻²
-    const HField denominator = (arealDensity - (fwFlux - fdw) * dt).clampAbove(Water::rhoOcean);
-    sssSlab = sss + (sss * fwFlux - fdw * dt) / denominator;
+    const double denominator = std::max(arealDensity - (fwFlux[i] - fdw[i]) * dt, Water::rhoOcean);
+    sssSlab[i] = sss[i] + (sss[i] * fwFlux[i] - fdw[i] * dt) / denominator;
 }
 
 } /* namespace Nextsim */

--- a/physics/src/include/SlabOcean.hpp
+++ b/physics/src/include/SlabOcean.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file SlabOcean.hpp
  *
- * @date 10 Feb 2025
+ * @date 29 Apr 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -82,6 +82,10 @@ private:
 
     double relaxationTimeT = defaultRelaxationTime;
     double relaxationTimeS = defaultRelaxationTime;
+
+    double dt;
+
+    void updateElement(size_t i, const TimestepTime& tst);
 };
 
 } /* namespace Nextsim */

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IOceanBoundary.hpp
  *
- * @date 13 Feb 2025
+ * @date 29 Apr 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -126,31 +126,39 @@ public:
      */
     void mergeFluxes(const TimestepTime& tst)
     {
-        const double dt = tst.step.seconds();
+        dt = tst.step.seconds();
+        overElements(std::bind(&IOceanBoundary::mergeFluxesElement, this, std::placeholders::_1,
+                         std::placeholders::_2),
+            tst);
+    }
 
+private:
+    double dt;
+
+    void mergeFluxesElement(size_t i, const TimestepTime& tst)
+    {
         // Heat fluxes - partitioned in solar and non-solar
-        qswNet = cice * qswBase + (1 - cice) * qswow;
-        qNoSun = cice * qio + (1 - cice) * qow - qswNet;
+        qswNet[i] = cice[i] * qswBase[i] + (1 - cice[i]) * qswow[i];
+        qNoSun[i] = cice[i] * qio[i] + (1 - cice[i]) * qow[i] - qswNet[i];
 
         // Mass fluxes - fresh water and salt
         // ice volume change, both laterally and vertically
-        const HField deltaIceVol = newIce + deltaHice * cice;
+        const double deltaIceVol = newIce[i] + deltaHice[i] * cice[i];
         // change in snow volume due to melting (should be < 0)
-        const HField meltSnowVol = deltaSmelt * cice;
+        const double meltSnowVol = deltaSmelt[i] * cice[i];
         // Effective ice salinity is always less than or equal to the SSS, and here we use the right
         // units too
-        HField effectiveIceSal = sss;
-        effectiveIceSal.clampBelow(Ice::s);
-        effectiveIceSal *= 1e-3;
+        const double effectiveIceSal = 1e-3 * std::min(Ice::s, sss[i]);
 
         // Positive flux is up!
-        fwFlux = ((1 - effectiveIceSal) * Ice::rho * deltaIceVol + Ice::rhoSnow * meltSnowVol) / dt
-            + emp * (1 - cice);
-        sFlux = effectiveIceSal * Ice::rho * deltaIceVol / dt;
+        fwFlux[i]
+            = ((1 - effectiveIceSal) * Ice::rho * deltaIceVol + Ice::rhoSnow * meltSnowVol) / dt
+            + emp[i] * (1 - cice[i]);
+        sFlux[i] = effectiveIceSal * Ice::rho * deltaIceVol / dt;
 
         // Momentum fluxes
-        tauX = cice * tauXIO + (1 - cice) * tauXOW;
-        tauY = cice * tauYIO + (1 - cice) * tauYOW;
+        tauX[i] = cice[i] * tauXIO[i] + (1 - cice[i]) * tauXOW[i];
+        tauY[i] = cice[i] * tauYIO[i] + (1 - cice[i]) * tauYOW[i];
     }
 
 protected:


### PR DESCRIPTION
# Use overElements in IOceanBoundary and derived classesFixes #819 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

This changes IOceanBoundary::mergeFluxes and SlabOcean::update to use overElements, instead of Eigen array arithmetics.

---
# Test Description

No additional tests needed.

---
# Documentation Impact

N/A

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README