### PR TITLE
Issue840 Fixing `ConfigOutput_test` to be deterministic

### DIFF
--- a/core/src/include/ModelMetadata.hpp
+++ b/core/src/include/ModelMetadata.hpp
@@ -110,9 +110,9 @@ private:
     // Angle from model reference to grid north (+y for grids) TODO: what for meshes? N/A?
     ModelArray m_gridAzimuth;
     // Are the coordinates Cartesian? x & y versus longitude and latitude
-    bool isCartesian;
+    bool isCartesian = false;
     // Are the more complex coordinates stored?
-    bool hasParameters;
+    bool hasParameters = false;
 #ifdef USE_MPI
     const std::string bboxName = "bounding_boxes";
 #endif

--- a/core/test/ConfigOutput_test.cpp
+++ b/core/test/ConfigOutput_test.cpp
@@ -99,6 +99,18 @@ TEST_CASE("Test periodic output")
     ModelComponent::getStore().registerArray(Protected::T_ICE, &tice);
 
     ModelMetadata meta;
+    // Set up the coordinates, but use arrays filled with zeros
+    HField latlonData(ModelArray::Type::H);
+    latlonData = 0.;
+    VertexField coordsData(ModelArray::Type::VERTEX);
+    coordsData = 0.;
+    ModelState modelCoordinates = { {
+             { longitudeName, latlonData },
+             { latitudeName, latlonData },
+             { gridAzimuthName, latlonData },
+             { coordsName, coordsData },
+    }, { } };
+    meta.extractCoordinates(modelCoordinates);
     meta.setTime(TimePoint("2020-01-01T00:00:00Z"));
 
 #ifdef USE_MPI


### PR DESCRIPTION
# Fixing `ConfigOutput_test` to be deterministic

Fixes #840

---
# Change Description

Set the `bool` values `ModelMetadata::isCartesian` and `ModelMetadata::hasParameters` to be initially `false`.

---
# Test Description

Added a call to `ModelMetadata::extractCoordinates()` to `ConfigOutput_test.cpp`, so that the model state that is to be written definitely has `coords` and `grid_azimuth` fields, even if they are filled with zeros.
