### PR TITLE
Enable multiplatform build of the docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,4 +43,5 @@ jobs:
         with:
           push: true
           file: Dockerfiles/Dockerfile.devenv
+          platforms: linux/amd64,linux/arm64
           tags: ghcr.io/nextsimhub/nextsimdg-dev-env:latest


### PR DESCRIPTION
# Enable multiplatform build of the docker image
Fixes #864 

### Task List
- [ ] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [ ] Implemented the source code change that satisfies the tests
- [ ] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [ ] Completed the pre-Request checklist below

---
# Change Description

Add "platforms: linux/amd64,linux/arm64" to docker.yml. This should allow github to build a multiplatform image.

---
# Test Description

Trigger a build and confirm that the image built works on both amd64 and arm64 machines.

---
# Documentation Impact

N/A

---
# Other Details

None

---
### Pre-Request Checklist

- [ ] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [ ] No new warnings are generated
- [ ] The documentation has been updated (or an issue has been created to track the corresponding change)
- [ ] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [ ] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [ ] File dates have been updated to reflect modification date
- [ ] This change conforms to the conventions described in the README