### PR TITLE
Add coordinates to ConfigOutput outputs

### DIFF
--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ConfigOutput.cpp
  *
- * @date 24 Sep 2024
+ * @date 02 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -153,7 +153,7 @@ void ConfigOutput::outputState(const ModelMetadata& meta)
         lastFileChange = time;
     }
 
-    ModelState state;
+    ModelState state {};
     auto storeData = ModelComponent::getStore().getAllData();
     if (outputAllTheFields) {
         // If the internal to external name lookup table is still empty, fill it
@@ -199,6 +199,7 @@ void ConfigOutput::outputState(const ModelMetadata& meta)
         && (everyTS || std::fmod(timeSinceOutput.seconds(), outputPeriod.seconds()) == 0.)) {
         Logged::info("ConfigOutput: Outputting " + std::to_string(state.data.size()) + " fields to "
             + currentFileName + " at " + meta.time().format() + "\n");
+        meta.affixCoordinates(state);
         StructureFactory::fileFromState(state, meta, currentFileName, false);
         lastOutput = meta.time();
     }

--- a/core/test/ConfigOutput_test.cpp
+++ b/core/test/ConfigOutput_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ConfigOutput_test.cpp
  *
- * @date 24 Sep 2024
+ * @date 06 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -21,8 +21,8 @@
 #include "include/ModelComponent.hpp"
 #include "include/ModelMetadata.hpp"
 #include "include/ModelState.hpp"
-#include "include/NextsimModule.hpp"
 #include "include/NZLevels.hpp"
+#include "include/NextsimModule.hpp"
 #include "include/gridNames.hpp"
 
 #include <ncDim.h>
@@ -177,7 +177,7 @@ TEST_CASE("Test periodic output")
     REQUIRE(timeDim.getSize() == hr_day);
 
     std::multimap<std::string, netCDF::NcVar> vars(dataGroup.getVars());
-    REQUIRE(vars.size() == fields.size() + 1); // +1 for the time variable
+    REQUIRE(vars.size() == fields.size() + 1 + 4); // +1 for the time variable + 4 for the coords
     for (auto field : fields) {
         REQUIRE(vars.count(field) == 1);
     }


### PR DESCRIPTION
# Add coordinates to ConfigOutput outputs
Fixes #(your issue number)

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

A single line change to add coordinates to the ConfigOutput outputs. A well-placed ``meta.affixCoordinates(state)`` was all that was needed.

---
# Test Description

Run any realistic setup (e.g. the June 23 one) and confirm that the output contains the variables latitude and longitude.

---
# Documentation Impact

None

---
# Other Details

N/A

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README