### PR TITLE
XIOS: Create files from config upon initialisation

### DIFF
--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ParaGridIO_Xios.cpp
  *
- * @date 07 May 2025
+ * @date 12 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Joe Wallwork <jw2423@cam.ac.uk>
  */
@@ -80,9 +80,10 @@ ParaGridIO::ParaGridIO(ParametricGrid& grid)
 bool ParaGridIO::doOnce()
 {
     Xios& xiosHandler = Xios::getInstance();
+    // NOTE: getInstance will automatically create XIOS input and output files if the
+    // XiosInput.filename and XiosOutput.filename parameters are set in the config.
 
     // TODO: Setup XIOS in this method.
-    // * We can read the file name from the XiosConfig.
     // * We can read the field names from the XiosConfig, too.
     // * We can determine the read access for the fields from the XiosConfig, too.
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1745,6 +1745,24 @@ std::vector<std::string> Xios::fileGetFieldIds(const std::string fileId)
     return fieldIds;
 }
 
+// Check whether a fieldId exists in a string of field names separated by commas
+bool checkField(const std::string fieldId, const std::string fieldsStr)
+{
+    bool found = false;
+    if (fieldsStr.length() > 0) {
+        const char delim = ',';
+        std::istringstream iss(fieldsStr);
+        std::string item;
+        while (std::getline(iss, item, delim)) {
+            if (item == fieldId) {
+                found = true;
+                break;
+            }
+        }
+    }
+    return found;
+}
+
 /*!
  * Associate a field with a file
  *
@@ -1754,6 +1772,23 @@ std::vector<std::string> Xios::fileGetFieldIds(const std::string fileId)
 void Xios::fileAddField(const std::string fileId, const std::string fieldId)
 {
     xios::CField* field = getField(fieldId);
+
+    // Determine whether the field has read access
+    std::string inputFieldsStr;
+    istringstream(Configured::getConfiguration(keyMap.at(INPUT_FIELD_NAMES_KEY), std::string()))
+        >> inputFieldsStr;
+    bool readAccess = checkField(fieldId, inputFieldsStr);
+    std::string outputFieldsStr;
+    istringstream(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()))
+        >> outputFieldsStr;
+    bool writeAccess = checkField(fieldId, outputFieldsStr);
+    if ((!readAccess && !writeAccess) || (readAccess && writeAccess)) {
+        throw std::runtime_error("Xios: Invalid read/write access for field '" + fieldId + "'");
+        // TODO: Refactor to allow a field to be both read and written
+    }
+    setFieldReadAccess(fieldId, readAccess);
+
+    // Add the field to the file
     cxios_xml_tree_add_fieldtofile(getFile(fileId), &field, fieldId.c_str(), fieldId.length());
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1745,24 +1745,6 @@ std::vector<std::string> Xios::fileGetFieldIds(const std::string fileId)
     return fieldIds;
 }
 
-// Check whether a fieldId exists in a string of field names separated by commas
-bool checkField(const std::string fieldId, const std::string fieldsStr)
-{
-    bool found = false;
-    if (fieldsStr.length() > 0) {
-        const char delim = ',';
-        std::istringstream iss(fieldsStr);
-        std::string item;
-        while (std::getline(iss, item, delim)) {
-            if (item == fieldId) {
-                found = true;
-                break;
-            }
-        }
-    }
-    return found;
-}
-
 /*!
  * Associate a field with a file
  *
@@ -1772,23 +1754,6 @@ bool checkField(const std::string fieldId, const std::string fieldsStr)
 void Xios::fileAddField(const std::string fileId, const std::string fieldId)
 {
     xios::CField* field = getField(fieldId);
-
-    // Determine whether the field has read access
-    std::string inputFieldsStr;
-    istringstream(Configured::getConfiguration(keyMap.at(INPUT_FIELD_NAMES_KEY), std::string()))
-        >> inputFieldsStr;
-    bool readAccess = checkField(fieldId, inputFieldsStr);
-    std::string outputFieldsStr;
-    istringstream(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()))
-        >> outputFieldsStr;
-    bool writeAccess = checkField(fieldId, outputFieldsStr);
-    if ((!readAccess && !writeAccess) || (readAccess && writeAccess)) {
-        throw std::runtime_error("Xios: Invalid read/write access for field '" + fieldId + "'");
-        // TODO: Refactor to allow a field to be both read and written
-    }
-    setFieldReadAccess(fieldId, readAccess);
-
-    // Add the field to the file
     cxios_xml_tree_add_fieldtofile(getFile(fileId), &field, fieldId.c_str(), fieldId.length());
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -74,10 +74,26 @@ void enableXios()
  */
 Xios::Xios(const std::string contextid, const std::string calendartype)
 {
+    static bool firstTime = true;
     contextId = contextid;
     calendarType = calendartype;
     configure();
     static bool doneOnce = doOnce();
+
+    // Create the input and output files (if found in the config)
+    if (firstTime) {
+        for (int key : { INPUT_FILENAME_KEY, OUTPUT_FILENAME_KEY }) {
+            std::string filenameStr;
+            istringstream(Configured::getConfiguration(keyMap.at(key), std::string()))
+                >> filenameStr;
+            if (filenameStr.length() > 0) {
+                filenameStr = ((std::filesystem::path)filenameStr).replace_extension();
+                createFile(filenameStr);
+                setFileName(filenameStr, filenameStr);
+            }
+        }
+    }
+    firstTime = false;
 }
 
 bool Xios::doOnce()

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -3,7 +3,7 @@
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    07 May 2025
+ * @date    12 May 2025
  * @brief   XIOS interface implementation
  * @details
  *
@@ -1164,9 +1164,8 @@ xios::CField* Xios::getField(const std::string fieldId)
     return field;
 }
 
-// Check whether a fieldId exists in a string of field names separated by commas, as determined by
-// the map key
-bool Xios::checkField(const std::string fieldId, const bool reading)
+// Extract the field_names entry from the XiosInput or XiosOutput section of the config
+std::vector<std::string> Xios::configGetFieldNames(const bool reading)
 {
     std::string fieldsStr;
     if (reading) {
@@ -1177,16 +1176,28 @@ bool Xios::checkField(const std::string fieldId, const bool reading)
             Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()))
             >> fieldsStr;
     }
-    bool found = false;
+    std::vector<std::string> fieldNames;
     if (fieldsStr.length() > 0) {
         const char delim = ',';
         std::istringstream iss(fieldsStr);
         std::string item;
         while (std::getline(iss, item, delim)) {
-            if (item == fieldId) {
-                found = true;
-                break;
-            }
+            fieldNames.push_back(item);
+        }
+    }
+    return fieldNames;
+}
+
+// Check whether a fieldId exists in a string of field names separated by commas, as determined by
+// the map key
+bool Xios::checkField(const std::string fieldId, const bool reading)
+{
+    std::vector<std::string> fieldNames = configGetFieldNames(reading);
+    bool found = false;
+    for (std::string fieldName : fieldNames) {
+        if (fieldName == fieldId) {
+            found = true;
+            break;
         }
     }
     return found;

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1190,7 +1190,7 @@ std::vector<std::string> Xios::configGetFieldNames(const bool reading)
 
 // Check whether a fieldId exists in a string of field names separated by commas, as determined by
 // the map key
-bool Xios::checkField(const std::string fieldId, const bool reading)
+bool Xios::configCheckField(const std::string fieldId, const bool reading)
 {
     std::vector<std::string> fieldNames = configGetFieldNames(reading);
     bool found = false;
@@ -1218,8 +1218,8 @@ void Xios::createField(const std::string fieldId)
     }
 
     // Check that the field is in the XiosOutput or XiosInput config
-    bool readAccess = checkField(fieldId, true);
-    bool writeAccess = checkField(fieldId, false);
+    bool readAccess = configCheckField(fieldId, true);
+    bool writeAccess = configCheckField(fieldId, false);
     if (!(readAccess || writeAccess)) {
         throw std::runtime_error("Xios: Field '" + fieldId
             + "' cannot be found in the XiosInput or XiosOutput config sections");

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -205,7 +205,7 @@ private:
     xios::CField* getField(const std::string fieldId);
     void setFieldReadAccess(const std::string fieldId, const bool readAccess);
     std::vector<std::string> configGetFieldNames(const bool reading);
-    bool checkField(const std::string fieldId, const bool reading);
+    bool configCheckField(const std::string fieldId, const bool reading);
 
     /* Grid */
     xios::CGridGroup* getGridGroup();

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -3,7 +3,7 @@
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    07 May 2025
+ * @date    12 May 2025
  * @brief   XIOS interface header
  * @details
  *
@@ -204,6 +204,7 @@ private:
     xios::CFieldGroup* getFieldGroup();
     xios::CField* getField(const std::string fieldId);
     void setFieldReadAccess(const std::string fieldId, const bool readAccess);
+    std::vector<std::string> configGetFieldNames(const bool reading);
     bool checkField(const std::string fieldId, const bool reading);
 
     /* Grid */

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -135,7 +135,6 @@ public:
 
     /* File */
     void createFile(const std::string fileId);
-    void setFileName(const std::string fileId, const std::string fileName);
     void setFileType(const std::string fileId, const std::string fileType);
     void setFileOutputFreq(const std::string fileId, const Duration outputFreq);
     void setFileSplitFreq(const std::string fileId, const Duration splitFreq);
@@ -214,6 +213,7 @@ private:
     /* File */
     xios::CFileGroup* getFileGroup();
     xios::CFile* getFile(const std::string fileId);
+    void setFileName(const std::string fileId, const std::string fileName);
     void setFileMode(const std::string fileId, const std::string mode);
 };
 

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -87,13 +87,10 @@ MPI_TEST_CASE("TestXiosFile", 2)
     // NOTE: This is set based off the XiosInput.period and XiosOutput.period entries when a file
     // is created
     REQUIRE(xiosHandler.getFileOutputFreq(fileId).seconds() == 3.0 * 60 * 60);
-    Duration timestep = xiosHandler.getCalendarTimestep();
-    xiosHandler.setFileOutputFreq(fileId, timestep);
-    REQUIRE(xiosHandler.getFileOutputFreq(fileId).seconds() == 1.5 * 60 * 60);
     // Split frequency
     REQUIRE_THROWS_WITH(
         xiosHandler.getFileSplitFreq(fileId), "Xios: Undefined split frequency for file 'output'");
-    xiosHandler.setFileSplitFreq(fileId, timestep);
+    xiosHandler.setFileSplitFreq(fileId, xiosHandler.getCalendarTimestep());
     REQUIRE(xiosHandler.getFileSplitFreq(fileId).seconds() == 1.5 * 60 * 60);
     // File mode
     // NOTE: This is set based off the XiosInput.filename and XiosOutput.filename entries when a

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -109,6 +109,7 @@ MPI_TEST_CASE("TestXiosFile", 2)
     // Create a new file for each time unit to check more thoroughly that XIOS interprets output
     // frequency and split frequency correctly.
     // (If we reused the same file then the XIOS interface would raise warnings.)
+    // TODO: Can we get rid of some of this to allow setFileOutputFreq to be privatised?
     xiosHandler.createFile("unittest_year");
     xiosHandler.setFileOutputFreq("unittest_year", Duration("P1-0T00:00:00"));
     xiosHandler.setFileSplitFreq("unittest_year", Duration("P2-0T00:00:00"));

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -68,16 +68,16 @@ MPI_TEST_CASE("TestXiosFile", 2)
 
     // --- Tests for file API
     const std::string fileId = "output";
-    REQUIRE_THROWS_WITH(xiosHandler.getFileName(fileId), "Xios: Undefined file 'output'");
-    xiosHandler.createFile(fileId);
+    REQUIRE_THROWS_WITH(
+        xiosHandler.getFileName("unittest_undef"), "Xios: Undefined file 'unittest_undef'");
+    // File creation
+    // NOTE: This is called based on the XiosInput.filename and XiosOutput.filename entries upon
+    // initialization
     REQUIRE_THROWS_WITH(xiosHandler.createFile(fileId), "Xios: File 'output' already exists");
     // File name
     // NOTE: This is set based off the XiosInput.filename and XiosOutput.filename entries when a
     // file is created
-    REQUIRE(xiosHandler.getFileName(fileId) == "output");
-    const std::string fileName = "diagnostic";
-    xiosHandler.setFileName(fileId, fileName);
-    REQUIRE(xiosHandler.getFileName(fileId) == fileName);
+    REQUIRE(xiosHandler.getFileName(fileId) == fileId);
     // File type
     REQUIRE_THROWS_WITH(xiosHandler.getFileType(fileId), "Xios: Undefined type for file 'output'");
     const std::string fileType = "one_file";

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -2,7 +2,7 @@
  * @file    XiosFile_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    07 May 2025
+ * @date    12 May 2025
  * @brief   Tests for XIOS file
  * @details
  * This test is designed to test file functionality of the C++ interface
@@ -38,7 +38,6 @@ MPI_TEST_CASE("TestXiosFile", 2)
     config << "[model]" << std::endl;
     config << "start = 2023-03-17T17:11:00Z" << std::endl;
     config << "time_step = P0-0T01:30:00" << std::endl;
-    config << "field_names = field_B" << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "period = P0-0T03:00:00" << std::endl;
     config << "filename = output" << std::endl;

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -94,7 +94,6 @@ MPI_TEST_CASE("TestXiosRead", 2)
 
     // Create an file for reading of field data
     std::string fileId = "xios_test_input";
-    xiosHandler.createFile(fileId);
     xiosHandler.setFileType(fileId, "one_file");
     xiosHandler.setFileParAccess(fileId, "collective");
     xiosHandler.fileAddField(fileId, "field_2D");

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -94,7 +94,6 @@ MPI_TEST_CASE("TestXiosWrite", 2)
 
     // Create an file for writing of field data
     std::string fileId = "xios_test_output";
-    xiosHandler.createFile(fileId);
     xiosHandler.setFileType(fileId, "one_file");
     xiosHandler.setFileSplitFreq(fileId, Duration("P0-0T03:00:00"));
     xiosHandler.fileAddField(fileId, "field_2D");


### PR DESCRIPTION
# XIOS: Create files from config upon initialisation

Fixes #835

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

To quote the issue:
> Following on from #834, we can automate file creation by querying the config to determine input and output files.
> ```
> [XiosInput]
> filename = ...
> field_names = ...
> [XiosOutput]
> filename = ...
> field_names = ...
> ```
> It's probably simplest to just use the `filename` as both the `fileId` and the `fileName` passed to XIOS.
> 
> Further, we can automatically create and add all fields associated with such files based off the `field_names` entries.

---
# Test Description

XIOS read, write, and file tests are updated accordingly.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README