### PR TITLE
Xios config output fix

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -83,7 +83,10 @@ jobs:
 
   test-ubuntu-mpi-noxios:
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 10
+
     container:
       image: ghcr.io/nextsimhub/nextsimdg-dev-env:latest
 

--- a/core/test/ConfigOutput_test.cpp
+++ b/core/test/ConfigOutput_test.cpp
@@ -26,9 +26,6 @@
 #include "include/NZLevels.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/gridNames.hpp"
-#ifdef USE_XIOS
-#include "include/Xios.hpp"
-#endif
 
 #include <ncDim.h>
 #include <ncFile.h>
@@ -102,12 +99,6 @@ TEST_CASE("Test periodic output")
     ModelComponent::getStore().registerArray(Protected::T_ICE, &tice);
 
     ModelMetadata meta;
-#ifdef USE_XIOS
-    enableXios();
-    Xios& xiosHandler = Xios::getInstance("P0-0T01:00:00", "test1");
-    xiosHandler.setCalendarOrigin(TimePoint("1970-01-01T00:00:00Z"));
-    xiosHandler.close_context_definition();
-#endif
     meta.setTime(TimePoint("2020-01-01T00:00:00Z"));
 
 #ifdef USE_MPI

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -107,7 +107,7 @@ MPI_TEST_CASE("TestXiosRead", 2)
     // Create HField instances to read the data into
     HField field_2D(ModelArray::Type::H);
     field_2D.resize();
-    HField field_3D(ModelArray::Type::Z);
+    ZField field_3D(ModelArray::Type::Z);
     field_3D.resize();
 
     // Check calendar step is zero initially


### PR DESCRIPTION
I noticed that the `ConfigOutput` test failed upon merging #824 into `develop`. (See https://github.com/nextsimhub/nextsimdg/actions/runs/14859539094/job/41720738522.)

I think this PR should fix it, by fully removing XIOS from the `ConfigOutput_test`, as recommended by @timspainNERSC.

I also added in a minor fix for the `XiosRead_test`, which used `HField` where it should've used `ZField`.