### PR TITLE
Set up `Finalizer` for XIOS

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -2,7 +2,7 @@
  * @file    Xios.cpp
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    10 Dec 2024
+ * @date    29 Apr 2025
  * @brief   XIOS interface implementation
  * @details
  *
@@ -18,6 +18,7 @@
 #include <boost/date_time/posix_time/time_parsers.hpp>
 #if USE_XIOS
 
+#include "include/Finalizer.hpp"
 #include "include/Xios.hpp"
 
 #include <boost/algorithm/string.hpp>
@@ -59,6 +60,14 @@ Xios::Xios(const std::string dt, const std::string contextid, const std::string 
     contextId = contextid;
     calendarType = calendartype;
     configure();
+    static bool doneOnce = doOnce();
+}
+
+bool Xios::doOnce()
+{
+    // Register the finalization function here
+    Finalizer::registerUnique(finalize);
+    return true;
 }
 
 //! Destructor
@@ -86,6 +95,7 @@ void Xios::finalize()
     if (isEnabled) {
         cxios_finalize();
     }
+    isEnabled = false;
 }
 
 /*!

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -2,7 +2,7 @@
  * @file    Xios.hpp
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    09 Apr 2025
+ * @date    29 Apr 2025
  * @brief   XIOS interface header
  * @details
  *
@@ -31,14 +31,17 @@ void enableXios();
 
 class Xios : public Configured<Xios> {
 private:
-    // Private constructor
+    //! Private constructor
     Xios(const std::string dt, const std::string contextId, const std::string startTime,
         const std::string calendarType);
+
+    //! Performs some one-time initialization for the class. Returns true.
+    static bool doOnce();
 
 public:
     ~Xios();
 
-    // Prevent copying
+    //! Prevent copying
     Xios(const Xios&) = delete;
 
     /*
@@ -58,7 +61,7 @@ public:
     /* Initialization and finalization */
     void close_context_definition();
     void context_finalize();
-    void finalize();
+    static void finalize();
     bool isInitialized();
 
     /* Configuration */
@@ -165,8 +168,7 @@ protected:
     bool isConfigured;
 
 private:
-    bool isEnabled;
-
+    inline static bool isEnabled = false;
     std::string clientId;
     std::string calendarType;
     std::string contextId;

--- a/core/test/ConfigOutput_test.cpp
+++ b/core/test/ConfigOutput_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ConfigOutput_test.cpp
  *
- * @date 08 Apr 2025
+ * @date 29 Apr 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -16,6 +16,7 @@
 #include "DiagnosticOutputModule/include/ConfigOutput.hpp"
 
 #include "include/FileCallbackCloser.hpp"
+#include "include/Finalizer.hpp"
 #include "include/IStructure.hpp"
 #include "include/ModelArray.hpp"
 #include "include/ModelArrayRef.hpp"
@@ -200,6 +201,8 @@ TEST_CASE("Test periodic output")
     for (auto fileName : diagFiles) {
         std::filesystem::remove(fileName);
     }
+
+    Finalizer::finalize();
 }
 TEST_SUITE_END();
 }

--- a/core/test/ParaGrid_test.cpp
+++ b/core/test/ParaGrid_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ParaGrid_test.cpp
  *
- * @date 08 Apr 2025
+ * @date 29 Apr 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -17,6 +17,7 @@
 
 #include "include/Configurator.hpp"
 #include "include/ConfiguredModule.hpp"
+#include "include/Finalizer.hpp"
 #include "include/IStructure.hpp"
 #include "include/NZLevels.hpp"
 #include "include/NextsimModule.hpp"
@@ -309,6 +310,8 @@ TEST_CASE("Write and read a ModelState-based ParaGrid restart file")
     REQUIRE(ms.data.count(gridAzimuthName) > 0);
     REQUIRE(ms.data.at(gridAzimuthName)(0, 0) == gridAzimuth0);
     std::filesystem::remove(filename);
+
+    Finalizer::finalize();
 }
 
 #ifdef USE_MPI
@@ -483,6 +486,8 @@ TEST_CASE("Write a diagnostic ParaGrid file")
     ncFile.close();
 
     std::filesystem::remove(diagFile);
+
+    Finalizer::finalize();
 }
 
 #ifndef TEST_FILE_SOURCE
@@ -532,6 +537,8 @@ TEST_CASE("Test array ordering")
     REQUIRE(state.data.count(fieldName) > 0);
     index2d = state.data.at(fieldName);
     REQUIRE(index2d(3, 5) == 35);
+
+    Finalizer::finalize();
 }
 
 #ifdef USE_MPI
@@ -559,6 +566,8 @@ TEST_CASE("Check an exception is thrown for an invalid file name")
 #else
     REQUIRE_THROWS(state = gridIn.getModelState(longRandomFilename));
 #endif
+
+    Finalizer::finalize();
 }
 
 #ifdef USE_MPI
@@ -631,6 +640,8 @@ TEST_CASE("Check if a file with the old dimension names can be read")
     REQUIRE(ModelArray::dimensions(ModelArray::Type::Z)[0] == localNX);
     REQUIRE(ModelArray::dimensions(ModelArray::Type::Z)[1] == ny);
     REQUIRE(ModelArray::dimensions(ModelArray::Type::Z)[2] == NZLevels::get());
+
+    Finalizer::finalize();
 }
 
 TEST_SUITE_END();

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosAxis_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    08 Apr 2025
+ * @date    29 Apr 2025
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -12,6 +12,7 @@
 #undef INFO
 
 #include "StructureModule/include/ParametricGrid.hpp"
+#include "include/Finalizer.hpp"
 #include "include/Xios.hpp"
 
 namespace Nextsim {
@@ -58,5 +59,6 @@ MPI_TEST_CASE("TestXiosAxis", 2)
 
     xiosHandler.close_context_definition();
     xiosHandler.context_finalize();
+    Finalizer::finalize();
 }
 }

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosCalendar_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    08 Apr 2025
+ * @date    29 Apr 2025
  * @brief   Tests for XIOS calandars
  * @details
  * This test is designed to test calendar functionality of the C++ interface
@@ -12,6 +12,7 @@
 #undef INFO
 
 #include "StructureModule/include/ParametricGrid.hpp"
+#include "include/Finalizer.hpp"
 #include "include/Xios.hpp"
 
 namespace Nextsim {
@@ -68,6 +69,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     REQUIRE(xiosHandler.getCurrentDate() == "2023-03-17T18:41:00Z");
 
     xiosHandler.context_finalize();
+    Finalizer::finalize();
 }
 
 }

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosDomain_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    08 Apr 2025
+ * @date    29 Apr 2025
  * @brief   Tests for XIOS domains
  * @details
  * This test is designed to test domain functionality of the C++ interface
@@ -12,6 +12,7 @@
 #undef INFO
 
 #include "StructureModule/include/ParametricGrid.hpp"
+#include "include/Finalizer.hpp"
 #include "include/Xios.hpp"
 
 namespace Nextsim {
@@ -106,5 +107,6 @@ MPI_TEST_CASE("TestXiosDomain", 2)
 
     xiosHandler.close_context_definition();
     xiosHandler.context_finalize();
+    Finalizer::finalize();
 }
 }

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosField_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    08 Apr 2025
+ * @date    29 Apr 2025
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -12,6 +12,7 @@
 #undef INFO
 
 #include "StructureModule/include/ParametricGrid.hpp"
+#include "include/Finalizer.hpp"
 #include "include/Xios.hpp"
 
 namespace Nextsim {
@@ -79,5 +80,6 @@ MPI_TEST_CASE("TestXiosField", 2)
 
     xiosHandler.close_context_definition();
     xiosHandler.context_finalize();
+    Finalizer::finalize();
 }
 }

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosFile_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    08 Apr 2025
+ * @date    29 Apr 2025
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -12,6 +12,7 @@
 #undef INFO
 
 #include "StructureModule/include/ParametricGrid.hpp"
+#include "include/Finalizer.hpp"
 #include "include/Xios.hpp"
 
 using namespace doctest;
@@ -122,5 +123,6 @@ MPI_TEST_CASE("TestXiosFile", 2)
 
     xiosHandler.close_context_definition();
     xiosHandler.context_finalize();
+    Finalizer::finalize();
 }
 }

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosGrid_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    08 Apr 2025
+ * @date    29 Apr 2025
  * @brief   Tests for XIOS axes
  * @details
  * This test is designed to test axis functionality of the C++ interface
@@ -11,6 +11,7 @@
 #include <doctest/extensions/doctest_mpi.h>
 #undef INFO
 
+#include "include/Finalizer.hpp"
 #include "include/Xios.hpp"
 
 namespace Nextsim {
@@ -72,5 +73,6 @@ MPI_TEST_CASE("TestXiosGrid", 2)
 
     xiosHandler.close_context_definition();
     xiosHandler.context_finalize();
+    Finalizer::finalize();
 }
 }

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosRead_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    08 Apr 2025
+ * @date    29 Apr 2025
  * @brief   Tests for XIOS read functionality
  * @details
  * This test is designed to test the file reading functionality of the C++
@@ -12,6 +12,7 @@
 #undef INFO
 
 #include "StructureModule/include/ParametricGrid.hpp"
+#include "include/Finalizer.hpp"
 #include "include/ModelMetadata.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
@@ -127,6 +128,7 @@ MPI_TEST_CASE("TestXiosRead", 2)
         }
     }
     xiosHandler.context_finalize();
+    Finalizer::finalize();
 }
 
 }

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file    XiosWrite_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    08 Apr 2025
+ * @date    29 Apr 2025
  * @brief   Tests for XIOS write functionality
  * @details
  * This test is designed to test the file writing functionality of the C++
@@ -12,6 +12,7 @@
 #undef INFO
 
 #include "StructureModule/include/ParametricGrid.hpp"
+#include "include/Finalizer.hpp"
 #include "include/ModelMetadata.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
@@ -135,6 +136,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     }
 
     xiosHandler.context_finalize();
+    Finalizer::finalize();
 }
 
 }


### PR DESCRIPTION
Supersedes #808.

As discussed in the meeting this morning, this PR hooks the `Xios` class into the `Finalizer`. Since no `Model`s are created in the standalone XIOS unit tests, they need to call `Finalizer::finalize` explicitly. It seems the same is also true of the `ConfigOutput` and `ParaGrid` tests. So actually the changeset isn't that different than @TomMelt's one in #808.