### PR TITLE
XIOS implementation of `dumpModelState`

### DIFF
--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -271,19 +271,14 @@ void ParaGridIO::dumpModelState(
 {
     Xios& xiosHandler = Xios::getInstance();
 
-    // TODO: coordsName, xName, yName, gridAzimuthName and others
-    std::set<std::string> restartFields = { hiceName, ciceName, hsnowName, ticeName, sstName,
-        sssName, maskName, longitudeName, latitudeName, uName, vName, damageName };
-    // If the above fields are found in the supplied ModelState, output them
+    // Assume that all fields in the supplied ModelState are necessary, and so write them to file.
     for (auto entry : state.data) {
         const std::string fieldId = entry.first;
-        if (restartFields.count(fieldId)) {
-            if (xiosHandler.getFieldReadAccess(fieldId)) {
-                throw std::runtime_error("ParaGridIO::dumpModelState: field " + fieldId
-                    + " is not configured for writing, but is being written to file.");
-            };
-            xiosHandler.write(fieldId, entry.second);
-        }
+        if (xiosHandler.getFieldReadAccess(fieldId)) {
+            throw std::runtime_error("ParaGridIO::dumpModelState: field " + fieldId
+                + " is not configured for writing, but is being written to file.");
+        };
+        xiosHandler.write(fieldId, entry.second);
     }
 }
 

--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -269,80 +269,22 @@ ModelState ParaGridIO::readForcingTimeStatic(
 void ParaGridIO::dumpModelState(
     const ModelState& state, const ModelMetadata& metadata, const std::string& filePath)
 {
-    // TODO: XIOS implementation
+    Xios& xiosHandler = Xios::getInstance();
 
-#ifdef USE_MPI
-    netCDF::NcFilePar ncFile(filePath, netCDF::NcFile::replace, metadata.mpiComm);
-#else
-    netCDF::NcFile ncFile(filePath, netCDF::NcFile::replace);
-#endif
-
-    CommonRestartMetadata::writeStructureType(ncFile, metadata);
-    netCDF::NcGroup metaGroup = ncFile.addGroup(IStructure::metadataNodeName());
-    netCDF::NcGroup dataGroup = ncFile.addGroup(IStructure::dataNodeName());
-    CommonRestartMetadata::writeRestartMetadata(metaGroup, metadata);
-
-    // Dump the dimensions and number of components
-    std::map<ModelArray::Dimension, netCDF::NcDim> ncFromMAMap;
-    for (auto entry : ModelArray::definedDimensions) {
-        ModelArray::Dimension dim = entry.first;
-        size_t dimSz = (dimCompMap.count(dim)) ? ModelArray::nComponents(dimCompMap.at(dim))
-                                               : dimSz = entry.second.globalLength;
-        ncFromMAMap[dim] = dataGroup.addDim(entry.second.name, dimSz);
-        // TODO Do I need to add data, even if it is just integers 0...n-1?
-    }
-
-    // Also create the sets of dimensions to be connected to the data fields
-    std::map<ModelArray::Type, std::vector<netCDF::NcDim>> dimMap;
-    for (auto entry : ModelArray::typeDimensions) {
-        ModelArray::Type type = entry.first;
-        std::vector<netCDF::NcDim> ncDims;
-        for (auto iter = entry.second.rbegin(); iter != entry.second.rend(); ++iter) {
-            ModelArray::Dimension& maDim = *iter;
-            ncDims.push_back(ncFromMAMap.at(maDim));
-        }
-        dimMap[type] = ncDims;
-    }
-
-    // Everything that has components needs that dimension, too. This always varies fastest, and so
-    // is last in the vector of dimensions.
-    for (auto entry : dimCompMap) {
-        dimMap.at(entry.second).push_back(ncFromMAMap.at(entry.first));
-    }
-
+    // TODO: coordsName, xName, yName, gridAzimuthName and others
     std::set<std::string> restartFields = { hiceName, ciceName, hsnowName, ticeName, sstName,
-        sssName, maskName, coordsName, xName, yName, longitudeName, latitudeName, gridAzimuthName,
-        uName, vName, damageName }; // TODO and others
+        sssName, maskName, longitudeName, latitudeName, uName, vName, damageName, "field_2D" };
     // If the above fields are found in the supplied ModelState, output them
     for (auto entry : state.data) {
         if (restartFields.count(entry.first)) {
-            // Get the type, then relevant vector of NetCDF dimensions
-            ModelArray::Type type = entry.second.getType();
-            std::vector<size_t> start;
-            std::vector<size_t> count;
-            if (ModelArray::hasDoF(type)) {
-                auto ncomps = entry.second.nComponents();
-                start.push_back(0);
-                count.push_back(ncomps);
-            }
-            for (ModelArray::Dimension dt : entry.second.typeDimensions.at(type)) {
-                auto dim = entry.second.definedDimensions.at(dt);
-                start.push_back(dim.start);
-                count.push_back(dim.localLength);
-            }
-            // dims are looped in [dg], x, y, [z] order so start and count
-            // order must be reveresed to match order netcdf expects
-            std::reverse(start.begin(), start.end());
-            std::reverse(count.begin(), count.end());
-
-            std::vector<netCDF::NcDim>& ncDims = dimMap.at(type);
-            netCDF::NcVar var(dataGroup.addVar(entry.first, netCDF::ncDouble, ncDims));
-            var.putAtt(mdiName, netCDF::ncDouble, MissingData::value());
-            var.putVar(start, count, entry.second.getData());
+            const std::string fieldId = entry.first;
+            if (xiosHandler.getFieldReadAccess(fieldId)) {
+                throw std::runtime_error("ParaGridIO::dumpModelState: field " + fieldId
+                    + " is not configured for writing, but is being written to file.");
+            };
+            xiosHandler.write(fieldId, entry.second);
         }
     }
-
-    ncFile.close();
 }
 
 void ParaGridIO::writeDiagnosticTime(

--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -273,7 +273,7 @@ void ParaGridIO::dumpModelState(
 
     // TODO: coordsName, xName, yName, gridAzimuthName and others
     std::set<std::string> restartFields = { hiceName, ciceName, hsnowName, ticeName, sstName,
-        sssName, maskName, longitudeName, latitudeName, uName, vName, damageName, "field_2D" };
+        sssName, maskName, longitudeName, latitudeName, uName, vName, damageName };
     // If the above fields are found in the supplied ModelState, output them
     for (auto entry : state.data) {
         if (restartFields.count(entry.first)) {

--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -276,8 +276,8 @@ void ParaGridIO::dumpModelState(
         sssName, maskName, longitudeName, latitudeName, uName, vName, damageName };
     // If the above fields are found in the supplied ModelState, output them
     for (auto entry : state.data) {
-        if (restartFields.count(entry.first)) {
-            const std::string fieldId = entry.first;
+        const std::string fieldId = entry.first;
+        if (restartFields.count(fieldId)) {
             if (xiosHandler.getFieldReadAccess(fieldId)) {
                 throw std::runtime_error("ParaGridIO::dumpModelState: field " + fieldId
                     + " is not configured for writing, but is being written to file.");

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1123,7 +1123,7 @@ xios::CField* Xios::getField(const std::string fieldId)
 }
 
 // Extract the field_names entry from the XiosInput or XiosOutput section of the config
-std::vector<std::string> Xios::configGetFieldNames(const bool reading)
+std::set<std::string> Xios::configGetFieldNames(const bool reading)
 {
     std::string fieldsStr;
     if (reading) {
@@ -1134,13 +1134,13 @@ std::vector<std::string> Xios::configGetFieldNames(const bool reading)
             Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()))
             >> fieldsStr;
     }
-    std::vector<std::string> fieldNames;
+    std::set<std::string> fieldNames;
     if (fieldsStr.length() > 0) {
         const char delim = ',';
         std::istringstream iss(fieldsStr);
         std::string item;
         while (std::getline(iss, item, delim)) {
-            fieldNames.push_back(item);
+            fieldNames.insert(item);
         }
     }
     return fieldNames;
@@ -1150,15 +1150,8 @@ std::vector<std::string> Xios::configGetFieldNames(const bool reading)
 // the map key
 bool Xios::configCheckField(const std::string fieldId, const bool reading)
 {
-    std::vector<std::string> fieldNames = configGetFieldNames(reading);
-    bool found = false;
-    for (std::string fieldName : fieldNames) {
-        if (fieldName == fieldId) {
-            found = true;
-            break;
-        }
-    }
-    return found;
+    std::set<std::string> fieldNames = configGetFieldNames(reading);
+    return fieldNames.find(fieldId) != fieldNames.end();
 }
 
 /*!
@@ -1687,6 +1680,12 @@ void Xios::fileAddField(const std::string fileId, const std::string fieldId)
  */
 void Xios::write(const std::string fieldId, ModelArray& modelarray)
 {
+    const bool readAccess = false;
+    std::set<std::string> fieldNames = configGetFieldNames(readAccess);
+    if (fieldNames.find(fieldId) == fieldNames.end()) {
+        throw std::runtime_error(
+            "Xios::write: field " + fieldId + " has not been configured for writing with XIOS.");
+    }
     auto ndim = modelarray.nDimensions();
     auto dims = modelarray.dimensions();
     if (ndim == 2) {
@@ -1705,6 +1704,12 @@ void Xios::write(const std::string fieldId, ModelArray& modelarray)
  */
 void Xios::read(const std::string fieldId, ModelArray& modelarray)
 {
+    const bool readAccess = true;
+    std::set<std::string> fieldNames = configGetFieldNames(readAccess);
+    if (fieldNames.find(fieldId) == fieldNames.end()) {
+        throw std::runtime_error(
+            "Xios::read: field " + fieldId + " has not been configured for reading with XIOS.");
+    }
     auto ndim = modelarray.nDimensions();
     auto dims = modelarray.dimensions();
     if (ndim == 2) {

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1692,14 +1692,8 @@ void Xios::write(const std::string fieldId, ModelArray& modelarray)
     if (ndim == 2) {
         cxios_write_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1], -1);
-    } else if (ndim == 3) {
-        cxios_write_data_k83(
-            fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1], dims[2], -1);
-    } else if (ndim == 4) {
-        cxios_write_data_k84(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
-            dims[1], dims[2], dims[3], -1);
     } else {
-        throw std::invalid_argument("Only ModelArrays of dimension 2, 3, or 4 are supported");
+        throw std::invalid_argument("Only ModelArrays of dimension 2 are supported");
     }
 }
 
@@ -1716,14 +1710,8 @@ void Xios::read(const std::string fieldId, ModelArray& modelarray)
     if (ndim == 2) {
         cxios_read_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1]);
-    } else if (ndim == 3) {
-        cxios_read_data_k83(
-            fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1], dims[2]);
-    } else if (ndim == 4) {
-        cxios_read_data_k84(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
-            dims[1], dims[2], dims[3]);
     } else {
-        throw std::invalid_argument("Only ModelArrays of dimension 2, 3, or 4 are supported");
+        throw std::invalid_argument("Only ModelArrays of dimension 2 are supported");
     }
 }
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -471,9 +471,6 @@ xios::CAxis* Xios::getAxis(const std::string axisId)
 /*!
  * Create an axis with some ID.
  *
- * If the axis ID is 'z_axis' and a domain called 'xy_domain' exists then a grid called 'grid_3D'
- * will automatically be created with this axis and that domain.
- *
  * @param the axis ID
  */
 void Xios::createAxis(const std::string axisId)
@@ -491,16 +488,6 @@ void Xios::createAxis(const std::string axisId)
     cxios_axis_valid_id(&exists, axisId.c_str(), axisId.length());
     if (!exists) {
         throw std::runtime_error("Xios: Failed to create axis '" + axisId + "'");
-    }
-    if (axisId == "z_axis") {
-        // Create grid_3D associated with a domain called xy_domain and an axis called z_axis
-        const std::string domainId = "xy_domain";
-        cxios_domain_valid_id(&exists, domainId.c_str(), domainId.length());
-        if (exists) {
-            createGrid("grid_3D");
-            gridAddDomain("grid_3D", "xy_domain");
-            gridAddAxis("grid_3D", "z_axis");
-        }
     }
 }
 
@@ -625,8 +612,7 @@ xios::CDomain* Xios::getDomain(const std::string domainId)
  * Create a domain with some ID.
  *
  * If the domain ID is 'xy_domain' then a grid called 'grid_2D' will automatically be created with
- * this domain. If an axis called 'z_axis' also exists then a grid called 'grid_3D' will
- * automatically be created with this domain and that axis.
+ * this domain.
  *
  * @param the domain ID
  */
@@ -651,15 +637,6 @@ void Xios::createDomain(const std::string domainId)
         const std::string gridId = "grid_2D";
         createGrid(gridId);
         gridAddDomain(gridId, "xy_domain");
-
-        // Create grid_3D if there is also an axis called z_axis
-        const std::string axisId = "z_axis";
-        cxios_axis_valid_id(&exists, axisId.c_str(), axisId.length());
-        if (exists) {
-            createGrid("grid_3D");
-            gridAddDomain("grid_3D", "xy_domain");
-            gridAddAxis("grid_3D", "z_axis");
-        }
     }
 }
 

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -199,7 +199,7 @@ private:
     xios::CFieldGroup* getFieldGroup();
     xios::CField* getField(const std::string fieldId);
     void setFieldReadAccess(const std::string fieldId, const bool readAccess);
-    std::vector<std::string> configGetFieldNames(const bool reading);
+    std::set<std::string> configGetFieldNames(const bool reading);
     bool configCheckField(const std::string fieldId, const bool reading);
 
     /* Grid */

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -26,6 +26,9 @@
 
 namespace Nextsim {
 
+// Forward declaration of ParaGridIO to avoid circular dependency
+class ParaGridIO;
+
 void enableXios();
 
 class Xios : public Configured<Xios> {
@@ -142,7 +145,6 @@ public:
     std::vector<std::string> fileGetFieldIds(const std::string fileId);
 
     /* I/O */
-    void write(const std::string fieldId, ModelArray& modelarray);
     void read(const std::string fieldId, ModelArray& modelarray);
 
     enum {
@@ -208,6 +210,12 @@ private:
     xios::CFileGroup* getFileGroup();
     xios::CFile* getFile(const std::string fileId);
     void setFileMode(const std::string fileId, const std::string mode);
+
+    /* I/O */
+    void write(const std::string fieldId, ModelArray& modelarray);
+
+    /* Declare any classes that need to access private members */
+    friend ParaGridIO;
 };
 
 }

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -186,21 +186,11 @@ bool cxios_is_defined_file_par_access(xios::CFile* file_hdl);
 void cxios_xml_tree_add_fieldtofile(
     xios::CFile* file, xios::CField** field, const char* _id, int _id_len);
 
-// writing methods
+// I/O methods
 void cxios_write_data_k82(const char* fieldid, int fieldid_size, const double* data_k8,
     int data_size1, int data_size2, int tileid);
-void cxios_write_data_k83(const char* fieldid, int fieldid_size, const double* data_k8,
-    int data_size1, int data_size2, int data_size3, int tileid);
-void cxios_write_data_k84(const char* fieldid, int fieldid_size, const double* data_k8,
-    int data_size1, int data_size2, int data_size3, int date_size4, int tileid);
-
-// reading methods
 void cxios_read_data_k82(
     const char* fieldid, int fieldid_size, const double* data_k8, int data_size1, int data_size2);
-void cxios_read_data_k83(const char* fieldid, int fieldid_size, const double* data_k8,
-    int data_size1, int data_size2, int data_size3);
-void cxios_read_data_k84(const char* fieldid, int fieldid_size, const double* data_k8,
-    int data_size1, int data_size2, int data_size3, int data_size4);
 };
 
 #endif

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -39,11 +39,11 @@ MPI_TEST_CASE("TestXiosFile", 2)
     config << "[XiosInput]" << std::endl;
     config << "period = P0-0T03:00:00" << std::endl;
     config << "filename = xios_test_input" << std::endl;
-    config << "field_names = field_2D" << std::endl;
+    config << "field_names = field_1D" << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "period = P0-0T03:00:00" << std::endl;
     config << "filename = xios_test_output" << std::endl;
-    config << "field_names = field_3D" << std::endl;
+    config << "field_names = field_2D" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -66,12 +66,17 @@ MPI_TEST_CASE("TestXiosFile", 2)
     xiosHandler.createAxis("z_axis");
     xiosHandler.setAxisValues("z_axis", { 0.0, 1.0 });
 
+    // Create a 1D grid
+    // NOTE: The 2D grid is created automatically along with the xy_domain
+    xiosHandler.createGrid("grid_1D");
+    xiosHandler.gridAddAxis("grid_1D", "z_axis");
+
     // Associate fields with grids
     // NOTE: fields are automatically created along with files
+    xiosHandler.setFieldOperation("field_1D", "instant");
+    xiosHandler.setFieldGridRef("field_1D", "grid_1D");
     xiosHandler.setFieldOperation("field_2D", "instant");
     xiosHandler.setFieldGridRef("field_2D", "grid_2D");
-    xiosHandler.setFieldOperation("field_3D", "instant");
-    xiosHandler.setFieldGridRef("field_3D", "grid_3D");
 
     // --- Tests for file API
     const std::string inFileId = "xios_test_input";
@@ -106,12 +111,12 @@ MPI_TEST_CASE("TestXiosFile", 2)
     // File add field
     // NOTE: fileAddField is triggered by a call to createFile, which parses the config to create
     // all the corresponding fields and then associated them with the file
-    std::vector<std::string> inFieldIds = xiosHandler.fileGetFieldIds(inFileId);
-    REQUIRE(inFieldIds.size() == 1);
-    REQUIRE(inFieldIds[0] == "field_2D");
-    std::vector<std::string> outFieldIds = xiosHandler.fileGetFieldIds(outFileId);
-    REQUIRE(outFieldIds.size() == 1);
-    REQUIRE(outFieldIds[0] == "field_3D");
+    std::vector<std::string> field_1DIds = xiosHandler.fileGetFieldIds(inFileId);
+    REQUIRE(field_1DIds.size() == 1);
+    REQUIRE(field_1DIds[0] == "field_1D");
+    std::vector<std::string> field_2DIds = xiosHandler.fileGetFieldIds(outFileId);
+    REQUIRE(field_2DIds.size() == 1);
+    REQUIRE(field_2DIds[0] == "field_2D");
 
     // Create a new file for each time unit to check more thoroughly that XIOS interprets output
     // frequency and split frequency correctly.

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -80,6 +80,12 @@ MPI_TEST_CASE("TestXiosRead", 2)
     HField field_2D(ModelArray::Type::H);
     field_2D.resize();
 
+    // Setup ModelState with field above
+    ModelState state = { {
+                             { "field_2D", field_2D },
+                         },
+        {} };
+
     // Check calendar step is zero initially
     REQUIRE(xiosHandler.getCalendarStep() == 0);
 
@@ -93,12 +99,16 @@ MPI_TEST_CASE("TestXiosRead", 2)
         metadata.incrementTime(timestep);
         REQUIRE(xiosHandler.getCalendarStep() == ts);
         // Receive data from XIOS that is read from disk
-        xiosHandler.read("field_2D", field_2D);
+        for (auto& entry : state.data) {
+            xiosHandler.read(entry.first, entry.second);
+        }
     }
 
-    for (size_t j = 0; j < ny; ++j) {
-        for (size_t i = 0; i < nx; ++i) {
-            REQUIRE(field_2D(i, j) == doctest::Approx(i + nx * j));
+    for (auto& entry : state.data) {
+        for (size_t j = 0; j < ny; ++j) {
+            for (size_t i = 0; i < nx; ++i) {
+                REQUIRE(entry.second(i, j) == doctest::Approx(i + nx * j));
+            }
         }
     }
     xiosHandler.context_finalize();

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -15,6 +15,7 @@
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
 #include "include/Xios.hpp"
+#include "include/gridNames.hpp"
 
 #include <filesystem>
 
@@ -37,7 +38,7 @@ MPI_TEST_CASE("TestXiosRead", 2)
     config << "[XiosInput]" << std::endl;
     config << "period = P0-0T01:30:00" << std::endl;
     config << "filename = xios_test_input" << std::endl;
-    config << "field_names = field_2D" << std::endl;
+    config << "field_names = hice" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -69,20 +70,20 @@ MPI_TEST_CASE("TestXiosRead", 2)
     // Create fields on the two grids
     // NOTE: Fields are created when the XIOS handler is constructed
     // NOTE: The 2D grid is created along with the 2D domain
-    xiosHandler.setFieldOperation("field_2D", "instant");
-    xiosHandler.setFieldGridRef("field_2D", "grid_2D");
+    xiosHandler.setFieldOperation(hiceName, "instant");
+    xiosHandler.setFieldGridRef(hiceName, "grid_2D");
     Duration timestep = xiosHandler.getCalendarTimestep();
-    xiosHandler.setFieldFreqOffset("field_2D", timestep);
+    xiosHandler.setFieldFreqOffset(hiceName, timestep);
 
     xiosHandler.close_context_definition();
 
     // Create HField and ZField instances to read the data into
-    HField field_2D(ModelArray::Type::H);
-    field_2D.resize();
+    HField hice(ModelArray::Type::H);
+    hice.resize();
 
     // Setup ModelState with field above
     ModelState state = { {
-                             { "field_2D", field_2D },
+                             { hiceName, hice },
                          },
         {} };
 

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -15,6 +15,7 @@
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
 #include "include/Xios.hpp"
+#include "include/gridNames.hpp"
 
 #include <filesystem>
 
@@ -37,7 +38,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     config << "[XiosOutput]" << std::endl;
     config << "period = P0-0T01:30:00" << std::endl;
     config << "filename = xios_test_output" << std::endl;
-    config << "field_names = field_2D" << std::endl;
+    config << "field_names = hice" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -69,10 +70,10 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     // Create a field on the grid
     // NOTE: Fields are created when the XIOS handler is constructed
     // NOTE: The 2D grid is created along with the 2D domain
-    xiosHandler.setFieldOperation("field_2D", "instant");
-    xiosHandler.setFieldGridRef("field_2D", "grid_2D");
+    xiosHandler.setFieldOperation(hiceName, "instant");
+    xiosHandler.setFieldGridRef(hiceName, "grid_2D");
     Duration timestep = xiosHandler.getCalendarTimestep();
-    xiosHandler.setFieldFreqOffset("field_2D", timestep);
+    xiosHandler.setFieldFreqOffset(hiceName, timestep);
 
     // Set file split frequency
     // NOTE: Files are created when the XIOS handler is constructed
@@ -82,19 +83,18 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     xiosHandler.close_context_definition();
 
     // Create some fake data to test writing methods
-    HField field_2D(ModelArray::Type::H);
-    field_2D.resize();
+    HField hice(ModelArray::Type::H);
+    hice.resize();
     for (size_t j = 0; j < ny; ++j) {
         for (size_t i = 0; i < nx; ++i) {
-            field_2D(i, j) = 1.0 * (i + nx * j);
+            hice(i, j) = 1.0 * (i + nx * j);
         }
     }
     // Setup ModelState with field above
     ModelState state = { {
-                             { "field_2D", field_2D },
+                             { hiceName, hice },
                          },
         {} };
-    // TODO: Use hiceName: hice
 
     // Check calendar step is zero initially
     REQUIRE(xiosHandler.getCalendarStep() == 0);

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -89,6 +89,12 @@ MPI_TEST_CASE("TestXiosWrite", 2)
             field_2D(i, j) = 1.0 * (i + nx * j);
         }
     }
+    // Setup ModelState with field above
+    ModelState state = { {
+                             { "field_2D", field_2D },
+                         },
+        {} };
+    // TODO: Use hiceName: hice
 
     // Check calendar step is zero initially
     REQUIRE(xiosHandler.getCalendarStep() == 0);
@@ -102,8 +108,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
         // Update the current timestep and verify it's updated in XIOS
         metadata.incrementTime(timestep);
         REQUIRE(xiosHandler.getCalendarStep() == ts);
-        // Send data to XIOS to be written to disk
-        xiosHandler.write("field_2D", field_2D);
+        grid.dumpModelState(state, metadata, "xios_test_output", true);
     }
 
     // Check the files have indeed been created then remove it

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -90,6 +90,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
             hice(i, j) = 1.0 * (i + nx * j);
         }
     }
+
     // Setup ModelState with field above
     ModelState state = { {
                              { hiceName, hice },

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -1,4 +1,4 @@
-netcdf xios_test_output {
+netcdf xios_test_input {
 dimensions:
 	axis_nbounds = 2 ;
 	lon = 4 ;
@@ -41,20 +41,18 @@ variables:
 		field_1D:interval_write = "5400 s" ;
 		field_1D:cell_methods = "time: point" ;
 		field_1D:coordinates = "time_instant" ;
-	float field_2D(time_counter, lat, lon) ;
-		field_2D:online_operation = "instant" ;
-		field_2D:interval_operation = "5400 s" ;
-		field_2D:interval_write = "5400 s" ;
-		field_2D:cell_methods = "time: point" ;
-		field_2D:coordinates = "time_instant" ;
+	float hice(time_counter, lat, lon) ;
+		hice:online_operation = "instant" ;
+		hice:interval_operation = "5400 s" ;
+		hice:interval_write = "5400 s" ;
+		hice:cell_methods = "time: point" ;
+		hice:coordinates = "time_instant" ;
 
 // global attributes:
-		:name = "xios_test_output" ;
-		:description = "Created by xios" ;
-		:title = "Created by xios" ;
+		:name = "xios_test_input" ;
+		:description = "Test input file for XIOS" ;
+    :title = "XIOS test input" ;
 		:Conventions = "CF-1.6" ;
-		:timeStamp = "2024-Aug-27 08:47:07 GMT" ;
-		:uuid = "28e10e5f-e296-4219-903d-bc75bd2e4a9a" ;
 data:
 
  lat = -1, 1 ;
@@ -82,7 +80,7 @@ data:
  field_1D =
   0, 1, 0, 1 ;
 
- field_2D =
+ hice =
   0, 1, 0, 1,
   2, 3, 2, 3,
   0, 1, 0, 1,

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -35,18 +35,18 @@ variables:
 		time_counter:time_origin = "2020-01-23 00:08:15" ;
 		time_counter:bounds = "time_counter_bounds" ;
 	double time_counter_bounds(time_counter, axis_nbounds) ;
+	float field_1D(time_counter, z_axis) ;
+		field_1D:online_operation = "instant" ;
+		field_1D:interval_operation = "5400 s" ;
+		field_1D:interval_write = "5400 s" ;
+		field_1D:cell_methods = "time: point" ;
+		field_1D:coordinates = "time_instant" ;
 	float field_2D(time_counter, lat, lon) ;
 		field_2D:online_operation = "instant" ;
 		field_2D:interval_operation = "5400 s" ;
 		field_2D:interval_write = "5400 s" ;
 		field_2D:cell_methods = "time: point" ;
 		field_2D:coordinates = "time_instant" ;
-	float field_3D(time_counter, z_axis, lat, lon) ;
-		field_3D:online_operation = "instant" ;
-		field_3D:interval_operation = "5400 s" ;
-		field_3D:interval_write = "5400 s" ;
-		field_3D:cell_methods = "time: point" ;
-		field_3D:coordinates = "time_instant" ;
 
 // global attributes:
 		:name = "xios_test_output" ;
@@ -79,6 +79,9 @@ data:
   99351165, 99351165,
   99356565, 99356565 ;
 
+ field_1D =
+  0, 1, 0, 1 ;
+
  field_2D =
   0, 1, 0, 1,
   2, 3, 2, 3,
@@ -88,22 +91,4 @@ data:
   2, 3, 2, 3,
   0, 1, 0, 1,
   2, 3, 2, 3 ;
-
- field_3D =
-  0, 1, 0, 1,
-  2, 3, 2, 3,
-  4, 5, 4, 5,
-  6, 7, 6, 7,
-  0, 1, 0, 1,
-  2, 3, 2, 3,
-  4, 5, 4, 5,
-  6, 7, 6, 7,
-  0, 1, 0, 1,
-  2, 3, 2, 3,
-  4, 5, 4, 5,
-  6, 7, 6, 7,
-  0, 1, 0, 1,
-  2, 3, 2, 3,
-  4, 5, 4, 5,
-  6, 7, 6, 7 ;
 }


### PR DESCRIPTION
# XIOS implementation of `dumpModelState`

Fixes #766

This PR provides the `dumpModelState` for the XIOS variant of the `ParaGridIO` class. To support it, robustness checks are added so we can be sure that the fields are properly set up. Similar checks are added for the file reading case. The field names in the XIOS tests are modified to account for the valid fields for restarts in `ParaGridIO`.

The PR also drops support for 3D and 4D fields, as these are no longer planned.