### PR TITLE
XIOS: Inline name setters and remove name getters

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1228,24 +1228,6 @@ void Xios::createField(const std::string fieldId)
 }
 
 /*!
- * Set the name of a field with a given ID
- *
- * @param the field ID
- * @param name to set
- */
-void Xios::setFieldName(const std::string fieldId, const std::string fieldName)
-{
-    xios::CField* field = getField(fieldId);
-    if (cxios_is_defined_field_name(field)) {
-        Logged::warning("Xios: Overwriting name for field '" + fieldId + "'");
-    }
-    cxios_set_field_name(field, fieldName.c_str(), fieldName.length());
-    if (!cxios_is_defined_field_name(field)) {
-        throw std::runtime_error("Xios: Failed to set name for field '" + fieldId + "'");
-    }
-}
-
-/*!
  * Set the operation for a field with a given ID
  *
  * @param the field ID
@@ -1316,23 +1298,6 @@ void Xios::setFieldFreqOffset(const std::string fieldId, const Duration freqOffs
         throw std::runtime_error(
             "Xios: Failed to set frequency offset for field '" + fieldId + "'");
     }
-}
-
-/*!
- * Get the name of a field with a given ID
- *
- * @param the field ID
- * @return name of the corresponding field
- */
-std::string Xios::getFieldName(const std::string fieldId)
-{
-    xios::CField* field = getField(fieldId);
-    if (!cxios_is_defined_field_name(field)) {
-        throw std::runtime_error("Xios: Undefined name for field '" + fieldId + "'");
-    }
-    char cStr[cStrLen];
-    cxios_get_field_name(field, cStr, cStrLen);
-    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -1518,9 +1483,15 @@ void Xios::createFile(const std::string fileId)
     // XiosInput.field_names or XiosOutput.field_names entries in the config.
     for (std::string fieldId : configGetFieldNames(readAccess)) {
         createField(fieldId);
-        setFieldName(fieldId, fieldId);
         fileAddField(fileId, fieldId);
         setFieldReadAccess(fieldId, readAccess);
+
+        // Set field name
+        xios::CField* field = getField(fieldId);
+        cxios_set_field_name(field, fieldId.c_str(), fieldId.length());
+        if (!cxios_is_defined_field_name(field)) {
+            throw std::runtime_error("Xios: Failed to set name for field '" + fieldId + "'");
+        }
     }
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -3,7 +3,7 @@
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    14 May 2025
+ * @date    19 May 2025
  * @brief   XIOS interface implementation
  * @details
  *
@@ -488,7 +488,8 @@ void Xios::createAxis(const std::string axisId)
         throw std::runtime_error("Xios: Failed to create axis '" + axisId + "'");
     }
     if (axisId == "z_axis") {
-        std::string domainId = "xy_domain";
+        // Create grid_3D associated with a domain called xy_domain and an axis called z_axis
+        const std::string domainId = "xy_domain";
         cxios_domain_valid_id(&exists, domainId.c_str(), domainId.length());
         if (exists) {
             createGrid("grid_3D");
@@ -641,9 +642,13 @@ void Xios::createDomain(const std::string domainId)
         throw std::runtime_error("Xios: Failed to create domain '" + domainId + "'");
     }
     if (domainId == "xy_domain") {
-        createGrid("grid_2D");
-        gridAddDomain("grid_2D", "xy_domain");
-        std::string axisId = "z_axis";
+        // Create grid_2D associated with a domain called xy_domain
+        const std::string gridId = "grid_2D";
+        createGrid(gridId);
+        gridAddDomain(gridId, "xy_domain");
+
+        // Create grid_3D if there is also an axis called z_axis
+        const std::string axisId = "z_axis";
         cxios_axis_valid_id(&exists, axisId.c_str(), axisId.length());
         if (exists) {
             createGrid("grid_3D");
@@ -1046,6 +1051,7 @@ void Xios::createGrid(const std::string gridId)
     if (!exists) {
         throw std::runtime_error("Xios: Failed to create grid '" + gridId + "'");
     }
+    setGridName(gridId, gridId);
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1094,7 +1094,7 @@ void Xios::gridAddDomain(const std::string gridId, const std::string domainId)
  * @param the grid ID
  * @return all axis IDs associated with the grid
  */
-std::vector<std::string> Xios::gridGetAxisIds(const std::string gridId)
+std::vector<std::string> Xios::getGridAxisIds(const std::string gridId)
 {
     return getGrid(gridId)->getAxisList();
 }
@@ -1105,7 +1105,7 @@ std::vector<std::string> Xios::gridGetAxisIds(const std::string gridId)
  * @param the grid ID
  * @return all domain IDs associated with the grid
  */
-std::vector<std::string> Xios::gridGetDomainIds(const std::string gridId)
+std::vector<std::string> Xios::getGridDomainIds(const std::string gridId)
 {
     return getGrid(gridId)->getDomainList();
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -91,7 +91,14 @@ Xios::Xios(const std::string contextid, const std::string calendartype)
             if (filenameStr.length() > 0) {
                 filenameStr = ((std::filesystem::path)filenameStr).replace_extension();
                 createFile(filenameStr);
-                setFileName(filenameStr, filenameStr);
+
+                // Set file name
+                xios::CFile* file = getFile(filenameStr);
+                cxios_set_file_name(file, filenameStr.c_str(), filenameStr.length());
+                if (!cxios_is_defined_file_name(file)) {
+                    throw std::runtime_error(
+                        "Xios: Failed to set name for file '" + filenameStr + "'");
+                }
             }
         }
     }
@@ -1518,24 +1525,6 @@ void Xios::createFile(const std::string fileId)
 }
 
 /*!
- * Set the name of a file with a given ID
- *
- * @param the file ID
- * @param file name to set
- */
-void Xios::setFileName(const std::string fileId, const std::string fileName)
-{
-    xios::CFile* file = getFile(fileId);
-    if (cxios_is_defined_file_name(file)) {
-        Logged::warning("Xios: Overwriting name for file '" + fileId + "'");
-    }
-    cxios_set_file_name(file, fileName.c_str(), fileName.length());
-    if (!cxios_is_defined_file_name(file)) {
-        throw std::runtime_error("Xios: Failed to set name for file '" + fileId + "'");
-    }
-}
-
-/*!
  * Set the type of a file with a given ID
  *
  * @param the file ID
@@ -1623,23 +1612,6 @@ void Xios::setFileParAccess(const std::string fileId, const std::string parAcces
     if (!cxios_is_defined_file_par_access(file)) {
         throw std::runtime_error("Xios: Failed to set parallel access for file '" + fileId + "'");
     }
-}
-
-/*!
- * Get the name of a file with a given ID
- *
- * @param the file ID
- * @return name of the corresponding file
- */
-std::string Xios::getFileName(const std::string fileId)
-{
-    xios::CFile* file = getFile(fileId);
-    if (!cxios_is_defined_file_name(file)) {
-        throw std::runtime_error("Xios: Undefined name for file '" + fileId + "'");
-    }
-    char cStr[cStrLen];
-    cxios_get_file_name(file, cStr, cStrLen);
-    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1051,39 +1051,7 @@ void Xios::createGrid(const std::string gridId)
     if (!exists) {
         throw std::runtime_error("Xios: Failed to create grid '" + gridId + "'");
     }
-    setGridName(gridId, gridId);
-}
-
-/*!
- * Get the name of a grid with a given ID
- *
- * @param the grid ID
- * @return name of the corresponding grid
- */
-std::string Xios::getGridName(const std::string gridId)
-{
-    xios::CGrid* grid = getGrid(gridId);
-    if (!cxios_is_defined_grid_name(grid)) {
-        throw std::runtime_error("Xios: Undefined name for grid '" + gridId + "'");
-    }
-    char cStr[cStrLen];
-    cxios_get_grid_name(grid, cStr, cStrLen);
-    return convertCStrToCppStr(cStr, cStrLen);
-}
-
-/*!
- * Set the name of a grid with a given ID
- *
- * @param the grid ID
- * @param name to set
- */
-void Xios::setGridName(const std::string gridId, const std::string gridName)
-{
-    xios::CGrid* grid = getGrid(gridId);
-    if (cxios_is_defined_grid_name(grid)) {
-        Logged::warning("Xios: Overwriting name for grid '" + gridId + "'");
-    }
-    cxios_set_grid_name(grid, gridName.c_str(), gridName.length());
+    cxios_set_grid_name(grid, gridId.c_str(), gridId.length());
     if (!cxios_is_defined_grid_name(grid)) {
         throw std::runtime_error("Xios: Failed to set name for grid '" + gridId + "'");
     }

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -136,7 +136,6 @@ public:
     void setFileOutputFreq(const std::string fileId, const Duration outputFreq);
     void setFileSplitFreq(const std::string fileId, const Duration splitFreq);
     void setFileParAccess(const std::string fileId, const std::string parAccess);
-    std::string getFileName(const std::string fileId);
     std::string getFileType(const std::string fileId);
     Duration getFileOutputFreq(const std::string fileId);
     Duration getFileSplitFreq(const std::string fileId);
@@ -212,7 +211,6 @@ private:
     /* File */
     xios::CFileGroup* getFileGroup();
     xios::CFile* getFile(const std::string fileId);
-    void setFileName(const std::string fileId, const std::string fileName);
     void setFileMode(const std::string fileId, const std::string mode);
 };
 

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -116,8 +116,8 @@ public:
     void createGrid(const std::string gridId);
     void gridAddAxis(std::string axisId, const std::string domainId);
     void gridAddDomain(const std::string gridId, const std::string domainId);
-    std::vector<std::string> gridGetAxisIds(const std::string gridId);
-    std::vector<std::string> gridGetDomainIds(const std::string gridId);
+    std::vector<std::string> getGridAxisIds(const std::string gridId);
+    std::vector<std::string> getGridDomainIds(const std::string gridId);
 
     /* Field */
     void createField(const std::string fieldId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -3,7 +3,7 @@
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    12 May 2025
+ * @date    19 May 2025
  * @brief   XIOS interface header
  * @details
  *
@@ -114,8 +114,6 @@ public:
 
     /* Grid */
     void createGrid(const std::string gridId);
-    void setGridName(const std::string gridId, const std::string name);
-    std::string getGridName(const std::string gridId);
     void gridAddAxis(std::string axisId, const std::string domainId);
     void gridAddDomain(const std::string gridId, const std::string domainId);
     std::vector<std::string> gridGetAxisIds(const std::string gridId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -124,7 +124,6 @@ public:
     void setFieldOperation(const std::string fieldId, const std::string operation);
     void setFieldGridRef(const std::string fieldId, const std::string gridRef);
     void setFieldFreqOffset(const std::string fieldId, const Duration freqOffset);
-    std::string getFieldName(const std::string fieldId);
     std::string getFieldOperation(const std::string fieldId);
     std::string getFieldGridRef(const std::string fieldId);
     bool getFieldReadAccess(const std::string fieldId);
@@ -199,7 +198,6 @@ private:
     /* Field */
     xios::CFieldGroup* getFieldGroup();
     xios::CField* getField(const std::string fieldId);
-    void setFieldName(const std::string fieldId, const std::string name);
     void setFieldReadAccess(const std::string fieldId, const bool readAccess);
     std::vector<std::string> configGetFieldNames(const bool reading);
     bool configCheckField(const std::string fieldId, const bool reading);

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -2,7 +2,7 @@
  * @file    xios_c_interface.hpp
  * @author  Tom Meltzer <tdm39@cam.ac.uk>
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
- * @date    09 Dec 2024
+ * @date    19 May 2025
  * @brief   C interface for XIOS library
  * @details
  * This interface is based on an earlier version provided by Laurent as part of
@@ -131,7 +131,6 @@ void cxios_xml_tree_add_grid(
 void cxios_grid_handle_create(xios::CGrid** _ret, const char* _id, int _id_len);
 void cxios_grid_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_grid_name(xios::CGrid* _ret, const char* name, int name_size);
-void cxios_get_grid_name(xios::CGrid* _ret, char* name, int name_size);
 bool cxios_is_defined_grid_name(xios::CGrid* file_hdl);
 void cxios_xml_tree_add_axistogrid(
     xios::CGrid* grid, xios::CAxis** axis, const char* _id, int _id_len);
@@ -151,7 +150,6 @@ void cxios_set_field_operation(xios::CField* _ret, const char* operation, int op
 void cxios_set_field_grid_ref(xios::CField* _ret, const char* grid_ref, int grid_ref_size);
 void cxios_set_field_read_access(xios::CField* _ret, bool read_access);
 void cxios_set_field_freq_offset(xios::CField* _ret, cxios_duration freq_offset);
-void cxios_get_field_name(xios::CField* _ret, char* name, int name_size);
 void cxios_get_field_operation(xios::CField* _ret, char* operation, int operation_size);
 void cxios_get_field_grid_ref(xios::CField* _ret, char* grid_ref, int grid_ref_size);
 void cxios_get_field_read_access(xios::CField* _ret, bool* read_access);
@@ -176,7 +174,6 @@ void cxios_set_file_output_freq(xios::CFile* file_hdl, cxios_duration output_fre
 void cxios_set_file_split_freq(xios::CFile* file_hdl, cxios_duration split_freq_c);
 void cxios_set_file_mode(xios::CFile* file_hdl, const char* mode, int mode_size);
 void cxios_set_file_par_access(xios::CFile* file_hdl, const char* par_access, int par_access_size);
-void cxios_get_file_name(xios::CFile* file_hdl, char* name, int name_size);
 void cxios_get_file_type(xios::CFile* file_hdl, char* type, int type_size);
 void cxios_get_file_output_freq(xios::CFile* file_hdl, cxios_duration* output_freq_c);
 void cxios_get_file_split_freq(xios::CFile* file_hdl, cxios_duration* split_freq_c);

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -2,7 +2,7 @@
  * @file    XiosField_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    14 May 2025
+ * @date    19 May 2025
  * @brief   Tests for XIOS fields
  * @details
  * This test is designed to test field functionality of the C++ interface
@@ -64,9 +64,6 @@ MPI_TEST_CASE("TestXiosField", 3)
     // Disallow creation of fields that aren't in either config section
     REQUIRE_THROWS_WITH(xiosHandler.createField("field_B"),
         "Xios: Field 'field_B' cannot be found in the XiosInput or XiosOutput config sections");
-    // Field name
-    // NOTE: This is set to the fieldId when a field is created
-    REQUIRE(xiosHandler.getFieldName(fieldId) == fieldId);
     // Operation
     REQUIRE_THROWS_WITH(
         xiosHandler.getFieldOperation(fieldId), "Xios: Undefined operation for field 'field_A'");

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -2,7 +2,7 @@
  * @file    XiosFile_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    14 May 2025
+ * @date    19 May 2025
  * @brief   Tests for XIOS file
  * @details
  * This test is designed to test file functionality of the C++ interface
@@ -79,16 +79,12 @@ MPI_TEST_CASE("TestXiosFile", 2)
     const std::string inFileId = "xios_test_input";
     const std::string outFileId = "xios_test_output";
     REQUIRE_THROWS_WITH(
-        xiosHandler.getFileName("unittest_undef"), "Xios: Undefined file 'unittest_undef'");
+        xiosHandler.getFileType("unittest_undef"), "Xios: Undefined file 'unittest_undef'");
     // File creation
     // NOTE: This is called based on the XiosInput.filename and XiosOutput.filename entries upon
     // initialization
     REQUIRE_THROWS_WITH(
         xiosHandler.createFile(outFileId), "Xios: File 'xios_test_output' already exists");
-    // File name
-    // NOTE: This is set based off the XiosInput.filename and XiosOutput.filename entries when a
-    // file is created
-    REQUIRE(xiosHandler.getFileName(outFileId) == outFileId);
     // File type
     // NOTE: This is to "one_file" when createFile is called
     REQUIRE(xiosHandler.getFileType(outFileId) == "one_file");

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -2,7 +2,7 @@
  * @file    XiosGrid_test.cpp
  * @author  Joe Wallwork <jw2423@cam.ac.uk>
  * @author  Adeleke Bankole <ab3191@cam.ac.uk>
- * @date    23 Apr 2025
+ * @date    19 May 2025
  * @brief   Tests for XIOS grid
  * @details
  * This test is designed to test grid functionality of the C++ interface
@@ -52,14 +52,9 @@ MPI_TEST_CASE("TestXiosGrid", 4)
 
     // --- Tests for grid API
     const std::string gridId = { "grid_2D" };
-    REQUIRE_THROWS_WITH(xiosHandler.getGridName(gridId), "Xios: Undefined grid 'grid_2D'");
+    REQUIRE_THROWS_WITH(xiosHandler.getGridAxisIds(gridId), "Xios: Undefined grid 'grid_2D'");
     xiosHandler.createGrid(gridId);
     REQUIRE_THROWS_WITH(xiosHandler.createGrid(gridId), "Xios: Grid 'grid_2D' already exists");
-    // Grid name
-    const std::string gridName = { "test_grid" };
-    REQUIRE_THROWS_WITH(xiosHandler.getGridName(gridId), "Xios: Undefined name for grid 'grid_2D'");
-    xiosHandler.setGridName(gridId, gridName);
-    REQUIRE(xiosHandler.getGridName(gridId) == gridName);
     // Add axis
     xiosHandler.gridAddAxis("grid_2D", "axis_Z");
     std::vector<std::string> axisIds = xiosHandler.gridGetAxisIds(gridId);

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -57,12 +57,12 @@ MPI_TEST_CASE("TestXiosGrid", 4)
     REQUIRE_THROWS_WITH(xiosHandler.createGrid(gridId), "Xios: Grid 'grid_2D' already exists");
     // Add axis
     xiosHandler.gridAddAxis("grid_2D", "axis_Z");
-    std::vector<std::string> axisIds = xiosHandler.gridGetAxisIds(gridId);
+    std::vector<std::string> axisIds = xiosHandler.getGridAxisIds(gridId);
     REQUIRE(axisIds.size() == 1);
     REQUIRE(axisIds[0] == "axis_Z");
     // Add domain
     xiosHandler.gridAddDomain("grid_2D", "domain_XY");
-    std::vector<std::string> domainIds = xiosHandler.gridGetDomainIds(gridId);
+    std::vector<std::string> domainIds = xiosHandler.getGridDomainIds(gridId);
     REQUIRE(domainIds.size() == 1);
     REQUIRE(domainIds[0] == "domain_XY");
 

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -16,31 +16,31 @@ Section under construction.
 Configuration
 -------------
 
-XIOS is configured automatically from files with `.cfg` extension that are
-passed to the `nextsim` executable. There are several configuration sections
+XIOS is configured automatically from files with ``.cfg`` extension that are
+passed to the ``nextsim`` executable. There are several configuration sections
 that are relevant to XIOS.
 
-The `xios` section contains a single entry, which determines whether or not to
+The ``xios`` section contains a single entry, which determines whether or not to
 build nextSIM-DG with XIOS as the I/O driver.
 
 .. code-block::
   [xios]
   enable = true
 
-The `model` section, which is used elsewhere in nextSIM-DG, contains two entries
-relevant to XIOS: `start` and `time_step`. These are used to configure the
-calendar used by XIOS and take the following default values.
+The ``model`` section, which is used elsewhere in nextSIM-DG, contains two
+entries relevant to XIOS: ``start`` and ``time_step``. These are used to
+configure the calendar used by XIOS and take the following default values.
 
 .. code-block::
   [model]
   start = 1970-01-01T00:00:00Z
   time_step = P0-0T01:00:00
 
-Files and fields to be read and written to files are configured via `XiosInput`
-and `XiosOutput` sections, which accept the same entries. For example, we could
-set the following values, which would specify two fields labelled `field_A` and
-`field_B`, which are written to file `my_output_file.nc` every two (simulated)
-hours.
+Files and fields to be read and written to files are configured via
+``XiosInput`` and ``XiosOutput`` sections, which accept the same entries. For
+example, we could set the following values, which would specify two fields
+labelled ``field_A`` and ``field_B``, which are written to file
+``my_output_file.nc`` every two (simulated) hours.
 
 .. code-block::
   [XiosOutput]
@@ -48,24 +48,24 @@ hours.
   filename = my_output_file.nc
   fields = field_A,field_B
 
-Note that both the `XiosInput` and `XiosOutput` sections are optional.
+Note that both the ``XiosInput`` and ``XiosOutput`` sections are optional.
 
 Developer notes
 ^^^^^^^^^^^^^^^
 
-The integration of XIOS into nextSIM-DG's is built around a static `Xios`
+The integration of XIOS into nextSIM-DG's is built around a static ``Xios``
 handler class, which provides a C++ API for the various XIOS functions. When the
 handler is instantiated, the config sections above will be parsed. Based on the
-values that are parsed, the handler object will automatically create `Field` and
-`File` data structures for XIOS and associate these as appropriate. If the
-`XiosInput` section is used, an attempt will be made to open the file provided
-by the `filename` entry. Note that the nextSIM-DG XIOS integration is set up
+values that are parsed, the handler object will automatically create ``Field``
+and ``File`` data structures for XIOS and associate these as appropriate. If the
+``XiosInput`` section is used, an attempt will be made to open the file provided
+by the ``filename`` entry. Note that the nextSIM-DG XIOS integration is set up
 such that the filename and field names coincide with the fileId and fieldId of
-the corresponding `File` and `Field` objects.
+the corresponding ``File`` and ``Field`` objects.
 
 XIOS requires information on the domain decomposition for it to be able to read
-and write data in parallel. This information is held by the `ModelMetadata`
+and write data in parallel. This information is held by the ``ModelMetadata``
 class, which may be constructed based off a partition metadata file. Upon
 construction of this object, if XIOS is enabled then the XIOS handler will
-automatically create a `Domain` data structure with the appropriate local and
+automatically create a ``Domain`` data structure with the appropriate local and
 global sizes and offsets.

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -59,7 +59,9 @@ handler is instantiated, the config sections above will be parsed. Based on the
 values that are parsed, the handler object will automatically create `Field` and
 `File` data structures for XIOS and associate these as appropriate. If the
 `XiosInput` section is used, an attempt will be made to open the file provided
-by the `filename` entry.
+by the `filename` entry. Note that the nextSIM-DG XIOS integration is set up
+such that the filename and field names coincide with the fileId and fieldId of
+the corresponding `File` and `Field` objects.
 
 XIOS requires information on the domain decomposition for it to be able to read
 and write data in parallel. This information is held by the `ModelMetadata`


### PR DESCRIPTION
# XIOS: Inline name setters and remove name getters

Towards #850.

The XIOS handler class currently supports setting and getting names for the XIOS File, Field, and Grids. However, it is most convenient to just use the same name as the ID for those objects. (In fact, we already do this in some cases.)

To reduce the amount of code to be maintained in the XIOS interface, the `setXName` methods are called once directly in the `createX` methods and inlined there. The corresponding `getXName` methods are dropped. The docs are updated to mention this.