### PR TITLE
[skip-ci]: wip

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -53,7 +53,8 @@ void enableXios()
  * @param calendartype Type of calendar to use
  */
 Xios::Xios(const std::string dt, const std::string contextid, const std::string starttime,
-    const std::string calendartype)
+    const std::string calendartype, const MPI_Comm comm)
+    : mainComm(comm)
 {
     timestep = Duration(dt);
     startTime = TimePoint(starttime);
@@ -119,7 +120,7 @@ void Xios::configureServer()
 {
     // Initialize XIOS Server process and store MPI communicator
     clientId = "client";
-    nullComm_F = MPI_Comm_c2f(MPI_COMM_NULL);
+    nullComm_F = MPI_Comm_c2f(mainComm);
     cxios_init_client(clientId.c_str(), clientId.length(), &nullComm_F, &clientComm_F);
 
     // Initialize MPI rank and size

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -33,7 +33,7 @@ class Xios : public Configured<Xios> {
 private:
     //! Private constructor
     Xios(const std::string dt, const std::string contextId, const std::string startTime,
-        const std::string calendarType);
+        const std::string calendarType, const MPI_Comm comm);
 
     //! Performs some one-time initialization for the class. Returns true.
     static bool doOnce();
@@ -49,12 +49,12 @@ public:
      *
      * NOTE: The arguments will only be used the first time this is called.
      */
-    inline static Xios& getInstance(const std::string dt = "P0-0T01:00:00",
-        const std::string contextId = "nextSIM-DG",
+    inline static Xios& getInstance(const MPI_Comm comm = nullptr,
+        const std::string dt = "P0-0T01:00:00", const std::string contextId = "nextSIM-DG",
         const std::string startTime = "1970-01-01T00:00:00Z",
         const std::string calendarType = "Gregorian")
     {
-        static Xios instance = Xios(dt, contextId, startTime, calendarType);
+        static Xios instance = Xios(dt, contextId, startTime, calendarType, comm);
         return instance;
     };
 
@@ -174,6 +174,7 @@ private:
     std::string contextId;
     Duration timestep;
     TimePoint startTime;
+    MPI_Comm mainComm;
     MPI_Comm clientComm;
     MPI_Fint clientComm_F;
     MPI_Fint nullComm_F;

--- a/core/test/ConfigOutput_test.cpp
+++ b/core/test/ConfigOutput_test.cpp
@@ -104,7 +104,7 @@ TEST_CASE("Test periodic output")
     ModelMetadata meta;
 #ifdef USE_XIOS
     enableXios();
-    Xios& xiosHandler = Xios::getInstance("P0-0T01:00:00", "test1");
+    Xios& xiosHandler = Xios::getInstance(test_comm, "P0-0T01:00:00", "test1");
     xiosHandler.setCalendarOrigin(TimePoint("1970-01-01T00:00:00Z"));
     xiosHandler.close_context_definition();
 #endif

--- a/core/test/ParaGrid_test.cpp
+++ b/core/test/ParaGrid_test.cpp
@@ -214,7 +214,7 @@ TEST_CASE("Write and read a ModelState-based ParaGrid restart file")
     ModelMetadata metadata;
 #ifdef USE_XIOS
     enableXios();
-    Xios& xiosHandler = Xios::getInstance("P0-0T01:00:00");
+    Xios& xiosHandler = Xios::getInstance(test_comm, "P0-0T01:00:00");
     xiosHandler.setCalendarOrigin(TimePoint("1970-01-01T00:00:00Z"));
     xiosHandler.close_context_definition();
 #endif
@@ -415,7 +415,7 @@ TEST_CASE("Write a diagnostic ParaGrid file")
     ModelMetadata metadata;
 #ifdef USE_XIOS
     enableXios();
-    Xios& xiosHandler = Xios::getInstance();
+    Xios& xiosHandler = Xios::getInstance(test_comm);
 #endif
     metadata.setTime(TimePoint("2000-01-01T00:00:00Z"));
     // The coordinates are passed through the metadata object as affix
@@ -559,7 +559,7 @@ TEST_CASE("Check an exception is thrown for an invalid file name")
     ModelMetadata metadataIn(partitionFilename, test_comm);
 #ifdef USE_XIOS
     enableXios();
-    Xios& xiosHandler = Xios::getInstance();
+    Xios& xiosHandler = Xios::getInstance(test_comm);
 #endif
     metadataIn.setTime(TimePoint(dateString));
     REQUIRE_THROWS(state = gridIn.getModelState(longRandomFilename, metadataIn));
@@ -616,7 +616,7 @@ TEST_CASE("Check if a file with the old dimension names can be read")
     ModelMetadata metadata;
 #ifdef USE_XIOS
     enableXios();
-    Xios& xiosHandler = Xios::getInstance();
+    Xios& xiosHandler = Xios::getInstance(test_comm);
 #endif
     metadata.setMpiMetadata(test_comm);
     if (metadata.mpiMyRank == 0) {

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -31,7 +31,7 @@ MPI_TEST_CASE("TestXiosAxis", 2)
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
-    Xios& xiosHandler = Xios::getInstance();
+    Xios& xiosHandler = Xios::getInstance(test_comm);
     REQUIRE(xiosHandler.isInitialized());
     REQUIRE(xiosHandler.getClientMPISize() == 2);
 

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -31,7 +31,7 @@ MPI_TEST_CASE("TestXiosInitialization", 2)
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
-    Xios& xiosHandler = Xios::getInstance();
+    Xios& xiosHandler = Xios::getInstance(test_comm);
     REQUIRE(xiosHandler.isInitialized());
     REQUIRE(xiosHandler.getClientMPISize() == 2);
 

--- a/core/test/XiosDomain_test.cpp
+++ b/core/test/XiosDomain_test.cpp
@@ -31,7 +31,7 @@ MPI_TEST_CASE("TestXiosDomain", 2)
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
-    Xios& xiosHandler = Xios::getInstance();
+    Xios& xiosHandler = Xios::getInstance(test_comm);
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
     REQUIRE(size == 2);

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -31,7 +31,7 @@ MPI_TEST_CASE("TestXiosField", 2)
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
-    Xios& xiosHandler = Xios::getInstance();
+    Xios& xiosHandler = Xios::getInstance(test_comm);
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
     REQUIRE(size == 2);

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -33,7 +33,7 @@ MPI_TEST_CASE("TestXiosFile", 2)
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
-    Xios& xiosHandler = Xios::getInstance("P0-0T01:30:00");
+    Xios& xiosHandler = Xios::getInstance(test_comm, "P0-0T01:30:00");
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
     REQUIRE(size == 2);

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -30,7 +30,7 @@ MPI_TEST_CASE("TestXiosGrid", 2)
     enableXios();
 
     // Get the Xios singleton instance and check it's initialized
-    Xios& xiosHandler = Xios::getInstance();
+    Xios& xiosHandler = Xios::getInstance(test_comm);
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
     REQUIRE(size == 2);

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -33,7 +33,8 @@ MPI_TEST_CASE("TestXiosRead", 2)
     enableXios();
 
     // Create Xios singleton instance and check it's initialized
-    Xios& xiosHandler = Xios::getInstance("P0-0T01:30:00", "test", "2023-03-17T17:11:00Z");
+    Xios& xiosHandler
+        = Xios::getInstance(test_comm, "P0-0T01:30:00", "test", "2023-03-17T17:11:00Z");
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
     REQUIRE(size == 2);

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -33,7 +33,8 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     enableXios();
 
     // Create Xios singleton instance and check it's initialized
-    Xios& xiosHandler = Xios::getInstance("P0-0T01:30:00", "test", "2023-03-17T17:11:00Z");
+    Xios& xiosHandler
+        = Xios::getInstance(test_comm, "P0-0T01:30:00", "test", "2023-03-17T17:11:00Z");
     REQUIRE(xiosHandler.isInitialized());
     const size_t size = xiosHandler.getClientMPISize();
     REQUIRE(size == 2);


### PR DESCRIPTION
**Work in progress**

Testing if I can run XIOS tests with more ranks than specified.

Currently works for all tests apart from `./testXiosWrite_MPI2` which fails with error:
```
$ mpirun -n 2 ./testXiosWrite_MPI2 
[doctest] doctest version is "2.4.11"
[doctest] run with "--help" for options
===============================================================================
/home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/core/test/XiosWrite_test.cpp:31:
DESCRIPTION: MPI_TEST_CASE
TEST CASE:  TestXiosWrite

/home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/core/test/XiosWrite_test.cpp:31: FATAL ERROR: test case CRASHED: SIGSEGV - Segmentation violation signal

===============================================================================
[doctest] test cases:  1 |  0 passed | 1 failed | 0 skipped
[doctest] assertions: 10 | 10 passed | 0 failed |
[doctest] Status: FAILURE!
===============================================================================
[doctest] assertions on all processes:     20 |     20 passed |      0 failed |
===============================================================================
[doctest] Status: FAILURE!
[lenny:469136] *** Process received signal ***
[lenny:469136] Signal: Segmentation fault (11)
[lenny:469136] Signal code:  (-6)
[lenny:469136] Failing at address: 0x3e800072890
[lenny:469136] [ 0] /lib/x86_64-linux-gnu/libc.so.6(+0x45330)[0x7cd75f8f0330]
[lenny:469136] [ 1] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZNKSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_S6_ImPcEESt10_Select1stISA_ESt4lessIS5_ESaISA_EE9_M_mbeginEv+0x10)[0x7cd7629284a4]
[lenny:469136] [ 2] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_S6_ImPcEESt10_Select1stISA_ESt4lessIS5_ESaISA_EE8_M_beginEv+0x1c)[0x7cd7629242c8]
[lenny:469136] [ 3] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZNSt8_Rb_treeINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairIKS5_S6_ImPcEESt10_Select1stISA_ESt4lessIS5_ESaISA_EE4findERS7_+0x3f)[0x7cd7631c5617]
[lenny:469136] [ 4] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZNSt3mapINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESt4pairImPcESt4lessIS5_ESaIS6_IKS5_S8_EEE4findERSB_+0x27)[0x7cd7631c5049]
[lenny:469136] [ 5] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN4xios9CRegistry13mergeRegistryERKS0_+0x73)[0x7cd7631c429b]
[lenny:469136] [ 6] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN4xios8CContext8finalizeEv+0x1d5)[0x7cd7628f8e09]
[lenny:469136] [ 7] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN4xios14CContextServer13dispatchEventERNS_12CEventServerE+0x16e)[0x7cd76293c7a8]
[lenny:469136] [ 8] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN4xios14CContextServer13processEventsEv+0x1e7)[0x7cd76293c3c7]
[lenny:469136] [ 9] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN4xios14CContextServer9eventLoopEb+0x3f)[0x7cd76293b727]
[lenny:469136] [10] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN4xios14CContextClient9waitEventERNSt7__cxx114listIiSaIiEEE+0x9c)[0x7cd7629357d0]
[lenny:469136] [11] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN4xios14CContextClient9sendEventERNS_12CEventClientE+0x5f1)[0x7cd76293512d]
[lenny:469136] [12] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN4xios14CContextClient8finalizeEv+0x284)[0x7cd762936b2e]
[lenny:469136] [13] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN4xios8CContext8finalizeEv+0xfa)[0x7cd7628f8d2e]
[lenny:469136] [14] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(cxios_context_finalize+0x118)[0x7cd762d5dca5]
[lenny:469136] [15] /home/melt/sync/cambridge/projects/current/sasip/nextsimdg/finalize/build-mpi/libnextsimlib.so(_ZN7Nextsim4Xios16context_finalizeEv+0x23)[0x7cd76238d587]
[lenny:469136] [16] ./testXiosWrite_MPI2(+0x1cb06)[0x62df42121b06]
[lenny:469136] [17] ./testXiosWrite_MPI2(+0x205eb)[0x62df421255eb]
[lenny:469136] [18] ./testXiosWrite_MPI2(+0x1abe2)[0x62df4211fbe2]
[lenny:469136] [19] ./testXiosWrite_MPI2(+0x3d596)[0x62df42142596]
[lenny:469136] [20] ./testXiosWrite_MPI2(+0x40405)[0x62df42145405]
[lenny:469136] [21] /lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7cd75f8d51ca]
[lenny:469136] [22] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7cd75f8d528b]
[lenny:469136] [23] ./testXiosWrite_MPI2(+0x1aaf5)[0x62df4211faf5]
[lenny:469136] *** End of error message ***
--------------------------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
--------------------------------------------------------------------------
--------------------------------------------------------------------------
mpirun noticed that process rank 0 with PID 0 on node lenny exited on signal 11 (Segmentation fault).
--------------------------------------------------------------------------

```