### PR TITLE
Add getConfiguration(), rework getState*().

### DIFF
--- a/core/src/DevStep.cpp
+++ b/core/src/DevStep.cpp
@@ -48,8 +48,7 @@ void DevStep::iterate(const TimestepTime& tst)
         lastOutput = mData->time();
     }
     // XIOS wants all the fields, every timestep, so I guess that's what everyone gets
-    OutputSpec os; // The default OutputSpec is all fields, but only cell average values
-    ModelState overallState = pData->getStateRecursive(os);
+    ModelState overallState = pData->getStateDiagnostic();
     overallState.merge(ConfiguredModule::getAllModuleConfigurations());
     Module::getImplementation<IDiagnosticOutput>().outputState(*mData);
 }

--- a/core/src/PDWriter.cpp
+++ b/core/src/PDWriter.cpp
@@ -19,7 +19,6 @@ void PrognosticData::writeRestartFile(
     Logged::notice(std::string("  Writing state-based restart file: ") + filePath + '\n');
 
     ModelState state = getStatePrognostic();
-//    state.merge(ConfiguredModule::getAllModuleConfigurations());
     state.merge(ModelConfig::getConfig());
 
     ModelMetadata meta(metadata);

--- a/core/src/PDWriter.cpp
+++ b/core/src/PDWriter.cpp
@@ -18,12 +18,11 @@ void PrognosticData::writeRestartFile(
 {
     Logged::notice(std::string("  Writing state-based restart file: ") + filePath + '\n');
 
-    ConfigMap modelConfig = ModelConfig::getConfig();
-    modelConfig.merge(getStateRecursive(true).config);
-    modelConfig.merge(ConfiguredModule::getAllModuleConfigurations());
+    ModelState state = getStatePrognostic();
+//    state.merge(ConfiguredModule::getAllModuleConfigurations());
+    state.merge(ModelConfig::getConfig());
+
     ModelMetadata meta(metadata);
-    meta.setConfig(modelConfig);
-    ModelState state = getState();
     meta.affixCoordinates(state);
 
     StructureFactory::fileFromState(state, meta, filePath, true);

--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -180,12 +180,13 @@ ModelState PrognosticData::getStateDiagnostic() const
 ModelState PrognosticData::getStatePrognostic() const
 {
     ModelState state = { {
-            { "mask", ModelArray(oceanMask()) }, // make a copy
-            { "hice", hiceAdvection },
-            { "cice", ciceAdvection },
-            { "hsnow", mask(m_snow) },
-            { "tice", mask(m_tice) },
-    }, ModelComponent::getConfiguration() };
+                             { "mask", ModelArray(oceanMask()) }, // make a copy
+                             { "hice", hiceAdvection },
+                             { "cice", ciceAdvection },
+                             { "hsnow", mask(m_snow) },
+                             { "tice", mask(m_tice) },
+                         },
+        ModelComponent::getConfiguration() };
 
     // Get the prognostic data from the dynamics, including the full dynamics state
     state.merge(pDynamics->getStatePrognostic());

--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -162,55 +162,38 @@ void PrognosticData::updateDynamicsFields()
     m_damage.setData(damageUpd);
 }
 
-// Gets all of the prognostic data, including that in the dynamics
-ModelState PrognosticData::getState() const
+// Gets the diagnostic data from all subcomponents
+ModelState PrognosticData::getStateDiagnostic() const
 {
-    ModelArrayRef<Protected::SST> sst(getStore());
-    ModelArrayRef<Protected::SSS> sss(getStore());
+    ModelState state = getStatePrognostic();
 
     // Get the prognostic data from the dynamics, including the full dynamics state
-    ModelState dynamicsState = pDynamics->getState();
-    // clang-format off
-    ModelState localState = { {
-                 { "mask", ModelArray(oceanMask()) }, // make a copy
-                 { "hice", hiceAdvection },
-                 { "cice", ciceAdvection },
-                 { "hsnow", mask(m_snow) },
-                 { "tice", mask(m_tice) },
-                 { "sst", mask(sst) },
-                 { "sss", mask(sss) },
-             },
-        {} };
-    // clang-format on
-
-    // Use the dynamics values of any duplicated fields
-    ModelState state(dynamicsState);
-    state.merge(localState);
+    state.merge(pDynamics->getStateDiagnostic());
+    state.merge(iceGrowth.getStateDiagnostic());
+    state.merge(pAtmBdy->getStateDiagnostic());
+    state.merge(pOcnBdy->getStateDiagnostic());
 
     return state;
 }
 
-// Recursively gets the data from all subcomponents
-ModelState PrognosticData::getStateRecursive(const OutputSpec& os) const
+// Gets the prognostic data from all subcomponents
+ModelState PrognosticData::getStatePrognostic() const
 {
-    ModelState state;
-    /* If allComponents is set on the OutputSpec, then for any duplicate fields, the subsystems
-     * take priority, otherwise the fields held by PrognosticData itself. Note that std::map::merge
-     * will not overwrite existing keys, so the first one that exists will survive.
-     */
-    if (os.allComponents()) {
-        state.merge(pAtmBdy->getStateRecursive(os));
-        state.merge(iceGrowth.getStateRecursive(os));
-        state.merge(pDynamics->getStateRecursive(os));
-        state.merge(getState());
-    } else {
-        state.merge(getState());
-        state.merge(pAtmBdy->getStateRecursive(os));
-        state.merge(iceGrowth.getStateRecursive(os));
-        state.merge(pDynamics->getStateRecursive(os));
-    }
-    // OceanBoundary does not contribute to the output model state
-    return os ? state : ModelState();
+    ModelState state = { {
+            { "mask", ModelArray(oceanMask()) }, // make a copy
+            { "hice", hiceAdvection },
+            { "cice", ciceAdvection },
+            { "hsnow", mask(m_snow) },
+            { "tice", mask(m_tice) },
+    }, ModelComponent::getConfiguration() };
+
+    // Get the prognostic data from the dynamics, including the full dynamics state
+    state.merge(pDynamics->getStatePrognostic());
+    state.merge(iceGrowth.getStatePrognostic());
+    state.merge(pAtmBdy->getStatePrognostic());
+    state.merge(pOcnBdy->getStatePrognostic());
+
+    return state;
 }
 
 PrognosticData::HelpMap& PrognosticData::getHelpText(HelpMap& map, bool getAll) { return map; }

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -158,36 +158,44 @@ public:
      */
     virtual void setData(const ModelState::DataMap& state) = 0;
     /*!
-     * @brief Returns a ModelState from this component.
+     * @brief Returns all data and configuration from this component.
      *
-     * @details The ModelState is map between field names and ModelArray data
-     * arrays. The intention is to merge together different ModelSatates to
-     * produce a combined state. The returned ModelState will include the
-     * states of any subsidiary components held by the object. This is the
-     * default level of output and should include all and only fields to be
-     * placed in the restart file.
+     * @details The ModelState consists of two components, a map between field
+     * names and ModelArray data arrays, and a map of configuration variables
+     * and their values. The state returned by this function contains all
+     * available data in this component and all components that it calls.
      */
-    virtual ModelState getState() const = 0;
+    virtual ModelState getStateDiagnostic() const
+    {
+        return getStatePrognostic();
+    }
     /*!
-     * @brief Returns a ModelState from this component at a specified level.
+     * @brief Returns a ModelState from this component at a specified level of detail.
      *
      * @details See the zero argument version for more details. The output
      * levels reuse those defined in the Logged class. The default level is
      * NOTICE, and only levels such as INFO, DEBUG and TRACE should be used,
      * and should provide extra diagnostic fields.
      */
-    virtual ModelState getState(const OutputLevel&) const = 0;
+    virtual ModelState getStateDiagnostic(const OutputLevel&) const
+    {
+        return getStateDiagnostic();
+    }
 
     /*!
-     * @brief Returns the state of the ModelComponent and any ModelComponents
-     * it depends on.
+     * @brief Returns the state of the ModelComponent.
+     *
+     * @details Returns the state of the ModelComponene and any ModelComponents
+     * it depends on. Unless overridden, the ModelState consists of no data
+     * fields and the contents of the configuration obtained from the
+     * getConfiguration() virtual method.
      *
      * @details Used to traverse the current tree of ModelComponents and return
      * the overall model state for diagnostic output.
      */
-    virtual ModelState getStateRecursive(const OutputSpec& os) const
+    virtual ModelState getStatePrognostic() const
     {
-        return os ? getState() : ModelState();
+        return { { }, getConfiguration()};
     }
 
     /*!
@@ -226,6 +234,14 @@ protected:
      * @brief Returns the ocean mask.
      */
     static const ModelArray& oceanMask();
+
+    /*!
+     * @brief Returns a map of the configuration used by the component.
+     */
+    virtual ConfigMap getConfiguration() const
+    {
+        return { };
+    }
 
 protected:
     static ModelArray& oceanMaskSingleton()

--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -160,15 +160,10 @@ public:
     /*!
      * @brief Returns all data and configuration from this component.
      *
-     * @details The ModelState consists of two components, a map between field
-     * names and ModelArray data arrays, and a map of configuration variables
-     * and their values. The state returned by this function contains all
+     * @details The state returned by this function contains all
      * available data in this component and all components that it calls.
      */
-    virtual ModelState getStateDiagnostic() const
-    {
-        return getStatePrognostic();
-    }
+    virtual ModelState getStateDiagnostic() const { return getStatePrognostic(); }
     /*!
      * @brief Returns a ModelState from this component at a specified level of detail.
      *
@@ -177,26 +172,18 @@ public:
      * NOTICE, and only levels such as INFO, DEBUG and TRACE should be used,
      * and should provide extra diagnostic fields.
      */
-    virtual ModelState getStateDiagnostic(const OutputLevel&) const
-    {
-        return getStateDiagnostic();
-    }
+    virtual ModelState getStateDiagnostic(const OutputLevel&) const { return getStateDiagnostic(); }
 
     /*!
      * @brief Returns the state of the ModelComponent.
      *
-     * @details Returns the state of the ModelComponene and any ModelComponents
-     * it depends on. Unless overridden, the ModelState consists of no data
-     * fields and the contents of the configuration obtained from the
-     * getConfiguration() virtual method.
+     * @details Returns the state of the ModelComponent and any ModelComponents
+     * it depends on.
      *
-     * @details Used to traverse the current tree of ModelComponents and return
-     * the overall model state for diagnostic output.
+     * @details The state returned by this function contains all the
+     * data necessary to restart this component and all components that it calls.
      */
-    virtual ModelState getStatePrognostic() const
-    {
-        return { { }, getConfiguration()};
-    }
+    virtual ModelState getStatePrognostic() const { return { {}, getConfiguration() }; }
 
     /*!
      * @brief Returns the ModelArrayRef backing store for column physics fields.
@@ -238,10 +225,7 @@ protected:
     /*!
      * @brief Returns a map of the configuration used by the component.
      */
-    virtual ConfigMap getConfiguration() const
-    {
-        return { };
-    }
+    virtual ConfigMap getConfiguration() const { return {}; }
 
 protected:
     static ModelArray& oceanMaskSingleton()

--- a/core/src/include/PrognosticData.hpp
+++ b/core/src/include/PrognosticData.hpp
@@ -34,9 +34,8 @@ public:
     std::string getName() const override { return "PrognosticData"; };
 
     void setData(const ModelState::DataMap& ms) override;
-    ModelState getState() const override;
-    ModelState getState(const OutputLevel& lvl) const override { return getState(); }
-    ModelState getStateRecursive(const OutputSpec& os) const override;
+    ModelState getStateDiagnostic() const override;
+    ModelState getStatePrognostic() const override;
 
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -214,14 +214,4 @@ std::string concatenateFields(const std::set<std::string>& strSet)
     return outStr;
 }
 
-ModelState ConfigOutput::getStateRecursive(const OutputSpec& os) const
-{
-    return { {},
-        {
-            { keyMap.at(PERIOD_KEY), outputPeriod.format() },
-            { keyMap.at(START_KEY), lastOutput.format() }, // FIXME Not necessarily the start date!
-            { keyMap.at(FIELDNAMES_KEY), concatenateFields(fieldsForOutput) },
-        } };
-}
-
 } /* namespace Nextsim */

--- a/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
@@ -43,14 +43,11 @@ public:
     // ModelComponent overrides
     inline std::string getName() const override { return "ConfigOutput"; };
     inline void setData(const ModelState::DataMap&) override {};
-    inline ModelState getState() const override { return ModelState(); };
-    inline ModelState getState(const OutputLevel&) const override { return ModelState(); };
 
     // Configured overrides
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     void configure() override;
-    ModelState getStateRecursive(const OutputSpec& os) const override;
 
 private:
     std::string m_filePrefix;

--- a/core/src/modules/DiagnosticOutputModule/include/NoOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/NoOutput.hpp
@@ -22,9 +22,6 @@ public:
 
     // ModelComponent functions
     std::string getName() const override { return "NoOutput"; }
-    // No configuration in getState
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
 };
 
 } /* namespace Nextsim */

--- a/core/src/modules/DiagnosticOutputModule/include/SimpleOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/SimpleOutput.hpp
@@ -22,9 +22,6 @@ public:
 
     // ModelComponent functions
     std::string getName() const override { return "SimpleOutput"; }
-    // No configuration in getState
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
 
 private:
     std::string m_filePrefix;

--- a/core/src/modules/DynamicsModule/BBMDynamics.cpp
+++ b/core/src/modules/DynamicsModule/BBMDynamics.cpp
@@ -63,6 +63,29 @@ void BBMDynamics::configure()
         = Configured::getConfiguration(keyMap.at(ANGLE_KEY), oceanTurningAngleDefault);
 }
 
+ConfigMap BBMDynamics::getConfiguration() const
+{
+    return {
+        { keyMap.at(C_KEY), params.compactionParam },
+        { keyMap.at(NU_KEY), params.nu0 },
+        { keyMap.at(YOUNG_KEY), params.young },
+        { keyMap.at(P0_KEY), params.P0 },
+        { keyMap.at(LAMBDA0_KEY), params.lambda0 },
+        { keyMap.at(ALPHA_KEY), params.alpha },
+        { keyMap.at(EXPPMAX_KEY), params.expPMax },
+        { keyMap.at(MU_KEY), params.mu },
+        { keyMap.at(NMAX_KEY), params.comprCap },
+        { keyMap.at(CLAB_KEY), params.cLab },
+        { keyMap.at(NSTEPS_KEY), params.nSteps },
+        { keyMap.at(RHOI_KEY), params.rhoIce },
+        { keyMap.at(RHOA_KEY), params.rhoAtm },
+        { keyMap.at(RHOO_KEY), params.rhoOcean },
+        { keyMap.at(CATM_KEY), params.CAtm },
+        { keyMap.at(COCEAN_KEY), params.COcean },
+        { keyMap.at(FC_KEY), params.fc },
+        { keyMap.at(ANGLE_KEY), params.oceanTurningAngle },
+    };
+}
 BBMDynamics::BBMDynamics()
     : IDynamics(true)
     , kernel(params)
@@ -145,35 +168,6 @@ void BBMDynamics::update(const TimestepTime& tst)
 
     taux = kernel.getDG0Data(uIOStressName);
     tauy = kernel.getDG0Data(vIOStressName);
-}
-
-// All data for prognostic output
-ModelState BBMDynamics::getState() const
-{
-    // Get the velocities from IDynamics
-    ModelState state(IDynamics::getState());
-
-    // Kernel prognostic fields
-    state.merge({
-        { damageName, kernel.getDGData(damageName) },
-    });
-
-    return state;
-}
-
-ModelState BBMDynamics::getStateRecursive(const OutputSpec& os) const
-{
-    // Base class state
-    ModelState state(IDynamics::getStateRecursive(os));
-
-    if (os.allComponents()) {
-        state.merge({
-            { hiceName, kernel.getDGData(hiceName) },
-            { ciceName, kernel.getDGData(ciceName) },
-            { damageName, kernel.getDGData(damageName) },
-        });
-    }
-    return state;
 }
 
 BBMDynamics::HelpMap& BBMDynamics::getHelpText(HelpMap& map, bool getAll)

--- a/core/src/modules/DynamicsModule/MEVPDynamics.cpp
+++ b/core/src/modules/DynamicsModule/MEVPDynamics.cpp
@@ -50,6 +50,23 @@ void MEVPDynamics::configure()
         = Configured::getConfiguration(keyMap.at(ANGLE_KEY), oceanTurningAngleDefault);
 }
 
+ConfigMap MEVPDynamics::getConfiguration() const
+{
+    return {
+        { keyMap.at(PSTAR_KEY), params.pStar },
+        { keyMap.at(DELTA_KEY), params.deltaMin },
+        { keyMap.at(C_KEY), params.compactionParam },
+        { keyMap.at(NSTEPS_KEY), params.nSteps },
+        { keyMap.at(RHOI_KEY), params.rhoIce },
+        { keyMap.at(RHOA_KEY), params.rhoAtm },
+        { keyMap.at(RHOO_KEY), params.rhoOcean },
+        { keyMap.at(CATM_KEY), params.CAtm },
+        { keyMap.at(COCEAN_KEY), params.COcean },
+        { keyMap.at(FC_KEY), params.fc },
+        { keyMap.at(ANGLE_KEY), params.oceanTurningAngle },
+    };
+}
+
 static const std::vector<std::string> namedFields = { uName, vName };
 MEVPDynamics::MEVPDynamics()
     : IDynamics()
@@ -103,20 +120,6 @@ void MEVPDynamics::update(const TimestepTime& tst)
 
     taux = kernel.getDG0Data(uIOStressName);
     tauy = kernel.getDG0Data(vIOStressName);
-}
-
-ModelState MEVPDynamics::getStateRecursive(const OutputSpec& os) const
-{
-    // Base class state
-    ModelState state(IDynamics::getStateRecursive(os));
-
-    if (os.allComponents()) {
-        state.merge({
-            { hiceName, kernel.getDG0Data(hiceName) },
-            { ciceName, kernel.getDG0Data(ciceName) },
-        });
-    }
-    return state;
 }
 
 MEVPDynamics::HelpMap& MEVPDynamics::getHelpText(HelpMap& map, bool getAll)

--- a/core/src/modules/DynamicsModule/include/BBMDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/BBMDynamics.hpp
@@ -27,9 +27,8 @@ public:
     void update(const TimestepTime& tst) override;
 
     void setData(const ModelState::DataMap&) override;
-    ModelState getState() const override;
-    ModelState getStateRecursive(const OutputSpec& os) const override;
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
     enum {
         C_KEY,

--- a/core/src/modules/DynamicsModule/include/MEVPDynamics.hpp
+++ b/core/src/modules/DynamicsModule/include/MEVPDynamics.hpp
@@ -34,8 +34,8 @@ public:
     void update(const TimestepTime& tst) override;
 
     void setData(const ModelState::DataMap&) override;
-    ModelState getStateRecursive(const OutputSpec& os) const override;
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
     enum {
         PSTAR_KEY,

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -44,19 +44,31 @@ public:
     }
     virtual ~IDynamics() = default;
 
-    ModelState getState() const override
+    ModelState getStatePrognostic() const override
     {
-        return { {
-                     { uName, mask(uice) },
-                     { vName, mask(vice) },
+        ModelState state = { {
+                { uName, mask(uice) },
+                { vName, mask(vice) },
                  },
-            {} };
+            getConfiguration()
+        };
+
+        if (m_usesDamage) {
+               ModelState::DataMap damageState = { { damageName, damage } };
+               state.merge(damageState);
+           }
+
+        return state;
     }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-    ModelState getStateRecursive(const OutputSpec& os) const override
+
+    ModelState getStateDiagnostic() const override
     {
-        // Ensure the base class implementation of getState() is called
-        return os ? IDynamics::getState() : ModelState();
+        ModelState state = { {
+                { "tau_x", taux },
+                { "tau_y", tauy },
+        }, { }
+        };
+        return state.merge(getStatePrognostic());
     }
 
     std::string getName() const override { return "IDynamics"; }

--- a/core/test/ModelComponent_test.cpp
+++ b/core/test/ModelComponent_test.cpp
@@ -28,8 +28,6 @@ public:
     {
         throw(HappyExcept(std::string("setData for ") + getName()));
     }
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel& lvl) const override { return getState(); }
 };
 
 class ModuleSupplyAndWait : public ModelComponent {
@@ -42,14 +40,13 @@ public:
     }
     void setData(const ModelState::DataMap& ms) override { hice[0] = hiceData; }
     std::string getName() const override { return "SupplyAndWait"; }
-    ModelState getState() const override
+    ModelState getStatePrognostic() const override
     {
         return { {
                      { "hice", hice },
                  },
             {} };
     }
-    ModelState getState(const OutputLevel& lvl) const override { return getState(); }
 
     const double hiceData = 1.2;
     double data() { return hice[0]; }
@@ -70,14 +67,13 @@ public:
     }
     void setData(const ModelState::DataMap& ms) override { cice[0] = ciceData; }
     std::string getName() const override { return "SupplyAndWait"; }
-    ModelState getState() const override
+    ModelState getStatePrognostic() const override
     {
         return { {
                      { "cice", cice },
                  },
             {} };
     }
-    ModelState getState(const OutputLevel& lvl) const override { return getState(); }
 
     const double ciceData = 0.6;
     double data() { return cice[0]; }
@@ -109,14 +105,13 @@ public:
     }
     void setData(const ModelState::DataMap& ms) override { qic[0] = qicData; }
     std::string getName() const override { return "SemiShared"; }
-    ModelState getState() const override
+    ModelState getStatePrognostic() const override
     {
         return { {
                      { "qic", qic },
                  },
             {} };
     }
-    ModelState getState(const OutputLevel& lvl) const override { return getState(); }
 
     const double qicData = 123;
     double data() { return qic[0]; }
@@ -137,14 +132,13 @@ public:
     }
     void setData(const ModelState::DataMap& ms) override { qio[0]; }
     std::string getName() const override { return "Shared"; }
-    ModelState getState() const override
+    ModelState getStatePrognostic() const override
     {
         return { {
                      { "qio", qio },
                  },
             {} };
     }
-    ModelState getState(const OutputLevel& lvl) const override { return getState(); }
 
     const double qioData = 234;
     const double qicData = 246;

--- a/core/test/PDTestDynamics.hpp
+++ b/core/test/PDTestDynamics.hpp
@@ -19,13 +19,12 @@ public:
     {
         dataMap = ms;
     }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-    ModelState getState() const override
+    ModelState getStateDiagnostic() const override
     {
         return { dataMap, {} };
     }
 
-    ModelState getStateRecursive(const OutputSpec& os) const override
+    ModelState getStatePrognostic() const override
     {
         return { dataMap, {} };
     }

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -70,9 +70,9 @@ void IceGrowth::setData(const ModelState::DataMap& ms)
     deltaCIce.resize();
 }
 
-ModelState IceGrowth::getState() const
+ModelState IceGrowth::getStateDiagnostic() const
 {
-    return { {
+    ModelState state = { {
                  { "hice_updated", hice },
                  { "cice_updated", cice },
                  { "hsnow_updated", hsnow },
@@ -81,17 +81,22 @@ ModelState IceGrowth::getState() const
                  { "hsnow_initial", hsnow0 },
              },
         getConfiguration() };
+    state.merge(iLateral->getStateDiagnostic());
+    state.merge(iVertical->getStateDiagnostic());
+    state.merge(iHealing->getStateDiagnostic());
+
+    return state;
 }
 
-ModelState IceGrowth::getStateRecursive(const OutputSpec& os) const
+ModelState IceGrowth::getStatePrognostic() const
 {
-    ModelState state(getState());
+    ModelState state;
     // Merge in other states here
-    state.merge(iLateral->getStateRecursive(os));
-    state.merge(iVertical->getStateRecursive(os));
-    state.merge(iHealing->getStateRecursive(os));
+    state.merge(iLateral->getStatePrognostic());
+    state.merge(iVertical->getStatePrognostic());
+    state.merge(iHealing->getStatePrognostic());
 
-    return os ? state : ModelState();
+    return state;
 }
 
 IceGrowth::HelpMap& IceGrowth::getHelpText(HelpMap& map, bool getAll)

--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -73,13 +73,13 @@ void IceGrowth::setData(const ModelState::DataMap& ms)
 ModelState IceGrowth::getStateDiagnostic() const
 {
     ModelState state = { {
-                 { "hice_updated", hice },
-                 { "cice_updated", cice },
-                 { "hsnow_updated", hsnow },
-                 { "hice_initial", hice0 },
-                 { "cice_initial", cice0 },
-                 { "hsnow_initial", hsnow0 },
-             },
+                             { "hice_updated", hice },
+                             { "cice_updated", cice },
+                             { "hsnow_updated", hsnow },
+                             { "hice_initial", hice0 },
+                             { "cice_initial", cice0 },
+                             { "hsnow_initial", hsnow0 },
+                         },
         getConfiguration() };
     state.merge(iLateral->getStateDiagnostic());
     state.merge(iVertical->getStateDiagnostic());

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -38,6 +38,34 @@ void SlabOcean::configure()
     getStore().registerArray(Protected::SLAB_SSS, &sssSlab, RO);
 }
 
+ConfigMap SlabOcean::getConfiguration() const
+{
+    return {
+        { keyMap.at(TIMET_KEY), relaxationTimeT },
+        { keyMap.at(TIMES_KEY), relaxationTimeS },
+    };
+}
+
+ModelState SlabOcean::getStatePrognostic() const
+{
+    return { {
+                 { sstSlabName, sstSlab },
+                 { sssSlabName, sssSlab },
+             },
+        getConfiguration()
+    };
+}
+
+ModelState SlabOcean::getStateDiagnostic() const
+{
+    ModelState state = { {
+            { "Q_slab", qdw },
+            { "F_slab", fdw },
+    }, { } };
+
+    return state.merge(getStatePrognostic());
+}
+
 SlabOcean::HelpMap& SlabOcean::getHelpText(HelpMap& map, bool getAll)
 {
     map[className] = {
@@ -58,16 +86,6 @@ void SlabOcean::setData(const ModelState::DataMap& ms)
     sstSlab.resize();
     sssSlab.resize();
 }
-
-ModelState SlabOcean::getState() const
-{
-    return { {
-                 { sstSlabName, sstSlab },
-                 { sssSlabName, sssSlab },
-             },
-        {} };
-}
-ModelState SlabOcean::getState(const OutputLevel&) const { return getState(); }
 
 void SlabOcean::update(const TimestepTime& tst)
 {

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -52,16 +52,16 @@ ModelState SlabOcean::getStatePrognostic() const
                  { sstSlabName, sstSlab },
                  { sssSlabName, sssSlab },
              },
-        getConfiguration()
-    };
+        getConfiguration() };
 }
 
 ModelState SlabOcean::getStateDiagnostic() const
 {
     ModelState state = { {
-            { "Q_slab", qdw },
-            { "F_slab", fdw },
-    }, { } };
+                             { "Q_slab", qdw },
+                             { "F_slab", fdw },
+                         },
+        {} };
 
     return state.merge(getStatePrognostic());
 }

--- a/physics/src/include/IceGrowth.hpp
+++ b/physics/src/include/IceGrowth.hpp
@@ -39,9 +39,8 @@ public:
     std::string getName() const override { return "IceGrowth"; }
 
     void setData(const ModelState::DataMap&) override;
-    ModelState getState() const override;
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-    ModelState getStateRecursive(const OutputSpec& os) const override;
+    ModelState getStateDiagnostic() const override;
+    ModelState getStatePrognostic() const override;
 
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);

--- a/physics/src/include/SlabOcean.hpp
+++ b/physics/src/include/SlabOcean.hpp
@@ -46,12 +46,15 @@ public:
     };
 
     void configure() override;
+    ConfigMap getConfiguration() const override;
+
+    ModelState getStatePrognostic() const override;
+    ModelState getStateDiagnostic() const override;
+
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
     void setData(const ModelState::DataMap& ms) override;
-    ModelState getState() const override;
-    ModelState getState(const OutputLevel&) const override;
     std::string getName() const override { return "SlabOcean"; }
 
     void update(const TimestepTime&);

--- a/physics/src/modules/AtmosphereBoundaryModule/ConfiguredAtmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ConfiguredAtmosphere.cpp
@@ -94,6 +94,20 @@ void ConfiguredAtmosphere::configure()
     tryConfigure(fluxImpl);
 }
 
+ConfigMap ConfiguredAtmosphere::getConfiguration() const
+{
+    return {
+        { keyMap.at(TAIR_KEY), tair0 },
+        { keyMap.at(TDEW_KEY), tdew0 },
+        { keyMap.at(PAIR_KEY), pair0 },
+        { keyMap.at(SW_KEY), sw0 },
+        { keyMap.at(LW_KEY), lw0 },
+        { keyMap.at(SNOW_KEY), snowfall0 },
+        { keyMap.at(RAIN_KEY), rain0 },
+        { keyMap.at(WIND_KEY), windspeed0 },
+    };
+}
+
 void ConfiguredAtmosphere::setData(const ModelState::DataMap& dm)
 {
 

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -54,6 +54,13 @@ void ERA5Atmosphere::configure()
     tryConfigure(fluxImpl);
 }
 
+ConfigMap ERA5Atmosphere::getConfiguration() const
+{
+    return {
+        { keyMap.at(FILEPATH_KEY), filePath },
+    };
+}
+
 void ERA5Atmosphere::update(const TimestepTime& tst)
 {
     // TODO: Get more authoritative names for the forcings

--- a/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
@@ -79,6 +79,21 @@ void FluxConfiguredAtmosphere::configure()
     v0 = Configured::getConfiguration(keyMap.at(WINDV_KEY), v0);
 }
 
+ConfigMap FluxConfiguredAtmosphere::getConfiguration() const
+{
+    return {
+       { keyMap.at(QIA_KEY), qia0 },
+       { keyMap.at(DQIA_DT_KEY), dqia_dt0 },
+       { keyMap.at(QOW_KEY), qow0 },
+       { keyMap.at(SUBL_KEY), subl0 },
+       { keyMap.at(SNOW_KEY), snowfall0 },
+       { keyMap.at(RAIN_KEY), rain0 },
+       { keyMap.at(EVAP_KEY), evap0 },
+       { keyMap.at(WINDU_KEY), u0 },
+       { keyMap.at(WINDV_KEY), v0 },
+    };
+}
+
 void FluxConfiguredAtmosphere::setData(const ModelState::DataMap& dm)
 {
     IAtmosphereBoundary::setData(dm);

--- a/physics/src/modules/AtmosphereBoundaryModule/MU71Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/MU71Atmosphere.cpp
@@ -27,6 +27,13 @@ void MU71Atmosphere::configure()
     m_I0 = Configured::getConfiguration(keyMap.at(I0_KEY), i0_default);
 }
 
+ConfigMap MU71Atmosphere::getConfiguration() const
+{
+    return {
+        { keyMap.at(I0_KEY), m_I0 },
+    };
+}
+
 MU71Atmosphere::HelpMap& MU71Atmosphere::getHelpText(HelpMap& map, bool getAll)
 {
     map["FiniteElementFluxes"] = {

--- a/physics/src/modules/AtmosphereBoundaryModule/include/ConfiguredAtmosphere.hpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/include/ConfiguredAtmosphere.hpp
@@ -37,6 +37,7 @@ public:
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
     //! Calculates the fluxes from the given values
     void update(const TimestepTime&) override;

--- a/physics/src/modules/AtmosphereBoundaryModule/include/ERA5Atmosphere.hpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/include/ERA5Atmosphere.hpp
@@ -34,6 +34,7 @@ public:
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
     //! Calculates the fluxes from the given values
     void update(const TimestepTime&) override;

--- a/physics/src/modules/AtmosphereBoundaryModule/include/FluxConfiguredAtmosphere.hpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/include/FluxConfiguredAtmosphere.hpp
@@ -39,6 +39,7 @@ public:
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
 protected:
     //! Performs the implementation specific updates. Does nothing.

--- a/physics/src/modules/AtmosphereBoundaryModule/include/MU71Atmosphere.hpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/include/MU71Atmosphere.hpp
@@ -33,6 +33,7 @@ public:
         I0_KEY,
     };
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);

--- a/physics/src/modules/DamageHealingModule/ConstantHealing.cpp
+++ b/physics/src/modules/DamageHealingModule/ConstantHealing.cpp
@@ -22,9 +22,9 @@ void ConstantHealing::configure()
     tD *= 86400.;
 }
 
-ModelState ConstantHealing::getStateRecursive(const Nextsim::OutputSpec& os) const
+ConfigMap ConstantHealing::getConfiguration() const
 {
-    return { {}, { { keyMap.at(TD_KEY), tD } } };
+    return { { keyMap.at(TD_KEY), tD } };
 }
 
 ConstantHealing::HelpMap& ConstantHealing::getHelpText(HelpMap& map, bool getAll)

--- a/physics/src/modules/DamageHealingModule/include/ConstantHealing.hpp
+++ b/physics/src/modules/DamageHealingModule/include/ConstantHealing.hpp
@@ -26,7 +26,7 @@ public:
     void configure() override;
     enum { TD_KEY };
 
-    ModelState getStateRecursive(const OutputSpec& os) const override;
+    ConfigMap getConfiguration() const override;
 
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap&, bool getAll);

--- a/physics/src/modules/DamageHealingModule/include/NoHealing.hpp
+++ b/physics/src/modules/DamageHealingModule/include/NoHealing.hpp
@@ -23,8 +23,6 @@ public:
     }
     virtual ~NoHealing() = default;
 
-    ModelState getStateRecursive(const OutputSpec& os) const override { return ModelState(); };
-
     // Do nothing when update is called.
     void update(const TimestepTime& tstep) override { damage = oldDamage; }
 };

--- a/physics/src/modules/FluxCalculationModule/FiniteElementFluxes.cpp
+++ b/physics/src/modules/FluxCalculationModule/FiniteElementFluxes.cpp
@@ -53,6 +53,38 @@ void FiniteElementFluxes::configure()
     m_I0 = Configured::getConfiguration(keyMap.at(I0_KEY), i0_default);
 }
 
+ConfigMap FiniteElementFluxes::getConfiguration() const
+{
+    return {
+        { keyMap.at(DRAGOCEANQ_KEY), dragOcean_q },
+        { keyMap.at(DRAGOCEANT_KEY), dragOcean_t },
+        { keyMap.at(DRAGICET_KEY), dragIce_t },
+        { keyMap.at(OCEANALBEDO_KEY), m_oceanAlbedo },
+        { keyMap.at(I0_KEY), m_I0 },
+    };
+}
+
+ModelState FiniteElementFluxes::getStateDiagnostic() const
+{
+    return { {
+                 { "evap", evap },
+                 { "Q_lh_ow", Q_lh_ow },
+                 { "Q_sh_ow", Q_sh_ow },
+                 { "Q_lw_ow", Q_lw_ow },
+                 { "Q_lh_ia", Q_lh_ia },
+                 { "Q_sh_ia", Q_sh_ia },
+                 { "Q_sw_ia", Q_sw_ia },
+                 { "Q_lw_ia", Q_lw_ia },
+                 { "rho_air", rho_air },
+                 { "cp_air", cp_air },
+                 { "sh_air", sh_air },
+                 { "sh_water", sh_water },
+                 { "sh_ice", sh_ice },
+                 { "dshice_dT", dshice_dT },
+             },
+        getConfiguration() };
+}
+
 void FiniteElementFluxes::setData(const ModelState::DataMap& ms)
 {
     // Data arrays can now be set to the correct size
@@ -70,16 +102,6 @@ void FiniteElementFluxes::setData(const ModelState::DataMap& ms)
     sh_water.resize();
     sh_ice.resize();
     dshice_dT.resize();
-}
-
-ModelState FiniteElementFluxes::getState() const { return { {}, {} }; }
-
-ModelState FiniteElementFluxes::getState(const OutputLevel&) const { return getState(); }
-
-ModelState FiniteElementFluxes::getStateRecursive(const OutputSpec& os) const
-{
-    ModelState state(getState());
-    return os ? state : ModelState();
 }
 
 FiniteElementFluxes::HelpMap& FiniteElementFluxes::getHelpText(HelpMap& map, bool getAll)

--- a/physics/src/modules/FluxCalculationModule/include/FiniteElementFluxes.hpp
+++ b/physics/src/modules/FluxCalculationModule/include/FiniteElementFluxes.hpp
@@ -62,12 +62,11 @@ public:
         I0_KEY,
     };
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
     void setData(const ModelState::DataMap&) override;
 
-    ModelState getState() const override;
-    ModelState getState(const OutputLevel&) const override;
-    ModelState getStateRecursive(const OutputSpec& os) const override;
+    ModelState getStateDiagnostic() const override;
 
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);

--- a/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoIce0.cpp
@@ -49,13 +49,29 @@ void ThermoIce0::configure()
     NZLevels::set(nZLevels);
 }
 
-ModelState ThermoIce0::getStateRecursive(const OutputSpec& os) const
+ConfigMap ThermoIce0::getConfiguration() const
 {
-    ModelState state = { {},
-        {
-            { keyMap.at(KS_KEY), kappa_s },
-        } };
-    return os ? state : ModelState();
+    return { { keyMap.at(KS_KEY), kappa_s } };
+}
+
+ModelState ThermoIce0::getStateDiagnostic() const
+{
+    ModelState state = { {
+        { "snow_melt", snowMelt },
+        { "top_melt", topMelt },
+        { "bottom_melt", botMelt },
+        { "Q_ic", qic },
+    },
+            getConfiguration()
+    };
+
+    return state.merge(IIceThermodynamics::getStateDiagnostic());
+}
+
+ModelState ThermoIce0::getStatePrognostic() const
+{
+    ModelState state = IIceThermodynamics::getStatePrognostic();
+    return state.merge(getConfiguration());
 }
 
 ThermoIce0::HelpMap& ThermoIce0::getHelpText(HelpMap& map, bool getAll)

--- a/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
@@ -50,13 +50,30 @@ void ThermoWinton::configure()
     NZLevels::set(nLevels);
 }
 
-ModelState ThermoWinton::getStateRecursive(const OutputSpec& os) const
+ConfigMap ThermoWinton::getConfiguration() const
 {
-    ModelState state = { {},
-        {
-            { keyMap.at(KS_KEY), kappa_s },
-        } };
-    return os ? state : ModelState();
+    return {
+        { keyMap.at(KS_KEY), kappa_s },
+        { keyMap.at(FLOODING_KEY), doFlooding },
+    };
+}
+
+ModelState ThermoWinton::getStateDiagnostic() const
+{
+    ModelState state =  { {
+            { "snow_melt", snowMelt },
+            { "top_melt", topMelt },
+            { "bottom_melt", botMelt },
+    },
+            getConfiguration()
+    };
+
+    return state.merge(IIceThermodynamics::getStateDiagnostic());
+}
+
+ModelState ThermoWinton::getStatePrognostic() const
+{
+    return { { }, getConfiguration() };
 }
 
 ThermoWinton::HelpMap& ThermoWinton::getHelpText(HelpMap& map, bool getAll)

--- a/physics/src/modules/IceThermodynamicsModule/include/DummyIceThermodynamics.hpp
+++ b/physics/src/modules/IceThermodynamicsModule/include/DummyIceThermodynamics.hpp
@@ -23,8 +23,6 @@ public:
     }
     ~DummyIceThermodynamics() = default;
 
-    ModelState getStateRecursive(const OutputSpec& os) const override { return ModelState(); }
-
     void setData(const ModelState::DataMap& ms) override { IIceThermodynamics::setData(ms); }
     void update(const TimestepTime& tsTime) override { }
 

--- a/physics/src/modules/IceThermodynamicsModule/include/ThermoIce0.hpp
+++ b/physics/src/modules/IceThermodynamicsModule/include/ThermoIce0.hpp
@@ -23,8 +23,10 @@ public:
         KS_KEY,
     };
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
-    ModelState getStateRecursive(const OutputSpec& os) const override;
+    ModelState getStateDiagnostic() const override;
+    ModelState getStatePrognostic() const override;
 
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);

--- a/physics/src/modules/IceThermodynamicsModule/include/ThermoWinton.hpp
+++ b/physics/src/modules/IceThermodynamicsModule/include/ThermoWinton.hpp
@@ -28,8 +28,10 @@ public:
         FLOODING_KEY,
     };
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
-    ModelState getStateRecursive(const OutputSpec& os) const override;
+    ModelState getStateDiagnostic() const override;
+    ModelState getStatePrognostic() const override;
 
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -26,13 +26,19 @@ void HiblerSpread::configure()
     phiM = Configured::getConfiguration(keyMap.at(PHIM_KEY), phimDefault);
 }
 
-ModelState HiblerSpread::getStateRecursive(const OutputSpec& os) const
+ConfigMap HiblerSpread::getConfiguration() const
 {
-    return { {},
-        {
-            { keyMap.at(H0_KEY), h0 },
-            { keyMap.at(PHIM_KEY), phiM },
-        } };
+    return {
+        { keyMap.at(H0_KEY), h0 },
+        { keyMap.at(PHIM_KEY), phiM },
+    };
+}
+
+ModelState HiblerSpread::getStateDiagnostic() const
+{
+    return { { },
+        getConfiguration()
+    };
 }
 
 HiblerSpread::HelpMap& HiblerSpread::getHelpText(HelpMap& map, bool getAll)

--- a/physics/src/modules/LateralIceSpreadModule/include/DummyIceSpread.hpp
+++ b/physics/src/modules/LateralIceSpreadModule/include/DummyIceSpread.hpp
@@ -20,8 +20,6 @@ public:
     }
     ~DummyIceSpread() = default;
 
-    ModelState getStateRecursive(const OutputSpec& os) const override { return ModelState(); }
-
     void freeze(const TimestepTime& tstep, double hice, double hsnow, double deltaHi, double newIce,
         double& cice, double& qow, double& deltaCfreeze) override
     {

--- a/physics/src/modules/LateralIceSpreadModule/include/HiblerSpread.hpp
+++ b/physics/src/modules/LateralIceSpreadModule/include/HiblerSpread.hpp
@@ -28,7 +28,9 @@ public:
         PHIM_KEY,
     };
 
-    ModelState getStateRecursive(const OutputSpec& os) const override;
+    ConfigMap getConfiguration() const override;
+
+    ModelState getStateDiagnostic() const override;
 
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap&, bool getAll);

--- a/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/ConfiguredOcean.cpp
@@ -83,6 +83,29 @@ void ConfiguredOcean::configure()
     tryConfigure(Module::getImplementation<IIceOceanHeatFlux>());
 }
 
+ConfigMap ConfiguredOcean::getConfiguration() const
+{
+    return {
+        { keyMap.at(SST_KEY), sst0 },
+        { keyMap.at(SSS_KEY), sss0 },
+        { keyMap.at(MLD_KEY), mld0 },
+        { keyMap.at(CURRENTU_KEY), u0 },
+        { keyMap.at(CURRENTV_KEY), v0},
+    };
+}
+
+ModelState ConfiguredOcean::getStatePrognostic() const
+{
+    ModelState state = IOceanBoundary::getStatePrognostic();
+    return state.merge(slabOcean.getStatePrognostic());
+}
+
+ModelState ConfiguredOcean::getStateDiagnostic() const
+{
+    ModelState state = IOceanBoundary::getStateDiagnostic();
+    return state.merge(slabOcean.getStateDiagnostic());
+}
+
 void ConfiguredOcean::setData(const ModelState::DataMap& ms)
 {
     IOceanBoundary::setData(ms);

--- a/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/FluxConfiguredOcean.cpp
@@ -67,6 +67,17 @@ void FluxConfiguredOcean::configure()
     v0 = Configured<FluxConfiguredOcean>::getConfiguration(keyMap.at(CURRENTV_KEY), v0);
 }
 
+ConfigMap FluxConfiguredOcean::getConfiguration() const
+{
+    return {
+        { keyMap.at(QIO_KEY), qio0 },
+        { keyMap.at(SST_KEY), sst0 },
+        { keyMap.at(SSS_KEY), sss0 },
+        { keyMap.at(MLD_KEY), mld0 },
+        { keyMap.at(CURRENTU_KEY), u0 },
+        { keyMap.at(CURRENTV_KEY), v0 },
+    };
+}
 void FluxConfiguredOcean::setData(const ModelState::DataMap& ms)
 {
     IOceanBoundary::setData(ms);

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -56,6 +56,11 @@ void TOPAZOcean::configure()
     getStore().registerArray(Protected::EXT_SSS, &sssExt, RO);
 }
 
+ConfigMap TOPAZOcean::getConfiguration() const
+{
+    return { { keyMap.at(FILEPATH_KEY), filePath } };
+}
+
 void TOPAZOcean::updateBefore(const TimestepTime& tst)
 {
     std::set<std::string> forcings = { sstName, sssName, mldName, uName, vName, sshName };

--- a/physics/src/modules/OceanBoundaryModule/include/ConfiguredOcean.hpp
+++ b/physics/src/modules/OceanBoundaryModule/include/ConfiguredOcean.hpp
@@ -36,7 +36,10 @@ public:
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
+    ModelState getStatePrognostic() const override;
+    ModelState getStateDiagnostic() const override;
     void updateBefore(const TimestepTime& tst) override;
     void updateAfter(const TimestepTime& tst) override;
 

--- a/physics/src/modules/OceanBoundaryModule/include/FluxConfiguredOcean.hpp
+++ b/physics/src/modules/OceanBoundaryModule/include/FluxConfiguredOcean.hpp
@@ -35,6 +35,7 @@ public:
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
     void updateBefore(const TimestepTime& tst) override { }
     void updateAfter(const TimestepTime& tst) override { }

--- a/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
+++ b/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
@@ -34,6 +34,7 @@ public:
     static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
 
     void configure() override;
+    ConfigMap getConfiguration() const override;
 
     void updateBefore(const TimestepTime&) override;
     void updateAfter(const TimestepTime&) override;

--- a/physics/src/modules/include/IAtmosphereBoundary.hpp
+++ b/physics/src/modules/include/IAtmosphereBoundary.hpp
@@ -15,22 +15,14 @@
 namespace Nextsim {
 
 //! An interface class for the atmospheric inputs into the ice physics.
-class IAtmosphereBoundary : public ModelComponent {
+class IAtmosphereBoundary: public ModelComponent {
 public:
     IAtmosphereBoundary()
-        : qia(ModelArray::Type::H)
-        , dqia_dt(ModelArray::Type::H)
-        , qow(ModelArray::Type::H)
-        , subl(ModelArray::Type::H)
-        , snow(ModelArray::Type::H)
-        , rain(ModelArray::Type::H)
-        , evap(ModelArray::Type::H)
-        , emp(ModelArray::Type::H)
-        , uwind(ModelArray::Type::U)
-        , vwind(ModelArray::Type::V)
-        , penSW(ModelArray::Type::H)
-        , tauXOW(ModelArray::Type::H)
-        , tauYOW(ModelArray::Type::H)
+            : qia(ModelArray::Type::H), dqia_dt(ModelArray::Type::H), qow(ModelArray::Type::H), subl(
+                    ModelArray::Type::H), snow(ModelArray::Type::H), rain(ModelArray::Type::H), evap(
+                    ModelArray::Type::H), emp(ModelArray::Type::H), uwind(ModelArray::Type::U), vwind(
+                    ModelArray::Type::V), penSW(ModelArray::Type::H), tauXOW(ModelArray::Type::H), tauYOW(
+                    ModelArray::Type::H)
     {
         m_couplingArrays.registerArray(CouplingFields::SUBL, &subl, RW);
         m_couplingArrays.registerArray(CouplingFields::SNOW, &snow, RW);
@@ -53,10 +45,10 @@ public:
     }
     virtual ~IAtmosphereBoundary() = default;
 
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-
-    std::string getName() const override { return "IAtmosphereBoundary"; }
+    std::string getName() const override
+    {
+        return "IAtmosphereBoundary";
+    }
     void setData(const ModelState::DataMap& ms) override
     {
         qia.resize();
@@ -73,10 +65,15 @@ public:
         tauXOW.resize();
         tauYOW.resize();
     }
-    virtual void update(const TimestepTime& tst) { }
+    virtual void update(const TimestepTime& tst)
+    {
+    }
 
 protected:
-    ModelArrayReferenceStore& couplingArrays() { return m_couplingArrays; }
+    ModelArrayReferenceStore& couplingArrays()
+    {
+        return m_couplingArrays;
+    }
 
     HField qia;
     HField dqia_dt;

--- a/physics/src/modules/include/IDamageHealing.hpp
+++ b/physics/src/modules/include/IDamageHealing.hpp
@@ -19,12 +19,6 @@ public:
 
     std::string getName() const override { return "DamageHealing"; }
     void setData(const ModelState::DataMap& ms) override { }
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-    ModelState getStateRecursive(const OutputSpec& os) const override
-    {
-        return os ? getState() : ModelState();
-    }
     /*!
      * Updates the ice damage based on lateral ice growth and healing
      *

--- a/physics/src/modules/include/IFluxCalculation.hpp
+++ b/physics/src/modules/include/IFluxCalculation.hpp
@@ -33,13 +33,6 @@ public:
 
     void setData(const ModelState::DataMap& ms) override { }
 
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-    ModelState getStateRecursive(const OutputSpec& os) const override
-    {
-        return os ? getState() : ModelState();
-    }
-
     std::string getName() const override { return "IFluxCalculation"; }
 
     /*!

--- a/physics/src/modules/include/IIceOceanHeatFlux.hpp
+++ b/physics/src/modules/include/IIceOceanHeatFlux.hpp
@@ -29,13 +29,6 @@ public:
 
     // This superclass has no state
     void setData(const ModelState::DataMap&) override {};
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-    ModelState getStateRecursive(const OutputSpec& os) const override
-    {
-        return os ? getState() : ModelState();
-    }
-    // …but it does have a name
     std::string getName() const override { return "IIceOceanHeatFlux"; }
 
     /*!

--- a/physics/src/modules/include/IIceThermodynamics.hpp
+++ b/physics/src/modules/include/IIceThermodynamics.hpp
@@ -9,6 +9,7 @@
 #define IICETHERMODYNAMICS_HPP
 
 #include "include/ConfigurationHelp.hpp"
+#include "include/gridNames.hpp"
 #include "include/ModelArray.hpp"
 #include "include/ModelArrayRef.hpp"
 #include "include/ModelComponent.hpp"
@@ -27,12 +28,18 @@ public:
         deltaHi.resize();
         snowToIce.resize();
     }
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-    ModelState getStateRecursive(const OutputSpec& os) const override
+
+    ModelState getStateDiagnostic() const override
     {
-        return os ? getState() : ModelState();
+        ModelState state = { {
+            { "delta_H_ice", deltaHi },
+            { "snow_to_ice", snowToIce },
+        },
+                getConfiguration()
+        };
+        return state;
     }
+
     /*!
      * Updates the ice thermodynamic and thickness growth calculation for the timestep.
      *

--- a/physics/src/modules/include/ILateralIceSpread.hpp
+++ b/physics/src/modules/include/ILateralIceSpread.hpp
@@ -21,12 +21,6 @@ public:
 
     std::string getName() const override { return "LateralIceSpread"; }
     void setData(const ModelState::DataMap& ms) override { }
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-    ModelState getStateRecursive(const OutputSpec& os) const override
-    {
-        return os ? getState() : ModelState();
-    }
     /*!
      * Updates the freezing of open water for the timestep.
      *

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -74,9 +74,6 @@ public:
     }
     virtual ~IOceanBoundary() = default;
 
-    ModelState getState() const override { return ModelState(); }
-    ModelState getState(const OutputLevel&) const override { return getState(); }
-
     std::string getName() const override { return "IOceanBoundary"; }
     void setData(const ModelState::DataMap& ms) override
     {

--- a/physics/test/BasicIceOceanFlux_test.cpp
+++ b/physics/test/BasicIceOceanFlux_test.cpp
@@ -67,8 +67,6 @@ TEST_CASE("Melting conditions")
         HField tice0;
         HField hice0; // ice averaged ice thickness
         HField hsnow0; // ice averaged snow thickness
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } iceState;
     iceState.setData(ModelState().data);
 
@@ -126,9 +124,6 @@ TEST_CASE("Freezing conditions")
         HField tice0;
         HField hice0; // ice averaged ice thickness
         HField hsnow0; // ice averaged snow thickness
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } iceState;
     iceState.setData(ModelState().data);
 

--- a/physics/test/DamageHealing_test.cpp
+++ b/physics/test/DamageHealing_test.cpp
@@ -60,9 +60,6 @@ TEST_CASE("Thermodynamic healing")
         HField deltaCi;
         HField damage;
         HField oldDamage;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } iceState;
     iceState.setData(ModelState().data);
 
@@ -126,9 +123,6 @@ TEST_CASE("New ice formation")
         HField deltaCi;
         HField damage;
         HField oldDamage;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } iceState;
     iceState.setData(ModelState().data);
 

--- a/physics/test/FiniteElementFluxes_test.cpp
+++ b/physics/test/FiniteElementFluxes_test.cpp
@@ -81,8 +81,6 @@ TEST_CASE("Melting conditions")
             lw_in = 330;
         }
         std::string getName() const override { return "AtmData"; }
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
 
     private:
         HField tair;
@@ -128,8 +126,6 @@ TEST_CASE("Melting conditions")
         HField tice0;
         HField hice0; // ice averaged ice thickness
         HField hsnow0; // ice averaged snow thickness
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } iceState;
     iceState.setData(ModelState().data);
 
@@ -238,8 +234,6 @@ TEST_CASE("Freezing conditions")
             lw_in = 265;
         }
         std::string getName() const override { return "AtmData"; }
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
 
     private:
         HField tair;
@@ -286,8 +280,6 @@ TEST_CASE("Freezing conditions")
         HField hice0; // ice averaged ice thickness
         HField hsnow0; // ice averaged snow thickness
 
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } iceState;
     iceState.setData(ModelState().data);
 

--- a/physics/test/IceGrowth_test.cpp
+++ b/physics/test/IceGrowth_test.cpp
@@ -82,9 +82,6 @@ TEST_CASE("New ice formation")
         HField cice;
         HField hsnow;
         ZField tice0;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } proData;
     proData.setData(ModelState().data);
 
@@ -166,9 +163,6 @@ TEST_CASE("Melting conditions")
         HField cice;
         HField hsnow;
         ZField tice0;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } proData;
     proData.setData(ModelState().data);
 
@@ -260,9 +254,6 @@ TEST_CASE("Freezing conditions")
         HField cice;
         HField hsnow;
         ZField tice0;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } proData;
     proData.setData(ModelState().data);
 
@@ -361,9 +352,6 @@ TEST_CASE("Dummy ice")
         HField cice;
         HField hsnow;
         ZField tice0;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } proData;
     proData.setData(ModelState().data);
 
@@ -461,9 +449,6 @@ TEST_CASE("Zero thickness")
         HField cice;
         HField hsnow;
         ZField tice0;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } proData;
     proData.setData(ModelState().data);
 
@@ -569,9 +554,6 @@ TEST_CASE("Turn off thermo")
         HField cice;
         HField hsnow;
         ZField tice0;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } proData;
     proData.setData(ModelState().data);
 

--- a/physics/test/ThermoIce0_test.cpp
+++ b/physics/test/ThermoIce0_test.cpp
@@ -94,9 +94,6 @@ TEST_CASE("Threshold ice")
         HField dqia_dt;
         HField subl;
         HField penSW;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } atmoState;
     atmoState.setData(ModelState::DataMap());
 
@@ -139,9 +136,6 @@ TEST_CASE("Threshold ice")
             subl[0] = 0;
             penSW[0] = 0;
         }
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
 
         void update(const TimestepTime&) override { }
     } fluxData;

--- a/physics/test/ThermoWintonTemperature_test.cpp
+++ b/physics/test/ThermoWintonTemperature_test.cpp
@@ -89,9 +89,6 @@ TEST_CASE("Melting conditions")
         HField hice;
         HField cice;
         HField hsnow;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } initCond;
     initCond.setData(ModelState().data);
 
@@ -192,9 +189,6 @@ TEST_CASE("Freezing conditions")
         HField hice;
         HField cice;
         HField hsnow;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } atmoState;
     atmoState.setData(ModelState().data);
 
@@ -295,9 +289,6 @@ TEST_CASE("No ice do nothing")
         HField hice;
         HField cice;
         HField hsnow;
-
-        ModelState getState() const override { return ModelState(); }
-        ModelState getState(const OutputLevel&) const override { return getState(); }
     } atmoState;
     atmoState.setData(ModelState().data);
 


### PR DESCRIPTION
# Add getConfiguration(), rework getState*().

Fixes #829 

---
# Change Description

The confusingly named `getState()` and `getStateRecursive()` functions were renamed to the more descriptive `getStatePrognostic()` and `getStateDiagnostic()`. Added a function to get configuration values, called `getConfiguration()`, which separates out the configuration collection part of the state.

---
# Test Description

Several tests were edited, as they had definitions of `getState()` or `getStateRecursive()` that are no longer needed.

---
# Documentation Impact

The diagnostic fields available for each `ModelComponent` should be documented somewhere, possibly as part of the online help system. This will be raised as an issue for the future, once the documentation for the output system is finalized, which depends on the XIOS work (#833 _et al._)
