### PR TITLE
Fixing how we pass evap and precip around

### DIFF
--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file ModelComponent.hpp
  *
- * @date 11 Feb 2025
+ * @date 23 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
@@ -52,8 +52,6 @@ namespace Protected {
     inline constexpr TextTag EXT_SST
         = "EXT_SST"; // sea surface temperature from coupling or forcing, ˚C
     inline constexpr TextTag SSH = "SSH"; // sea surface height, m
-    inline constexpr TextTag EVAP_MINUS_PRECIP
-        = "E-P"; // E-P atmospheric freshwater flux, kg s⁻¹ m⁻²
     // Derived fields, calculated once per timestep
     inline constexpr TextTag ML_BULK_CP = "CPML"; // Mixed layer bulk heat capacity J K⁻¹ m⁻²
     inline constexpr TextTag TF = "TF"; // Ocean freezing temperature, ˚C
@@ -98,6 +96,8 @@ namespace Shared {
     inline constexpr TextTag Q_SW_OW = "Q_SW_OW"; // Shortwave flux in open water W m⁻²
     inline constexpr TextTag Q_SW_BASE = "Q_SW_BASE"; // Shortwave flux at the base of the ice W m⁻²
     // Mass fluxes
+    inline constexpr TextTag EVAP = "EVAP"; // evaporation mass flux kg s⁻¹ m⁻²
+    inline constexpr TextTag RAIN = "RAIN"; // liquid mass flux kg s⁻¹ m⁻²
     inline constexpr TextTag HSNOW_MELT = "HSNOW_MELT"; // Thickness of snow that melted, m
     // Momentum fluxes
     inline constexpr TextTag OW_STRESS_X = "OW_STRESS_X"; // x(east)-ward open ocean stress, Pa

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ERA5Atmosphere.cpp
  *
- * @date 24 Sep 2024
+ * @date 23 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -77,7 +77,7 @@ void ERA5Atmosphere::update(const TimestepTime& tst)
     uwind = state.data.at("u");
     vwind = state.data.at("v");
     snow = 0; // FIXME get snow data
-    emp = 0; // FIXME get E - P data
+    rain = 0; // FIXME get rain data
 
     fluxImpl->update(tst);
 }

--- a/physics/src/modules/FluxCalculationModule/FiniteElementFluxes.cpp
+++ b/physics/src/modules/FluxCalculationModule/FiniteElementFluxes.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file FiniteElementFluxes.cpp
  *
- * @date 11 Feb 2025
+ * @date 23 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -88,7 +88,6 @@ ModelState FiniteElementFluxes::getStateDiagnostic() const
 void FiniteElementFluxes::setData(const ModelState::DataMap& ms)
 {
     // Data arrays can now be set to the correct size
-    evap.resize();
     Q_lh_ow.resize();
     Q_sh_ow.resize();
     Q_lw_ow.resize();
@@ -174,8 +173,7 @@ void FiniteElementFluxes::calculateIce(size_t i, const TimestepTime& tst)
     double dQlh_dT = latentHeatIce(tsurf[i]) * dmdot_dT;
 
     // Sensible heat flux
-    Q_sh_ia[i]
-        = dragIce_t * rho_air[i] * cp_air[i] * windSpeed[i] * (tsurf[i] - t_air[i]);
+    Q_sh_ia[i] = dragIce_t * rho_air[i] * cp_air[i] * windSpeed[i] * (tsurf[i] - t_air[i]);
     double dQsh_dT = dragIce_t * rho_air[i] * cp_air[i] * windSpeed[i];
 
     // Shortwave flux
@@ -189,8 +187,7 @@ void FiniteElementFluxes::calculateIce(size_t i, const TimestepTime& tst)
 
     // Longwave flux
     Q_lw_ia[i] = stefanBoltzmannLaw(tsurf[i]) - lw_in[i];
-    double dQlw_dT
-        = 4 / kelvin(tsurf[i]) * stefanBoltzmannLaw(tsurf[i]);
+    double dQlw_dT = 4 / kelvin(tsurf[i]) * stefanBoltzmannLaw(tsurf[i]);
 
     // Total flux
     qia[i] = Q_lh_ia[i] + Q_sh_ia[i] + Q_sw_ia[i] + Q_lw_ia[i];

--- a/physics/src/modules/FluxCalculationModule/include/FiniteElementFluxes.hpp
+++ b/physics/src/modules/FluxCalculationModule/include/FiniteElementFluxes.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file FiniteElementFluxes.hpp
  *
- * @date 25 Feb 2025
+ * @date 23 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -22,7 +22,6 @@ class FiniteElementFluxes : public IFluxCalculation, public Configured<FiniteEle
 public:
     FiniteElementFluxes()
         : iIceAlbedoImpl(nullptr)
-        , evap(ModelArray::Type::H)
         , Q_lh_ow(ModelArray::Type::H)
         , Q_sh_ow(ModelArray::Type::H)
         , Q_lw_ow(ModelArray::Type::H)
@@ -86,7 +85,6 @@ public:
 
 private:
     // Owned diagnostic fields
-    HField evap; // Open water evaporative mass flux [kg  m⁻²]
     HField Q_lh_ow; // Open water latent heat flux [W m⁻²]
     HField Q_sh_ow; // Open water sensible heat flux [W m⁻²]
     HField Q_lw_ow; // Open water net longwave radiative flux [W m⁻²]

--- a/physics/src/modules/include/IAtmosphereBoundary.hpp
+++ b/physics/src/modules/include/IAtmosphereBoundary.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IAtmosphereBoundary.hpp
  *
- * @date 11 Feb 2025
+ * @date 23 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -15,14 +15,21 @@
 namespace Nextsim {
 
 //! An interface class for the atmospheric inputs into the ice physics.
-class IAtmosphereBoundary: public ModelComponent {
+class IAtmosphereBoundary : public ModelComponent {
 public:
     IAtmosphereBoundary()
-            : qia(ModelArray::Type::H), dqia_dt(ModelArray::Type::H), qow(ModelArray::Type::H), subl(
-                    ModelArray::Type::H), snow(ModelArray::Type::H), rain(ModelArray::Type::H), evap(
-                    ModelArray::Type::H), emp(ModelArray::Type::H), uwind(ModelArray::Type::U), vwind(
-                    ModelArray::Type::V), penSW(ModelArray::Type::H), tauXOW(ModelArray::Type::H), tauYOW(
-                    ModelArray::Type::H)
+        : qia(ModelArray::Type::H)
+        , dqia_dt(ModelArray::Type::H)
+        , qow(ModelArray::Type::H)
+        , subl(ModelArray::Type::H)
+        , snow(ModelArray::Type::H)
+        , rain(ModelArray::Type::H)
+        , evap(ModelArray::Type::H)
+        , uwind(ModelArray::Type::U)
+        , vwind(ModelArray::Type::V)
+        , penSW(ModelArray::Type::H)
+        , tauXOW(ModelArray::Type::H)
+        , tauYOW(ModelArray::Type::H)
     {
         m_couplingArrays.registerArray(CouplingFields::SUBL, &subl, RW);
         m_couplingArrays.registerArray(CouplingFields::SNOW, &snow, RW);
@@ -38,17 +45,15 @@ public:
         getStore().registerArray(Shared::OW_STRESS_X, &tauXOW, RW);
         getStore().registerArray(Shared::OW_STRESS_Y, &tauYOW, RW);
         getStore().registerArray(Protected::SNOW, &snow, RO);
-        getStore().registerArray(Protected::EVAP_MINUS_PRECIP, &emp, RO);
+        getStore().registerArray(Shared::EVAP, &evap, RW);
+        getStore().registerArray(Shared::RAIN, &rain, RO);
         getStore().registerArray(Protected::WIND_U, &uwind, RO);
         getStore().registerArray(Protected::WIND_V, &vwind, RO);
         getStore().registerArray(Shared::Q_PEN_SW, &penSW, RW);
     }
     virtual ~IAtmosphereBoundary() = default;
 
-    std::string getName() const override
-    {
-        return "IAtmosphereBoundary";
-    }
+    std::string getName() const override { return "IAtmosphereBoundary"; }
     void setData(const ModelState::DataMap& ms) override
     {
         qia.resize();
@@ -58,22 +63,16 @@ public:
         snow.resize();
         rain.resize();
         evap.resize();
-        emp.resize();
         uwind.resize();
         vwind.resize();
         penSW.resize();
         tauXOW.resize();
         tauYOW.resize();
     }
-    virtual void update(const TimestepTime& tst)
-    {
-    }
+    virtual void update(const TimestepTime& tst) { }
 
 protected:
-    ModelArrayReferenceStore& couplingArrays()
-    {
-        return m_couplingArrays;
-    }
+    ModelArrayReferenceStore& couplingArrays() { return m_couplingArrays; }
 
     HField qia;
     HField dqia_dt;
@@ -82,7 +81,6 @@ protected:
     HField snow;
     HField rain;
     HField evap;
-    HField emp;
     UField uwind;
     VField vwind;
     HField penSW;

--- a/physics/src/modules/include/IFluxCalculation.hpp
+++ b/physics/src/modules/include/IFluxCalculation.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IFluxCalculation.hpp
  *
- * @date 11 Feb 2025
+ * @date 23 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -19,6 +19,7 @@ class IFluxCalculation : public ModelComponent {
 public:
     IFluxCalculation()
         : qow(getStore())
+        , evap(getStore())
         , subl(getStore())
         , qia(getStore())
         , penSW(getStore())
@@ -46,6 +47,7 @@ protected:
     // All fluxes are positive upwards, including incident radiation fluxes
     // The flux fields are owned by IAtmosphereBoundary
     ModelArrayRef<Shared::Q_OW, RW> qow;
+    ModelArrayRef<Shared::EVAP, RW> evap;
     ModelArrayRef<Shared::SUBLIM, RW> subl;
     ModelArrayRef<Shared::Q_IA, RW> qia;
     ModelArrayRef<Shared::Q_PEN_SW, RW> penSW;

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IOceanBoundary.hpp
  *
- * @date 29 Apr 2025
+ * @date 23 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -35,7 +35,8 @@ public:
         , tauX(ModelArray::Type::H)
         , tauY(ModelArray::Type::H)
         , cice(getStore())
-        , emp(getStore())
+        , evap(getStore())
+        , rain(getStore())
         , newIce(getStore())
         , deltaHice(getStore())
         , deltaSmelt(getStore())
@@ -150,7 +151,7 @@ private:
         // Positive flux is up!
         fwFlux[i]
             = ((1 - effectiveIceSal) * Ice::rho * deltaIceVol + Ice::rhoSnow * meltSnowVol) / dt
-            + emp[i] * (1 - cice[i]);
+            + (evap[i] - rain[i]) * (1 - cice[i]);
         sFlux[i] = effectiveIceSal * Ice::rho * deltaIceVol / dt;
 
         // Momentum fluxes
@@ -180,9 +181,10 @@ protected:
     ModelArrayReferenceStore m_couplingArrays;
 
     ModelArrayRef<Protected::C_ICE, RO> cice;
-    ModelArrayRef<Protected::EVAP_MINUS_PRECIP, RO> emp;
     ModelArrayRef<Protected::IO_STRESS_X> tauXIO;
     ModelArrayRef<Protected::IO_STRESS_X> tauYIO;
+    ModelArrayRef<Shared::EVAP, RW> evap;
+    ModelArrayRef<Shared::RAIN, RO> rain;
     ModelArrayRef<Shared::NEW_ICE, RW> newIce;
     ModelArrayRef<Shared::DELTA_HICE, RW> deltaHice;
     ModelArrayRef<Shared::HSNOW_MELT, RW> deltaSmelt;

--- a/physics/test/FiniteElementFluxes_test.cpp
+++ b/physics/test/FiniteElementFluxes_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file FiniteElementFluxes_test.cpp
  *
- * @date 11 Feb 2025
+ * @date 23 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -159,6 +159,10 @@ TEST_CASE("Melting conditions")
     subl.resize();
     ModelComponent::getStore().registerArray(Shared::SUBLIM, &subl, RW);
 
+    HField evap;
+    evap.resize();
+    ModelComponent::getStore().registerArray(Shared::EVAP, &evap, RW);
+
     HField tauX;
     HField tauY;
     tauX.resize();
@@ -306,6 +310,10 @@ TEST_CASE("Freezing conditions")
     HField subl;
     subl.resize();
     ModelComponent::getStore().registerArray(Shared::SUBLIM, &subl, RW);
+
+    HField evap;
+    evap.resize();
+    ModelComponent::getStore().registerArray(Shared::EVAP, &evap, RW);
 
     HField tauX;
     HField tauY;


### PR DESCRIPTION
# Fixing how we pass evap and precip around

Fixes no issue - links to PR #784

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

We had too many evap and precip variables, and we weren't using them consistently. Now, the evap and precip variables in IAtmosphereBoundary.hpp are only snow, rain, and evap - I've removed the redundant emp variable. This means that ERA5Atmosphere should read in snow and rain information (that's not implemented yet) and FiniteElementFluxes (or any flux implementation) should set evap (which is owned by IAtmosphereBoundary). I needed to make a tiny change in IOceanBoundary's mergeFluxes function to replace the emp variable.

This commit also contains some automated clang-format changes.

---
# Test Description

The realistic integration test works. Additionally, merging these changes into the issue774_check_fields branch resolves my issues with NaNs in the fields due to uninitialised arrays.

---
# Documentation Impact

N/A

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README