### PR TITLE
Issue734 add ctest functionality

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -66,16 +66,7 @@ jobs:
         apt install -y wget
         cd build
         (cd core/test && wget "ftp://ftp.nersc.no/nextsim/netCDF/partition_metadata_1.nc")
-        for component in core physics dynamics
-        do
-            cd $component/test
-            for file in $(find test* -maxdepth 0 -type f)
-            do
-              echo $file
-              ./$file
-            done
-            cd -
-        done
+        ctest -V
         mv ../test .
         cd test
         python3 ThermoIntegration_test.py
@@ -145,17 +136,8 @@ jobs:
         apt install -y wget
         cd build
         (cd core/test && wget "ftp://ftp.nersc.no/nextsim/netCDF/partition_metadata_1.nc")
-        for component in core physics dynamics
-        do
-            cd $component/test
-            for file in $(find test* -maxdepth 0 -type f)
-            do
-              echo $file
-              nprocs=$(echo $file | sed -r "s/.*MPI([0-9]+)/\1/")
-              mpirun --allow-run-as-root --oversubscribe -n $nprocs ./$file
-            done
-            cd -
-        done
+        ctest -V
+        cd -
 
   test-mac-serial:
 
@@ -195,16 +177,7 @@ jobs:
     - name: run serial tests
       run: |
         cd build
-        for component in core physics dynamics
-        do
-            cd $component/test
-            for file in $(find test* -maxdepth 0 -type f | grep -v "_MPI\d*$")
-            do
-              echo $file
-              ./$file
-            done
-            cd -
-        done
+        ctest -V
         mv ../test .
         cd test
         python ThermoIntegration_test.py

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -92,23 +92,18 @@ jobs:
         make -j 4
 
     - name: run MPI tests
+      # set enviornment variables for MPI tests to run in docker container
+      env:
+        OMPI_ALLOW_RUN_AS_ROOT=1
+        OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+        OMPI_MCA_rmaps_base_oversubscribe=1
       run: |
         . /opt/spack-environment/activate.sh
         apt update
         apt install -y wget
         cd build
         (cd core/test && wget "ftp://ftp.nersc.no/nextsim/netCDF/partition_metadata_1.nc")
-        for component in core physics dynamics
-        do
-            cd $component/test
-            for file in $(find test* -maxdepth 0 -type f)
-            do
-              echo $file
-              nprocs=$(echo $file | sed -r "s/.*MPI([0-9]+)/\1/")
-              mpirun --allow-run-as-root --oversubscribe -n $nprocs ./$file
-            done
-            cd -
-        done
+        ctest -V
 
   test-ubuntu-mpi-xios:
 
@@ -130,14 +125,21 @@ jobs:
         make -j 4
 
     - name: run MPI tests
+      # set enviornment variables for MPI tests to run in docker container
+      env:
+        OMPI_ALLOW_RUN_AS_ROOT=1
+        OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+        OMPI_MCA_rmaps_base_oversubscribe=1
       run: |
         . /opt/spack-environment/activate.sh
         apt update
         apt install -y wget
         cd build
         (cd core/test && wget "ftp://ftp.nersc.no/nextsim/netCDF/partition_metadata_1.nc")
+        echo "OMPI_ALLOW_RUN_AS_ROOT = $OMPI_ALLOW_RUN_AS_ROOT"
+        echo "OMPI_ALLOW_RUN_AS_ROOT_CONFIRM = $OMPI_ALLOW_RUN_AS_ROOT_CONFIRM"
+        echo "OMPI_MCA_rmaps_base_oversubscribe = $OMPI_MCA_rmaps_base_oversubscribe"
         ctest -V
-        cd -
 
   test-mac-serial:
 

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -92,12 +92,11 @@ jobs:
         make -j 4
 
     - name: run MPI tests
-      # set enviornment variables for MPI tests to run in docker container
-      env:
-        OMPI_ALLOW_RUN_AS_ROOT=1
-        OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-        OMPI_MCA_rmaps_base_oversubscribe=1
       run: |
+        # set enviornment variables for MPI tests to run in docker container
+        export OMPI_ALLOW_RUN_AS_ROOT=1
+        export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+        export OMPI_MCA_rmaps_base_oversubscribe=1
         . /opt/spack-environment/activate.sh
         apt update
         apt install -y wget
@@ -125,20 +124,16 @@ jobs:
         make -j 4
 
     - name: run MPI tests
-      # set enviornment variables for MPI tests to run in docker container
-      env:
-        OMPI_ALLOW_RUN_AS_ROOT=1
-        OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-        OMPI_MCA_rmaps_base_oversubscribe=1
       run: |
+        # set enviornment variables for MPI tests to run in docker container
+        export OMPI_ALLOW_RUN_AS_ROOT=1
+        export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+        export OMPI_MCA_rmaps_base_oversubscribe=1
         . /opt/spack-environment/activate.sh
         apt update
         apt install -y wget
         cd build
         (cd core/test && wget "ftp://ftp.nersc.no/nextsim/netCDF/partition_metadata_1.nc")
-        echo "OMPI_ALLOW_RUN_AS_ROOT = $OMPI_ALLOW_RUN_AS_ROOT"
-        echo "OMPI_ALLOW_RUN_AS_ROOT_CONFIRM = $OMPI_ALLOW_RUN_AS_ROOT_CONFIRM"
-        echo "OMPI_MCA_rmaps_base_oversubscribe = $OMPI_MCA_rmaps_base_oversubscribe"
         ctest -V
 
   test-mac-serial:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ if(BUILD_TESTS)
         TARGET doctest::doctest
         PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${DOCTEST_INCLUDE_DIR}"
     )
+    enable_testing() # Enable ctest
 endif()
 
 # Eigen

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(src)
 if(BUILD_TESTS) #(NOT(CMAKE_BUILD_TYPE STREQUAL "Release"))
+    enable_testing()
     add_subdirectory(test)
 endif()
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -102,6 +102,17 @@ if(ENABLE_MPI)
             PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
         )
         target_link_libraries(testXiosWrite_MPI2 PRIVATE nextsimlib doctest::doctest)
+
+        # In the MPI tests it's important to include the "-ns" flag which tells doctest to fail if test has been skipped.
+        # Without this, the test will technically pass if we run with fewer ranks than requested.
+        add_test(NAME testXiosCalendar_MPI1 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 testXiosCalendar_MPI1 -ns)
+        add_test(NAME testXiosAxis_MPI3 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 testXiosAxis_MPI3 -ns)
+        add_test(NAME testXiosDomain_MPI4 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 testXiosDomain_MPI4 -ns)
+        add_test(NAME testXiosGrid_MPI4 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 testXiosGrid_MPI4 -ns)
+        add_test(NAME testXiosField_MPI3 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 testXiosField_MPI3 -ns)
+        add_test(NAME testXiosFile_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testXiosFile_MPI2 -ns)
+        add_test(NAME testXiosRead_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testXiosRead_MPI2 -ns)
+        add_test(NAME testXiosWrite_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testXiosWrite_MPI2 -ns)
     else()
         add_executable(testRectGrid_MPI3 "RectGrid_test.cpp" "MainMPI.cpp")
         target_compile_definitions(
@@ -156,7 +167,14 @@ if(ENABLE_MPI)
             PRIVATE ${MODEL_INCLUDE_DIR} "${ModulesRoot}/StructureModule"
         )
         target_link_libraries(testParaGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
+
+        # In the MPI tests it's important to include the "-ns" flag which tells doctest to fail if test has been skipped.
+        # Without this, the test will technically pass if we run with fewer ranks than requested.
+        add_test(NAME testRectGrid_MPI3 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 testRectGrid_MPI3 -ns)
+        add_test(NAME testParaGrid_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testParaGrid_MPI2 -ns)
+        add_test(NAME testConfigOutput_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testConfigOutput_MPI2 -ns)
     endif()
+
 else()
     add_executable(testRectGrid "RectGrid_test.cpp")
     target_compile_definitions(testRectGrid PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
@@ -281,6 +299,25 @@ else()
     )
     target_include_directories(testModelArraySlice PRIVATE "../src" "${MODEL_INCLUDE_DIR}")
     target_link_libraries(testModelArraySlice PRIVATE doctest::doctest Eigen3::Eigen)
+
+    add_test(NAME testRectGrid COMMAND testRectGrid)
+    add_test(NAME testParaGrid COMMAND testParaGrid)
+    add_test(NAME testConfigOutput COMMAND testConfigOutput)
+    add_test(NAME testIterator COMMAND testIterator)
+    add_test(NAME testCommandLineParser COMMAND testCommandLineParser)
+    add_test(NAME testConfigurator COMMAND testConfigurator)
+    add_test(NAME testConfiguredModule COMMAND testConfiguredModule)
+    add_test(NAME testTimeClasses COMMAND testTimeClasses)
+    add_test(NAME testModelComponent COMMAND testModelComponent)
+    add_test(NAME testModelArrayRef COMMAND testModelArrayRef)
+    add_test(NAME testPrognosticData COMMAND testPrognosticData)
+    add_test(NAME testPrognosticDataIO COMMAND testPrognosticDataIO)
+    add_test(NAME testMonthlyCubicBSpline COMMAND testMonthlyCubicBSpline)
+    add_test(NAME testFileCallbackCloser COMMAND testFileCallbackCloser)
+    add_test(NAME testFinalizer COMMAND testFinalizer)
+    add_test(NAME testModelArray COMMAND testModelArray)
+    add_test(NAME testSlice COMMAND testSlice)
+    add_test(NAME testModelArraySlice COMMAND testModelArraySlice)
 
     # The help config test needs access to the full binary
     file(CREATE_LINK ${NEXTSIM_BINARY_PATH} ${CMAKE_CURRENT_BINARY_DIR}/nextsim SYMBOLIC)

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -103,16 +103,25 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosWrite_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-        # In the MPI tests it's important to include the "-ns" flag which tells doctest to fail if test has been skipped.
-        # Without this, the test will technically pass if we run with fewer ranks than requested.
-        add_test(NAME testXiosCalendar_MPI1 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 testXiosCalendar_MPI1 -ns)
-        add_test(NAME testXiosAxis_MPI3 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 testXiosAxis_MPI3 -ns)
-        add_test(NAME testXiosDomain_MPI4 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 testXiosDomain_MPI4 -ns)
-        add_test(NAME testXiosGrid_MPI4 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 4 testXiosGrid_MPI4 -ns)
-        add_test(NAME testXiosField_MPI3 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 testXiosField_MPI3 -ns)
-        add_test(NAME testXiosFile_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testXiosFile_MPI2 -ns)
-        add_test(NAME testXiosRead_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testXiosRead_MPI2 -ns)
-        add_test(NAME testXiosWrite_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testXiosWrite_MPI2 -ns)
+        # In the MPI tests it's important to include the "-ns" flag which tells
+        # doctest to fail if test has been skipped. Without this, the test will
+        # technically pass if we run with fewer ranks than requested.
+        add_test(NAME testXiosCalendar_MPI1 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 1 testXiosCalendar_MPI1 -ns)
+        add_test(NAME testXiosAxis_MPI3 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 3 testXiosAxis_MPI3 -ns)
+        add_test(NAME testXiosDomain_MPI4 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 4 testXiosDomain_MPI4 -ns)
+        add_test(NAME testXiosGrid_MPI4 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 4 testXiosGrid_MPI4 -ns)
+        add_test(NAME testXiosField_MPI3 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 3 testXiosField_MPI3 -ns)
+        add_test(NAME testXiosFile_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 2 testXiosFile_MPI2 -ns)
+        add_test(NAME testXiosRead_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 2 testXiosRead_MPI2 -ns)
+        add_test(NAME testXiosWrite_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 2 testXiosWrite_MPI2 -ns)
     else()
         add_executable(testRectGrid_MPI3 "RectGrid_test.cpp" "MainMPI.cpp")
         target_compile_definitions(
@@ -168,11 +177,15 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testParaGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-        # In the MPI tests it's important to include the "-ns" flag which tells doctest to fail if test has been skipped.
-        # Without this, the test will technically pass if we run with fewer ranks than requested.
-        add_test(NAME testRectGrid_MPI3 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 3 testRectGrid_MPI3 -ns)
-        add_test(NAME testParaGrid_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testParaGrid_MPI2 -ns)
-        add_test(NAME testConfigOutput_MPI2 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 testConfigOutput_MPI2 -ns)
+        # In the MPI tests it's important to include the "-ns" flag which tells
+        # doctest to fail if test has been skipped. Without this, the test will
+        # technically pass if we run with fewer ranks than requested.
+        add_test(NAME testRectGrid_MPI3 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 3 testRectGrid_MPI3 -ns)
+        add_test(NAME testParaGrid_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 2 testParaGrid_MPI2 -ns)
+        add_test(NAME testConfigOutput_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
+            ${MPIEXEC_NUMPROC_FLAG} 2 testConfigOutput_MPI2 -ns)
     endif()
 
 else()

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -19,6 +19,29 @@ include_directories(${COMMON_INCLUDE_DIRS})
 set(MODEL_INCLUDE_DIR "../../core/src/discontinuousgalerkin")
 
 if(ENABLE_MPI)
+
+    # This function takes a list of test executables and adds them to the test suite
+    function(add_mpi_test test_exec_list)
+        foreach(test_exec IN LISTS test_exec_list)
+            # Extract the number of MPI ranks from the test name (e.g., TestName_MPI3 -> 3)
+            string(REGEX MATCH "_MPI([0-9]+)$" _match "${test_exec}")
+            set(num_ranks "${CMAKE_MATCH_1}")
+            if(num_ranks)
+                # In the MPI tests it's important to include the "-ns" flag which
+                # tells doctest to fail if test has been skipped. Without this, the
+                # test will technically pass if we run with fewer ranks than
+                # requested.
+                add_test(
+                    NAME ${test_exec}
+                    COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG}
+                    ${num_ranks} ${test_exec} -ns
+                )
+            else()
+                message(WARNING "Could not extract MPI rank from test name: ${test_exec}")
+            endif()
+        endforeach()
+    endfunction()
+
     if(ENABLE_XIOS)
         set(XIOS_INCLUDE_LIST
             "${xios_INCLUDES}"
@@ -103,25 +126,18 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosWrite_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-        # In the MPI tests it's important to include the "-ns" flag which tells
-        # doctest to fail if test has been skipped. Without this, the test will
-        # technically pass if we run with fewer ranks than requested.
-        add_test(NAME testXiosCalendar_MPI1 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 1 testXiosCalendar_MPI1 -ns)
-        add_test(NAME testXiosAxis_MPI3 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 3 testXiosAxis_MPI3 -ns)
-        add_test(NAME testXiosDomain_MPI4 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 4 testXiosDomain_MPI4 -ns)
-        add_test(NAME testXiosGrid_MPI4 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 4 testXiosGrid_MPI4 -ns)
-        add_test(NAME testXiosField_MPI3 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 3 testXiosField_MPI3 -ns)
-        add_test(NAME testXiosFile_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 2 testXiosFile_MPI2 -ns)
-        add_test(NAME testXiosRead_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 2 testXiosRead_MPI2 -ns)
-        add_test(NAME testXiosWrite_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 2 testXiosWrite_MPI2 -ns)
+        set(XIOS_TESTS
+            testXiosCalendar_MPI1
+            testXiosAxis_MPI3
+            testXiosDomain_MPI4
+            testXiosGrid_MPI4
+            testXiosField_MPI3
+            testXiosFile_MPI2
+            testXiosRead_MPI2
+            testXiosWrite_MPI2
+        )
+
+        add_mpi_test("${XIOS_TESTS}")
     else()
         add_executable(testRectGrid_MPI3 "RectGrid_test.cpp" "MainMPI.cpp")
         target_compile_definitions(
@@ -177,15 +193,12 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testParaGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-        # In the MPI tests it's important to include the "-ns" flag which tells
-        # doctest to fail if test has been skipped. Without this, the test will
-        # technically pass if we run with fewer ranks than requested.
-        add_test(NAME testRectGrid_MPI3 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 3 testRectGrid_MPI3 -ns)
-        add_test(NAME testParaGrid_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 2 testParaGrid_MPI2 -ns)
-        add_test(NAME testConfigOutput_MPI2 COMMAND ${MPIEXEC_EXECUTABLE}
-            ${MPIEXEC_NUMPROC_FLAG} 2 testConfigOutput_MPI2 -ns)
+        set(MPI_TESTS
+            testRectGrid_MPI3
+            testParaGrid_MPI2
+            testConfigOutput_MPI2
+        )
+        add_mpi_test("${MPI_TESTS}")
     endif()
 
 else()
@@ -313,24 +326,30 @@ else()
     target_include_directories(testModelArraySlice PRIVATE "../src" "${MODEL_INCLUDE_DIR}")
     target_link_libraries(testModelArraySlice PRIVATE doctest::doctest Eigen3::Eigen)
 
-    add_test(NAME testRectGrid COMMAND testRectGrid)
-    add_test(NAME testParaGrid COMMAND testParaGrid)
-    add_test(NAME testConfigOutput COMMAND testConfigOutput)
-    add_test(NAME testIterator COMMAND testIterator)
-    add_test(NAME testCommandLineParser COMMAND testCommandLineParser)
-    add_test(NAME testConfigurator COMMAND testConfigurator)
-    add_test(NAME testConfiguredModule COMMAND testConfiguredModule)
-    add_test(NAME testTimeClasses COMMAND testTimeClasses)
-    add_test(NAME testModelComponent COMMAND testModelComponent)
-    add_test(NAME testModelArrayRef COMMAND testModelArrayRef)
-    add_test(NAME testPrognosticData COMMAND testPrognosticData)
-    add_test(NAME testPrognosticDataIO COMMAND testPrognosticDataIO)
-    add_test(NAME testMonthlyCubicBSpline COMMAND testMonthlyCubicBSpline)
-    add_test(NAME testFileCallbackCloser COMMAND testFileCallbackCloser)
-    add_test(NAME testFinalizer COMMAND testFinalizer)
-    add_test(NAME testModelArray COMMAND testModelArray)
-    add_test(NAME testSlice COMMAND testSlice)
-    add_test(NAME testModelArraySlice COMMAND testModelArraySlice)
+    set(TEST_EXECUTABLES
+        testRectGrid
+        testParaGrid
+        testConfigOutput
+        testIterator
+        testCommandLineParser
+        testConfigurator
+        testConfiguredModule
+        testTimeClasses
+        testModelComponent
+        testModelArrayRef
+        testPrognosticData
+        testPrognosticDataIO
+        testMonthlyCubicBSpline
+        testFileCallbackCloser
+        testFinalizer
+        testModelArray
+        testSlice
+        testModelArraySlice
+    )
+
+    foreach(test_exec IN LISTS TEST_EXECUTABLES)
+        add_test(NAME ${test_exec} COMMAND ${test_exec})
+    endforeach()
 
     # The help config test needs access to the full binary
     file(CREATE_LINK ${NEXTSIM_BINARY_PATH} ${CMAKE_CURRENT_BINARY_DIR}/nextsim SYMBOLIC)

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -219,3 +219,28 @@ build arguments (``--build-arg`` that can be specified at build time). For examp
 
 For a full list of options, please see ``Dockerfile.production``. By default ``MPI`` and ``xios``
 options are disabled and the number of build jobs is 1.
+
+Running Tests
+-------------
+
+After building the code, you can run the tests provided with the repository using `ctest`. This ensures that the installation and build process was successful.
+
+To run all tests, navigate to the `build` directory and execute:
+
+.. code-block:: console
+
+    ctest
+
+If you want to see more detailed output for each test, use the `-V` option:
+
+.. code-block:: console
+
+    ctest -V
+
+If you want to run a subset of tests, you can use the `-R` option with a regular expression to match the test names. For example, to run only the tests related to `XIOS`, use:
+
+.. code-block:: console
+
+    ctest -R XIOS
+
+For more information on `ctest` options, you can refer to the official `ctest` documentation.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -241,6 +241,6 @@ If you want to run a subset of tests, you can use the `-R` option with a regular
 
 .. code-block:: console
 
-    ctest -R XIOS
+    ctest -R Xios
 
 For more information on `ctest` options, you can refer to the official `ctest` documentation.

--- a/dynamics/CMakeLists.txt
+++ b/dynamics/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(src)
 
 if(BUILD_TESTS)
+    enable_testing()
     add_subdirectory(test)
 endif()
 

--- a/dynamics/test/CMakeLists.txt
+++ b/dynamics/test/CMakeLists.txt
@@ -102,4 +102,12 @@ if(NOT ENABLE_MPI)
         PRIVATE "${CoreDir}" "${SRC_DIR}" "${CoreDir}/${ModelArrayStructure}"
     )
     target_link_libraries(testAdvectionPeriodicBC LINK_PUBLIC doctest::doctest Eigen3::Eigen)
+
+    add_test(NAME testDGModelArray COMMAND testDGModelArray)
+    add_test(NAME testDGVectorHolder COMMAND testDGVectorHolder)
+    add_test(NAME testCGModelArray COMMAND testCGModelArray)
+    add_test(NAME testParametricMesh COMMAND testParametricMesh)
+    add_test(NAME testParametricMeshArea COMMAND testParametricMeshArea)
+    add_test(NAME testAdvection COMMAND testAdvection)
+    add_test(NAME testAdvectionPeriodicBC COMMAND testAdvectionPeriodicBC)
 endif()

--- a/dynamics/test/CMakeLists.txt
+++ b/dynamics/test/CMakeLists.txt
@@ -103,11 +103,17 @@ if(NOT ENABLE_MPI)
     )
     target_link_libraries(testAdvectionPeriodicBC LINK_PUBLIC doctest::doctest Eigen3::Eigen)
 
-    add_test(NAME testDGModelArray COMMAND testDGModelArray)
-    add_test(NAME testDGVectorHolder COMMAND testDGVectorHolder)
-    add_test(NAME testCGModelArray COMMAND testCGModelArray)
-    add_test(NAME testParametricMesh COMMAND testParametricMesh)
-    add_test(NAME testParametricMeshArea COMMAND testParametricMeshArea)
-    add_test(NAME testAdvection COMMAND testAdvection)
-    add_test(NAME testAdvectionPeriodicBC COMMAND testAdvectionPeriodicBC)
+    set(TEST_EXECUTABLES
+        testDGModelArray
+        testDGVectorHolder
+        testCGModelArray
+        testParametricMesh
+        testParametricMeshArea
+        testAdvection
+        testAdvectionPeriodicBC
+    )
+
+    foreach(test_exec IN LISTS TEST_EXECUTABLES)
+        add_test(NAME ${test_exec} COMMAND ${test_exec})
+    endforeach()
 endif()

--- a/physics/CMakeLists.txt
+++ b/physics/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(src)
 if(BUILD_TESTS)
+    enable_testing()
     add_subdirectory(test)
 endif()
 

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -38,10 +38,13 @@ if(ENABLE_MPI)
     )
     target_link_libraries(testTOPAZOcn_MPI1 PRIVATE nextsimlib doctest::doctest)
 
-    # In the MPI tests it's important to include the "-ns" flag which tells doctest to fail if test has been skipped.
-    # Without this, the test will technically pass if we run with fewer ranks than requested.
-    add_test(NAME testERA5Atm_MPI1 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 testERA5Atm_MPI1 -ns)
-    add_test(NAME testTOPAZOcn_MPI1 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 testTOPAZOcn_MPI1 -ns)
+    # In the MPI tests it's important to include the "-ns" flag which tells
+    # doctest to fail if test has been skipped. Without this, the test will
+    # technically pass if we run with fewer ranks than requested.
+    add_test(NAME testERA5Atm_MPI1
+        COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 testERA5Atm_MPI1 -ns)
+    add_test(NAME testTOPAZOcn_MPI1 COMMAND
+        ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 testTOPAZOcn_MPI1 -ns)
 else()
     add_executable(testERA5Atm "ERA5Atm_test.cpp")
     target_compile_definitions(testERA5Atm PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -37,6 +37,11 @@ if(ENABLE_MPI)
         PRIVATE USE_MPI TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\"
     )
     target_link_libraries(testTOPAZOcn_MPI1 PRIVATE nextsimlib doctest::doctest)
+
+    # In the MPI tests it's important to include the "-ns" flag which tells doctest to fail if test has been skipped.
+    # Without this, the test will technically pass if we run with fewer ranks than requested.
+    add_test(NAME testERA5Atm_MPI1 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 testERA5Atm_MPI1 -ns)
+    add_test(NAME testTOPAZOcn_MPI1 COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 1 testTOPAZOcn_MPI1 -ns)
 else()
     add_executable(testERA5Atm "ERA5Atm_test.cpp")
     target_compile_definitions(testERA5Atm PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}\")
@@ -118,4 +123,19 @@ else()
         PRIVATE "${ModulesRoot}/DamageHealingModule" "${ModulesRoot}/DamageHealingModule"
     )
     target_link_libraries(testDamageHealing PRIVATE nextsimlib doctest::doctest)
+
+    add_test(NAME testERA5Atm COMMAND testERA5Atm)
+    add_test(NAME testTOPAZOcn COMMAND testTOPAZOcn)
+    add_test(NAME testIceGrowth COMMAND testIceGrowth)
+    add_test(NAME testThermoWinton COMMAND testThermoWinton)
+    add_test(NAME testFEFluxes COMMAND testFEFluxes)
+    add_test(NAME testBIOHFluxes COMMAND testBIOHFluxes)
+    add_test(NAME testSpecHum COMMAND testSpecHum)
+    add_test(NAME testThermoIce0 COMMAND testThermoIce0)
+    add_test(NAME testIceMinima COMMAND testIceMinima)
+    add_test(NAME testConstantOcn COMMAND testConstantOcn)
+    add_test(NAME testSlabOcn COMMAND testSlabOcn)
+    add_test(NAME testUniformOcean COMMAND testUniformOcean)
+    add_test(NAME testBenchmarkBoundaries COMMAND testBenchmarkBoundaries)
+    add_test(NAME testDamageHealing COMMAND testDamageHealing)
 endif()

--- a/physics/test/CMakeLists.txt
+++ b/physics/test/CMakeLists.txt
@@ -127,18 +127,24 @@ else()
     )
     target_link_libraries(testDamageHealing PRIVATE nextsimlib doctest::doctest)
 
-    add_test(NAME testERA5Atm COMMAND testERA5Atm)
-    add_test(NAME testTOPAZOcn COMMAND testTOPAZOcn)
-    add_test(NAME testIceGrowth COMMAND testIceGrowth)
-    add_test(NAME testThermoWinton COMMAND testThermoWinton)
-    add_test(NAME testFEFluxes COMMAND testFEFluxes)
-    add_test(NAME testBIOHFluxes COMMAND testBIOHFluxes)
-    add_test(NAME testSpecHum COMMAND testSpecHum)
-    add_test(NAME testThermoIce0 COMMAND testThermoIce0)
-    add_test(NAME testIceMinima COMMAND testIceMinima)
-    add_test(NAME testConstantOcn COMMAND testConstantOcn)
-    add_test(NAME testSlabOcn COMMAND testSlabOcn)
-    add_test(NAME testUniformOcean COMMAND testUniformOcean)
-    add_test(NAME testBenchmarkBoundaries COMMAND testBenchmarkBoundaries)
-    add_test(NAME testDamageHealing COMMAND testDamageHealing)
+    set(TEST_EXECUTABLES
+        testERA5Atm
+        testTOPAZOcn
+        testIceGrowth
+        testThermoWinton
+        testFEFluxes
+        testBIOHFluxes
+        testSpecHum
+        testThermoIce0
+        testIceMinima
+        testConstantOcn
+        testSlabOcn
+        testUniformOcean
+        testBenchmarkBoundaries
+        testDamageHealing
+    )
+
+    foreach(test_exec IN LISTS TEST_EXECUTABLES)
+        add_test(NAME ${test_exec} COMMAND ${test_exec})
+    endforeach()
 endif()


### PR DESCRIPTION
fixes #734

I have added functionality to run the tests with `ctest` instead of running them manually with a script. This matches the approach used in the `decomp` tool

e.g.,

```bash
cd build
ctest
```

Or if you want verbose output:
```bash
cd build
ctest -V
```

And you can use regex's to run a subset if you want (e.g., run only the Xios tests):
```bash
cd build
ctest -R Xios
```