### PR TITLE
Move updateWrapper from IceGrowth

### DIFF
--- a/physics/src/IceGrowth.cpp
+++ b/physics/src/IceGrowth.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file IceGrowth.cpp
  *
- * @date 02 May 2025
+ * @date 04 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
@@ -28,25 +28,15 @@ IceGrowth::IceGrowth()
     , hsnow(ModelArray::Type::H)
     , hice0(ModelArray::Type::H)
     , hsnow0(ModelArray::Type::H)
-    , newice(ModelArray::Type::H)
-    , deltaCIce(ModelArray::Type::H)
-    , deltaCFreeze(ModelArray::Type::H)
-    , deltaCMelt(ModelArray::Type::H)
     , hIceCell(getStore())
     , hSnowCell(getStore())
     , cice0(getStore())
     , qow(getStore())
-    , mixedLayerBulkHeatCapacity(getStore())
-    , sst(getStore())
-    , tf(getStore())
     , deltaHi(getStore())
 {
     getStore().registerArray(Shared::H_ICE, &hice, RW);
     getStore().registerArray(Shared::C_ICE, &cice, RW);
     getStore().registerArray(Shared::H_SNOW, &hsnow, RW);
-    getStore().registerArray(Shared::NEW_ICE, &newice, RW);
-    getStore().registerArray(Shared::HSNOW_MELT, &snowMelt, RW);
-    getStore().registerArray(Shared::DELTA_CICE, &deltaCIce, RW);
 
     getStore().registerArray(Protected::HTRUE_ICE, &hice0, RO);
     getStore().registerArray(Protected::HTRUE_SNOW, &hsnow0, RO);
@@ -63,11 +53,6 @@ void IceGrowth::setData(const ModelState::DataMap& ms)
     hsnow.resize();
     hice0.resize();
     hsnow0.resize();
-    newice.resize();
-    snowMelt.resize();
-    deltaCFreeze.resize();
-    deltaCMelt.resize();
-    deltaCIce.resize();
 }
 
 ModelState IceGrowth::getStateDiagnostic() const
@@ -155,17 +140,13 @@ void IceGrowth::update(const TimestepTime& tsTime)
 {
     // Copy the ice data from the prognostic fields to the modifiable fields.
     initializeThicknesses();
-    overElements([this](size_t i, const TimestepTime& tst) { this->applyLimits(i, tst); }, tsTime);
 
     // The snowMelt array is not currently filled with data, but it used elsewhere
     // FIXME calculate a true value for snowMelt
-    snowMelt = 0;
 
     if (doThermo) {
         iVertical->update(tsTime);
-        // new ice formation
-        overElements(
-            [this](size_t i, const TimestepTime& tst) { this->updateWrapper(i, tst); }, tsTime);
+        iLateral->update(tsTime);
     }
 
     // Damage always heals, even if there's no active thermo
@@ -185,8 +166,6 @@ void IceGrowth::initializeThicknesses()
 // but only if ice concentration is non-zero.
 void IceGrowth::initializeThicknessesElement(size_t i, const TimestepTime&)
 {
-    deltaCIce[i] = 0;
-
     if (cice0[i] > 0 && hIceCell[i] > 0) {
         hice[i] = hice0[i] = hIceCell[i] / cice0[i];
         hsnow[i] = hsnow0[i] = hSnowCell[i] / cice0[i];
@@ -194,78 +173,6 @@ void IceGrowth::initializeThicknessesElement(size_t i, const TimestepTime&)
         hice[i] = hice0[i] = 0.;
         hsnow[i] = hsnow0[i] = 0.;
         cice[i] = 0.;
-    }
-
-    // reset the new ice volume array
-    newice[i] = 0;
-}
-
-void IceGrowth::newIceFormation(size_t i, const TimestepTime& tst)
-{
-    // Flux cooling the ocean from open water
-    // TODO Add assimilation fluxes here
-    double coolingFlux = qow[i];
-    // Temperature change of the mixed layer during this timestep
-    double deltaTml = -coolingFlux / mixedLayerBulkHeatCapacity[i] * tst.step;
-    // Initial temperature
-    double t0 = sst[i];
-    // Freezing point temperature
-    double tf0 = tf[i];
-    // Final temperature
-    double t1 = t0 + deltaTml;
-
-    // deal with cooling below the freezing point
-    if (t1 < tf0) {
-        // Heat lost cooling the mixed layer to freezing point
-        double sensibleFlux = (tf0 - t0) / deltaTml * coolingFlux;
-        // Any heat beyond that is latent heat forming new ice
-        double latentFlux = coolingFlux - sensibleFlux;
-
-        qow[i] = sensibleFlux;
-        newice[i] = latentFlux * tst.step * (1 - cice[i]) / (Ice::Lf * Ice::rho);
-    } else {
-        newice[i] = 0;
-    }
-}
-
-// Update thickness with concentration
-static double updateThickness(double& thick, double newConc, double deltaC, double deltaV)
-{
-    return thick += (deltaV - thick * deltaC) / newConc;
-}
-
-void IceGrowth::lateralIceSpread(size_t i, const TimestepTime& tstep)
-{
-    deltaCMelt[i] = 0;
-    deltaCFreeze[i] = 0;
-    iLateral->freeze(
-        tstep, hice[i], hsnow[i], deltaHi[i], newice[i], cice[i], qow[i], deltaCFreeze[i]);
-    if (deltaHi[i] < 0) {
-        // Note that the cell-averaged hice0 is converted to a ice averaged value
-        iLateral->melt(tstep, hice0[i], hsnow[i], deltaHi[i], cice[i], qow[i], deltaCMelt[i]);
-    }
-    deltaCIce[i] = deltaCFreeze[i] + deltaCMelt[i];
-    cice[i] = (hice[i] > 0 || newice[i] > 0) ? cice[i] + deltaCIce[i] : 0;
-    if (cice[i] >= IceMinima::c()) {
-        // The updated ice thickness must conserve volume
-        updateThickness(hice[i], cice[i], deltaCIce[i], newice[i]);
-        if (deltaCIce[i] < 0) {
-            // Snow is lost if the concentration decreases, and energy is returned to the ocean
-            qow[i] -= deltaCIce[i] * hsnow[i] * Water::Lf * Ice::rhoSnow / tstep.step;
-        } else {
-            // Update snow thickness. Currently no new snow is implemented
-            updateThickness(hsnow[i], cice[i], deltaCIce[i], 0);
-        }
-    }
-}
-
-void IceGrowth::applyLimits(size_t i, const TimestepTime& tstep)
-{
-    if ((0. < cice[i] && cice[i] < IceMinima::c()) || (0. < hice[i] && hice[i] < IceMinima::h())) {
-        qow[i] += cice[i] * Water::Lf * (hice[i] * Ice::rho + hsnow[i] * Ice::rhoSnow) / tstep.step;
-        hice[i] = 0;
-        cice[i] = 0;
-        hsnow[i] = 0;
     }
 }
 } /* namespace Nextsim */

--- a/physics/src/include/IceGrowth.hpp
+++ b/physics/src/include/IceGrowth.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IceGrowth.hpp
  *
- * @date Jul 5, 2022
+ * @date 04 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
@@ -68,25 +68,13 @@ private:
     HField hice; // Updated true ice thickness, m
     HField cice; // Updated ice concentration
     HField hsnow; // Updated true snow thickness, m
-    HField newice; // New ice over open water this timestep, m
     HField hice0; // Timestep initial true ice thickness, m
     HField hsnow0; // Timestep initial true snow thickness, m
-
-    HField snowMelt; // Ocean to snow transfer of freshwater kg m⁻²
-    // Since ILateralSpread is purely per-element, hold Δcice here
-    HField deltaCIce; // Change in ice concentration
-    // Owned data fields, not shared
-    HField deltaCFreeze; // New ice concentration due to freezing (+ve)
-    HField deltaCMelt; // Ice concentration loss due to melting (-ve)
 
     ModelArrayRef<Protected::H_ICE> hIceCell; // Timestep initial cell averaged ice thickness, m
     ModelArrayRef<Protected::H_SNOW> hSnowCell; // Timestep initial cell averaged snow thickness, m
     ModelArrayRef<Protected::C_ICE> cice0; // Timestep initial ice concentration
     ModelArrayRef<Shared::Q_OW, RW> qow; // open water heat flux, from FluxCalculation
-    ModelArrayRef<Protected::ML_BULK_CP>
-        mixedLayerBulkHeatCapacity; // J K⁻¹ m⁻², from atmospheric state
-    ModelArrayRef<Protected::SST> sst; // sea surface temperature, ˚C
-    ModelArrayRef<Protected::TF> tf; // ocean freezing point, ˚C
     ModelArrayRef<Shared::DELTA_HICE> deltaHi; // New ice thickness this timestep, m
 
     bool doThermo = true; // Perform any thermodynamics calculations at all

--- a/physics/src/include/IceGrowth.hpp
+++ b/physics/src/include/IceGrowth.hpp
@@ -47,9 +47,6 @@ public:
 
     void update(const TimestepTime&);
 
-    static double minimumIceThickness() { return IceMinima::h(); }
-    static double minimumIceConcentration() { return IceMinima::c(); }
-
     /*!
      * Updates the true ice and snow thickness arrays from the cell averages.
      */
@@ -79,15 +76,6 @@ private:
 
     bool doThermo = true; // Perform any thermodynamics calculations at all
 
-    void newIceFormation(size_t i, const TimestepTime&);
-    void lateralIceSpread(size_t i, const TimestepTime&);
-    void applyLimits(size_t i, const TimestepTime&);
-    void updateWrapper(size_t i, const TimestepTime& tst)
-    {
-        newIceFormation(i, tst);
-        lateralIceSpread(i, tst);
-        applyLimits(i, tst);
-    }
     void initializeThicknessesElement(size_t i, const TimestepTime&);
 };
 

--- a/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
+++ b/physics/src/modules/LateralIceSpreadModule/HiblerSpread.cpp
@@ -1,11 +1,14 @@
 /*!
  * @file HiblerSpread.cpp
  *
- * @date 20 Nov 2024
+ * @date 04 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
 #include "include/HiblerSpread.hpp"
+
+#include "include/IceMinima.hpp"
+#include "include/constants.hpp"
 
 namespace Nextsim {
 
@@ -34,12 +37,7 @@ ConfigMap HiblerSpread::getConfiguration() const
     };
 }
 
-ModelState HiblerSpread::getStateDiagnostic() const
-{
-    return { { },
-        getConfiguration()
-    };
-}
+ModelState HiblerSpread::getStateDiagnostic() const { return { {}, getConfiguration() }; }
 
 HiblerSpread::HelpMap& HiblerSpread::getHelpText(HelpMap& map, bool getAll)
 {
@@ -71,4 +69,71 @@ void HiblerSpread::melt(const TimestepTime& tstep, double hice, double hsnow, do
     }
 }
 
+void HiblerSpread::newIceFormation(size_t i, const TimestepTime& tst)
+{
+    // Flux cooling the ocean from open water
+    // TODO Add assimilation fluxes here
+    double coolingFlux = qow[i];
+    // Temperature change of the mixed layer during this timestep
+    double deltaTml = -coolingFlux / mixedLayerBulkHeatCapacity[i] * tst.step;
+    // Initial temperature
+    double t0 = sst[i];
+    // Freezing point temperature
+    double tf0 = tf[i];
+    // Final temperature
+    double t1 = t0 + deltaTml;
+
+    // deal with cooling below the freezing point
+    if (t1 < tf0) {
+        // Heat lost cooling the mixed layer to freezing point
+        double sensibleFlux = (tf0 - t0) / deltaTml * coolingFlux;
+        // Any heat beyond that is latent heat forming new ice
+        double latentFlux = coolingFlux - sensibleFlux;
+
+        qow[i] = sensibleFlux;
+        newice[i] = latentFlux * tst.step * (1 - cice[i]) / (Ice::Lf * Ice::rho);
+    } else {
+        newice[i] = 0;
+    }
+}
+
+// Update thickness with concentration
+double HiblerSpread::updateThickness(double& thick, double newConc, double deltaC, double deltaV)
+{
+    return thick += (deltaV - thick * deltaC) / newConc;
+}
+
+void HiblerSpread::lateralIceSpread(size_t i, const TimestepTime& tstep)
+{
+    double deltaCMelt = 0;
+    double deltaCFreeze = 0;
+    freeze(tstep, hice[i], hsnow[i], deltaHi[i], newice[i], cice[i], qow[i], deltaCFreeze);
+    if (deltaHi[i] < 0) {
+        // Note that the cell-averaged hice0 is converted to an ice averaged value
+        melt(tstep, hice0[i], hsnow[i], deltaHi[i], cice[i], qow[i], deltaCMelt);
+    }
+    deltaCIce[i] = deltaCFreeze + deltaCMelt;
+    cice[i] = (hice[i] > 0 || newice[i] > 0) ? cice[i] + deltaCIce[i] : 0;
+    if (cice[i] >= IceMinima::c()) {
+        // The updated ice thickness must conserve volume
+        updateThickness(hice[i], cice[i], deltaCIce[i], newice[i]);
+        if (deltaCIce[i] < 0) {
+            // Snow is lost if the concentration decreases, and energy is returned to the ocean
+            qow[i] -= deltaCIce[i] * hsnow[i] * Water::Lf * Ice::rhoSnow / tstep.step;
+        } else {
+            // Update snow thickness. Currently, no new snow is implemented
+            updateThickness(hsnow[i], cice[i], deltaCIce[i], 0);
+        }
+    }
+}
+
+void HiblerSpread::applyLimits(size_t i, const TimestepTime& tstep)
+{
+    if (cice[i] < IceMinima::c() || hice[i] < IceMinima::h()) {
+        qow[i] += cice[i] * Water::Lf * (hice[i] * Ice::rho + hsnow[i] * Ice::rhoSnow) / tstep.step;
+        hice[i] = 0;
+        cice[i] = 0;
+        hsnow[i] = 0;
+    }
+}
 }

--- a/physics/src/modules/LateralIceSpreadModule/include/DummyIceSpread.hpp
+++ b/physics/src/modules/LateralIceSpreadModule/include/DummyIceSpread.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file DummyIceSpread.hpp
  *
- * @date 18 Apr 2023
+ * @date 04 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -20,16 +20,9 @@ public:
     }
     ~DummyIceSpread() = default;
 
-    void freeze(const TimestepTime& tstep, double hice, double hsnow, double deltaHi, double newIce,
-        double& cice, double& qow, double& deltaCfreeze) override
-    {
-        deltaCfreeze = 0.;
-    }
-    void melt(const TimestepTime& tstep, double hice, double hsnow, double deltaHi, double& cice,
-        double& qow, double& deltaCmelt) override
-    {
-        deltaCmelt = 0.;
-    }
+    void update(const TimestepTime& tstep) override {
+        // No-op for dummy implementation
+    };
 };
 
 } /* namespace Nextsim */

--- a/physics/src/modules/LateralIceSpreadModule/include/HiblerSpread.hpp
+++ b/physics/src/modules/LateralIceSpreadModule/include/HiblerSpread.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file HiblerSpread.hpp
  *
- * @date 24 Sep 2024
+ * @date 04 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -18,6 +18,10 @@ class HiblerSpread : public ILateralIceSpread, public Configured<HiblerSpread> {
 public:
     HiblerSpread()
         : ILateralIceSpread()
+        , hice0(getStore())
+        , mixedLayerBulkHeatCapacity(getStore())
+        , sst(getStore())
+        , tf(getStore())
     {
     }
     virtual ~HiblerSpread() = default;
@@ -35,14 +39,61 @@ public:
     static HelpMap& getHelpText(HelpMap& map, bool getAll);
     static HelpMap& getHelpRecursive(HelpMap&, bool getAll);
 
-    void freeze(const TimestepTime& tstep, double hice, double hsnow, double deltaHi, double newIce,
-        double& cice, double& qow, double& deltaCfreeze) override;
-    void melt(const TimestepTime& tstep, double hice, double hsnow, double deltaHi, double& cice,
-        double& qow, double& deltaCmelt) override;
+    void update(const TimestepTime& tstep) override
+    {
+        overElements(
+            [this](size_t i, const TimestepTime& tst) { this->updateWrapper(i, tst); }, tstep);
+    }
 
 private:
+    void updateWrapper(size_t i, const TimestepTime& tst)
+    {
+        newIceFormation(i, tst);
+        lateralIceSpread(i, tst);
+        applyLimits(i, tst);
+    }
+
+    /*!
+     * Updates the freezing of open water for the timestep.
+     *
+     * @param tStep The object containing the timestep start and duration times.
+     * @param hice The ice-average ice thickness.
+     * @param hsnow The ice-average snow thickness.
+     * @param deltaHi The change in ice thickness this timestep.
+     * @param newIce The positive change in ice thickness this timestep.
+     * @param cice The ice concentration.
+     * @param qow The open water heat flux.
+     * @param deltaCFreeze The change in concentration due to freezing.
+     */
+    void freeze(const TimestepTime& tstep, double hice, double hsnow, double deltaHi, double newIce,
+        double& cice, double& qow, double& deltaCfreeze);
+
+    /*!
+     * Updates the lateral melting of ice for the timestep.
+     *
+     * @param tStep The object containing the timestep start and duration times.
+     * @param hice The ice-average ice thickness.
+     * @param hsnow The ice-average snow thickness.
+     * @param deltaHi The change in ice thickness this timestep.
+     * @param cice The ice concentration.
+     * @param qow The open water heat flux.
+     * @param deltaCmelt The change in concentration due to melting.
+     */
+    void melt(const TimestepTime& tstep, double hice, double hsnow, double deltaHi, double& cice,
+        double& qow, double& deltaCmelt);
+    void newIceFormation(size_t i, const TimestepTime& tst);
+    double updateThickness(double& thick, double newConc, double deltaC, double deltaV);
+    void lateralIceSpread(size_t i, const TimestepTime& tstep);
+    void applyLimits(size_t i, const TimestepTime& tstep);
+
     static double h0;
     static double phiM;
+
+    ModelArrayRef<Protected::ML_BULK_CP>
+        mixedLayerBulkHeatCapacity; // J K⁻¹ m⁻², from atmospheric state
+    ModelArrayRef<Protected::SST> sst; // sea surface temperature, ˚C
+    ModelArrayRef<Protected::TF> tf; // ocean freezing point, ˚C
+    ModelArrayRef<Protected::HTRUE_ICE> hice0; // Timestep initial true ice thickness, m
 };
 
 }

--- a/physics/src/modules/include/ILateralIceSpread.hpp
+++ b/physics/src/modules/include/ILateralIceSpread.hpp
@@ -27,10 +27,9 @@ public:
         snowMelt.resize();
 
         /* Set these to zero, so we don't have uninitialized values floating around.
-         * Should this be done here, or in derived classes? Arguably only in the derived classes,
-         * since having uninitialised values helps with error detection. But as long as we have the
-         * nextsim_thermo.use_thermo_forcing option, all derived classes must initialise these
-         * values to something sensible.*/
+         * This could be done in the derived classes, but it is convenient to do it here because
+         * since we have the nextsim_thermo.use_thermo_forcing option, all derived classes must
+         * initialise these values to something sensible.*/
         deltaCIce = 0.;
         newice = 0.;
         snowMelt = 0.;

--- a/physics/src/modules/include/ILateralIceSpread.hpp
+++ b/physics/src/modules/include/ILateralIceSpread.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file ILateralIceSpread.hpp
  *
- * @date Jul 5, 2022
+ * @date 04 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Einar Ólason <einar.olason@nersc.no>
  */
@@ -20,53 +20,45 @@ public:
     virtual ~ILateralIceSpread() = default;
 
     std::string getName() const override { return "LateralIceSpread"; }
-    void setData(const ModelState::DataMap& ms) override { }
+    void setData(const ModelState::DataMap& ms) override
+    {
+        deltaCIce.resize();
+        newice.resize();
+        snowMelt.resize();
+    }
+
     /*!
-     * Updates the freezing of open water for the timestep.
+     * Updates the lateral ice melt and formation for the timestep.
      *
      * @param tStep The object containing the timestep start and duration times.
-     * @param hice The ice-average ice thickness.
-     * @param hsnow The ice-average snow thickness.
-     * @param deltaHi The change in ice thickness this timestep.
-     * @param newIce The positive change in ice thickness this timestep.
-     * @param cice The ice concentration.
-     * @param qow The open water heat flux.
-     * @param deltaCFreeze The change in concentration due to freezing.
      */
-    virtual void freeze(const TimestepTime& tstep, double hice, double hsnow, double deltaHi,
-        double newIce, double& cice, double& qow, double& deltaCfreeze)
-        = 0;
-    /*!
-     * Updates the lateral melting of ice for the timestep.
-     *
-     * @param tStep The object containing the timestep start and duration times.
-     * @param hice The ice-average ice thickness.
-     * @param hsnow The ice-average snow thickness.
-     * @param deltaHi The change in ice thickness this timestep.
-     * @param cice The ice concentration.
-     * @param qow The open water heat flux.
-     * @param deltaCmelt The change in concentration due to melting.
-     */
-    virtual void melt(const TimestepTime& tstep, double hice, double hsnow, double deltaHi,
-        double& cice, double& qow, double& deltaCmelt)
-        = 0;
+    virtual void update(const TimestepTime& tstep) = 0;
 
 protected:
     ILateralIceSpread()
-        : cice(getStore())
-        , qow(getStore())
+        : deltaCIce(ModelArray::Type::H)
+        , newice(ModelArray::Type::H)
+        , snowMelt(ModelArray::Type::H)
+        , cice(getStore())
+        , deltaHi(getStore())
         , hice(getStore())
         , hsnow(getStore())
-        , deltaHi(getStore())
+        , qow(getStore())
     {
+        getStore().registerArray(Shared::DELTA_CICE, &deltaCIce, RW);
+        getStore().registerArray(Shared::HSNOW_MELT, &snowMelt, RW);
+        getStore().registerArray(Shared::NEW_ICE, &newice, RW);
     }
 
-    ModelArrayRef<Shared::C_ICE, RW> cice; // From IceGrowth
-    ModelArrayRef<Shared::Q_OW, RW> qow; // From FluxCalculation
+    HField deltaCIce; // Change in ice concentration
+    HField newice; // New ice over open water this timestep, m
+    HField snowMelt; // Ocean to snow transfer of freshwater kg m⁻²
 
-    ModelArrayRef<Shared::H_ICE, RO> hice; // From IceGrowth
-    ModelArrayRef<Shared::H_SNOW, RO> hsnow; // From Ice Growth?
+    ModelArrayRef<Shared::C_ICE, RW> cice; // From IceGrowth
     ModelArrayRef<Shared::DELTA_HICE, RO> deltaHi; // From Vertical Ice Growth
+    ModelArrayRef<Shared::H_ICE, RW> hice; // From IceGrowth
+    ModelArrayRef<Shared::H_SNOW, RW> hsnow; // From Ice Growth?
+    ModelArrayRef<Shared::Q_OW, RW> qow; // From FluxCalculation
 };
 
 } /* namespace Nextsim */

--- a/physics/src/modules/include/ILateralIceSpread.hpp
+++ b/physics/src/modules/include/ILateralIceSpread.hpp
@@ -26,10 +26,11 @@ public:
         newice.resize();
         snowMelt.resize();
 
-        /* Set these to zero, so we don't have uninitialized values floating around.
-         * This could be done in the derived classes, but it is convenient to do it here because
-         * since we have the nextsim_thermo.use_thermo_forcing option, all derived classes must
-         * initialise these values to something sensible.*/
+        /*
+         * Set these to zero, so we don't have uninitialized values floating around.
+         * As long as we have the nextsim_thermo.use_thermo_forcing option, all
+         * derived classes must initialise these values to something sensible.
+         */
         deltaCIce = 0.;
         newice = 0.;
         snowMelt = 0.;

--- a/physics/src/modules/include/ILateralIceSpread.hpp
+++ b/physics/src/modules/include/ILateralIceSpread.hpp
@@ -25,6 +25,15 @@ public:
         deltaCIce.resize();
         newice.resize();
         snowMelt.resize();
+
+        /* Set these to zero, so we don't have uninitialized values floating around.
+         * Should this be done here, or in derived classes? Arguably only in the derived classes,
+         * since having uninitialised values helps with error detection. But as long as we have the
+         * nextsim_thermo.use_thermo_forcing option, all derived classes must initialise these
+         * values to something sensible.*/
+        deltaCIce = 0.;
+        newice = 0.;
+        snowMelt = 0.;
     }
 
     /*!


### PR DESCRIPTION
# Move updateWrapper from IceGrowth

Fixes #866 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

I replaced the overElements call to updateWrapper in IceGrowth with a call to iLateral->update(tst). The idea is to separate out the logic of lateral ice growth and melt out of IceGrowth itself and into ILateralIceSpread modules. This does require ILateralIceSpread.hpp to define and share three variables; for change in ice concentration, ice thickness, and snow thickness.

---
# Test Description

All CI tests pass.

---
# Documentation Impact

N/A

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README