### PR TITLE
A minimally functioning restart

### DIFF
--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ParaGridIO.cpp
  *
- * @date 03 Jun 2025
+ * @date 09 Dec 2024
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ParaGridIO.cpp
  *
- * @date 09 Dec 2024
+ * @date 03 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IDynamics.hpp
  *
- * @date 26 May 2025
+ * @date 03 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -57,8 +57,8 @@ public:
     ModelState getStatePrognostic() const override
     {
         ModelState state = { {
-                                 { uName, mask(uice) },
-                                 { vName, mask(vice) },
+                                 { uName, uice },
+                                 { vName, vice },
                              },
             getConfiguration() };
 

--- a/physics/src/SlabOcean.cpp
+++ b/physics/src/SlabOcean.cpp
@@ -1,21 +1,20 @@
 /*!
  * @file SlabOcean.cpp
  *
- * @date 08 May 2025
+ * @date 03 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
 #include "include/SlabOcean.hpp"
 
 #include "include/constants.hpp"
+#include "include/gridNames.hpp"
 
 #include <map>
 #include <string>
 
 namespace Nextsim {
 
-const std::string SlabOcean::sstSlabName = "sst_slab";
-const std::string SlabOcean::sssSlabName = "sss_slab";
 const double SlabOcean::defaultRelaxationTime = 30 * 24 * 60 * 60; // 30 days in seconds
 
 // Configuration strings
@@ -49,8 +48,8 @@ ConfigMap SlabOcean::getConfiguration() const
 ModelState SlabOcean::getStatePrognostic() const
 {
     return { {
-                 { sstSlabName, sstSlab },
-                 { sssSlabName, sssSlab },
+                 { sstName, sstSlab },
+                 { sssName, sssSlab },
              },
         getConfiguration() };
 }

--- a/physics/src/include/SlabOcean.hpp
+++ b/physics/src/include/SlabOcean.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file SlabOcean.hpp
  *
- * @date 29 Apr 2025
+ * @date 03 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -79,9 +79,6 @@ private:
     ModelArrayRef<CouplingFields::FWFLUX, RO> fwFlux;
     ModelArrayRef<CouplingFields::SFLUX, RO> sFlux;
     // TODO ModelArrayRef to assimilation flux
-
-    static const std::string sstSlabName;
-    static const std::string sssSlabName;
 
     double relaxationTimeT = defaultRelaxationTime;
     double relaxationTimeS = defaultRelaxationTime;

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file TOPAZOcean.cpp
  *
- * @date 02 May 2025
+ * @date 03 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -56,10 +56,7 @@ void TOPAZOcean::configure()
     getStore().registerArray(Protected::EXT_SSS, &sssExt, RO);
 }
 
-ConfigMap TOPAZOcean::getConfiguration() const
-{
-    return { { keyMap.at(FILEPATH_KEY), filePath } };
-}
+ConfigMap TOPAZOcean::getConfiguration() const { return { { keyMap.at(FILEPATH_KEY), filePath } }; }
 
 void TOPAZOcean::updateBefore(const TimestepTime& tst)
 {
@@ -89,6 +86,18 @@ void TOPAZOcean::updateAfter(const TimestepTime& tst)
     slabOcean.update(tst);
     sst = ModelArrayRef<Protected::SLAB_SST, RO>(getStore());
     sss = ModelArrayRef<Protected::SLAB_SSS, RO>(getStore());
+}
+
+ModelState TOPAZOcean::getStatePrognostic() const
+{
+    ModelState state = IOceanBoundary::getStatePrognostic();
+    return state.merge(slabOcean.getStatePrognostic());
+}
+
+ModelState TOPAZOcean::getStateDiagnostic() const
+{
+    ModelState state = IOceanBoundary::getStateDiagnostic();
+    return state.merge(slabOcean.getStateDiagnostic());
 }
 
 void TOPAZOcean::setFilePath(const std::string& filePathIn) { filePath = filePathIn; }

--- a/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
+++ b/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file TOPAZOcean.hpp
  *
- * @date Nov 25, 2022
+ * @date 03 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -38,6 +38,8 @@ public:
 
     void updateBefore(const TimestepTime&) override;
     void updateAfter(const TimestepTime&) override;
+    ModelState getStatePrognostic() const override;
+    ModelState getStateDiagnostic() const override;
 
     void setFilePath(const std::string& filePathIn);
 

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file IOceanBoundary.hpp
  *
- * @date 23 May 2025
+ * @date 03 Jun 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -10,6 +10,7 @@
 
 #include "include/ModelComponent.hpp"
 #include "include/constants.hpp"
+#include "include/gridNames.hpp"
 
 namespace Nextsim {
 
@@ -96,11 +97,11 @@ public:
         tauX.resize();
         tauY.resize();
 
-        if (ms.count("sst")) {
-            sst = ms.at("sst");
+        if (ms.count(sstName)) {
+            sst = ms.at(sstName);
         }
-        if (ms.count("sss")) {
-            sss = ms.at("sss");
+        if (ms.count(sssName)) {
+            sss = ms.at(sssName);
         }
     }
 


### PR DESCRIPTION
# A minimally functioning restart

Related to issue #206

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

The model now creates restart files from which it can start again. The restart is not identical, but similar. To get here, I had to make two changes to the way the model generates restart files:

 1. Include SST and SSS
 2. Mask u and v with zeros and not the number for the missing value

The rationale behind the changes is (loosely) documented in the commit messages.

---
# Test Description

I run the realistic integration test and then restart the model from the restart file generated by that test. The model does not crash, like it did before. A longer run before restarting confirms that the main features of the simulated field are conserved during restart. The difference is not identifiable by eye, but restarting does not produce bit-wise identical results, as it should. This is left for a separate issue/PR.

---
# Documentation Impact

None

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
