### PR TITLE
Fixes to FluxConfiguredAtmosphere and ConfiguredAtmosphere

### DIFF
--- a/core/test/PrognosticData_test.cpp
+++ b/core/test/PrognosticData_test.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file PrognosticData_test.cpp
  *
- * @date 7 Sep 2023
+ * @date 30 Apr 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -17,7 +17,6 @@
 #include "include/constants.hpp"
 
 #include <sstream>
-#include <iostream>
 
 extern template class Module::Module<Nextsim::IOceanBoundary>;
 
@@ -40,7 +39,8 @@ TEST_CASE("PrognosticData call order test")
     config << "lw_in = 330" << std::endl;
     config << "snow = 0" << std::endl;
     config << "rainfall = 0" << std::endl;
-    config << "wind_speed = 5" << std::endl;
+    config << "wind_u = 3" << std::endl;
+    config << "wind_v = 4" << std::endl;
 
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));

--- a/physics/src/modules/AtmosphereBoundaryModule/ConfiguredAtmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ConfiguredAtmosphere.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file ConfiguredAtmosphere.cpp
  *
- * @date 20 Nov 2024
+ * @date 20 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -9,6 +9,8 @@
 
 #include "include/Finalizer.hpp"
 #include "include/NextsimModule.hpp"
+
+#include <cmath>
 
 namespace Nextsim {
 
@@ -19,7 +21,8 @@ double ConfiguredAtmosphere::sw0 = 0; // Night
 double ConfiguredAtmosphere::lw0 = 315.637; // Stefan-Boltzmann at 0˚C
 double ConfiguredAtmosphere::snowfall0 = 0; // No snow
 double ConfiguredAtmosphere::rain0 = 0; // No rain
-double ConfiguredAtmosphere::windspeed0 = 0; // Still
+double ConfiguredAtmosphere::uWind0 = 0; // Still
+double ConfiguredAtmosphere::vWind0 = 0; // Still
 
 static const std::string pfx = "ConfiguredAtmosphere";
 static const std::string tKey = pfx + ".t_air";
@@ -29,7 +32,8 @@ static const std::string swKey = pfx + ".sw_in";
 static const std::string lwKey = pfx + ".lw_in";
 static const std::string snowKey = pfx + ".snow";
 static const std::string rainKey = pfx + ".rainfall";
-static const std::string windKey = pfx + ".wind_speed";
+static const std::string uWindKey = pfx + ".wind_u";
+static const std::string vWindKey = pfx + ".wind_v";
 
 const static std::map<int, std::string> keyMap = {
     { ConfiguredAtmosphere::TAIR_KEY, tKey },
@@ -39,7 +43,8 @@ const static std::map<int, std::string> keyMap = {
     { ConfiguredAtmosphere::LW_KEY, lwKey },
     { ConfiguredAtmosphere::SNOW_KEY, snowKey },
     { ConfiguredAtmosphere::RAIN_KEY, rainKey },
-    { ConfiguredAtmosphere::WIND_KEY, windKey },
+    { ConfiguredAtmosphere::UWIND_KEY, uWindKey },
+    { ConfiguredAtmosphere::VWIND_KEY, vWindKey },
 };
 
 ConfiguredAtmosphere::ConfiguredAtmosphere()
@@ -70,8 +75,10 @@ ConfigurationHelp::HelpMap& ConfiguredAtmosphere::getHelpRecursive(HelpMap& map,
             "", "Snowfall mass flux (kg s⁻¹ m⁻²)." },
         { rainKey, ConfigType::NUMERIC, { "0", "2.998e8" }, ConfigurationHelp::toString(rain0), "",
             "Rainfall mass flux (kg s⁻¹ m⁻²)." },
-        { windKey, ConfigType::NUMERIC, { "0", "2.998e8" }, ConfigurationHelp::toString(windspeed0),
-            "", "Windspeed (m s⁻¹)." },
+        { uWindKey, ConfigType::NUMERIC, { "0", "2.998e8" }, ConfigurationHelp::toString(uWind0),
+            "m/s", "Component of wind in the x (eastward) direction (m s⁻¹)." },
+        { vWindKey, ConfigType::NUMERIC, { "0", "2.998e8" }, ConfigurationHelp::toString(vWind0),
+            "m/s", "Component of wind in the y (northward) direction (m s⁻¹)." },
     };
     Module::getHelpRecursive<IFluxCalculation>(map, getAll);
 
@@ -87,7 +94,8 @@ void ConfiguredAtmosphere::configure()
     lw0 = Configured::getConfiguration(keyMap.at(LW_KEY), lw0);
     snowfall0 = Configured::getConfiguration(keyMap.at(SNOW_KEY), snowfall0);
     rain0 = Configured::getConfiguration(keyMap.at(RAIN_KEY), rain0);
-    windspeed0 = Configured::getConfiguration(keyMap.at(WIND_KEY), windspeed0);
+    uWind0 = Configured::getConfiguration(keyMap.at(UWIND_KEY), uWind0);
+    vWind0 = Configured::getConfiguration(keyMap.at(VWIND_KEY), vWind0);
 
     Finalizer::registerUnique(Module::finalize<IFluxCalculation>);
     fluxImpl = &Module::getImplementation<IFluxCalculation>();
@@ -104,7 +112,8 @@ ConfigMap ConfiguredAtmosphere::getConfiguration() const
         { keyMap.at(LW_KEY), lw0 },
         { keyMap.at(SNOW_KEY), snowfall0 },
         { keyMap.at(RAIN_KEY), rain0 },
-        { keyMap.at(WIND_KEY), windspeed0 },
+        { keyMap.at(UWIND_KEY), uWind0 },
+        { keyMap.at(VWIND_KEY), vWind0 },
     };
 }
 
@@ -126,7 +135,10 @@ void ConfiguredAtmosphere::setData(const ModelState::DataMap& dm)
     lw_in = lw0;
     snow = snowfall0;
     rain = rain0;
-    wind = windspeed0;
+    wind = std::hypot(uWind0, vWind0);
+
+    uwind = uWind0;
+    vwind = vWind0;
 
     fluxImpl->setData(dm);
 }

--- a/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
@@ -1,7 +1,7 @@
 /*!
  * @file FluxConfiguredAtmosphere.cpp
  *
- * @date 20 Nov 2024
+ * @date 20 May 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -82,15 +82,15 @@ void FluxConfiguredAtmosphere::configure()
 ConfigMap FluxConfiguredAtmosphere::getConfiguration() const
 {
     return {
-       { keyMap.at(QIA_KEY), qia0 },
-       { keyMap.at(DQIA_DT_KEY), dqia_dt0 },
-       { keyMap.at(QOW_KEY), qow0 },
-       { keyMap.at(SUBL_KEY), subl0 },
-       { keyMap.at(SNOW_KEY), snowfall0 },
-       { keyMap.at(RAIN_KEY), rain0 },
-       { keyMap.at(EVAP_KEY), evap0 },
-       { keyMap.at(WINDU_KEY), u0 },
-       { keyMap.at(WINDV_KEY), v0 },
+        { keyMap.at(QIA_KEY), qia0 },
+        { keyMap.at(DQIA_DT_KEY), dqia_dt0 },
+        { keyMap.at(QOW_KEY), qow0 },
+        { keyMap.at(SUBL_KEY), subl0 },
+        { keyMap.at(SNOW_KEY), snowfall0 },
+        { keyMap.at(RAIN_KEY), rain0 },
+        { keyMap.at(EVAP_KEY), evap0 },
+        { keyMap.at(WINDU_KEY), u0 },
+        { keyMap.at(WINDV_KEY), v0 },
     };
 }
 

--- a/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/FluxConfiguredAtmosphere.cpp
@@ -108,4 +108,11 @@ void FluxConfiguredAtmosphere::setData(const ModelState::DataMap& dm)
     vwind = v0;
 }
 
+void FluxConfiguredAtmosphere::update(const TimestepTime& tst)
+{
+    /* The open water heat flux is reset by the thermodynamics, so that the (slab) ocean doesn't
+     * super cool. Therefore, we have to reset it here on every update */
+    qow = qow0;
+}
+
 } /* namespace Nextsim */

--- a/physics/src/modules/AtmosphereBoundaryModule/include/ConfiguredAtmosphere.hpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/include/ConfiguredAtmosphere.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file ConfiguredAtmosphere.hpp
  *
- * @date Aug 31, 2022
+ * @date 30 Apr 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -28,7 +28,8 @@ public:
         LW_KEY,
         SNOW_KEY,
         RAIN_KEY,
-        WIND_KEY,
+        UWIND_KEY,
+        VWIND_KEY,
     };
 
     void setData(const ModelState::DataMap&) override;
@@ -50,7 +51,8 @@ private:
     static double lw0;
     static double snowfall0;
     static double rain0;
-    static double windspeed0;
+    static double uWind0;
+    static double vWind0;
 
     HField tair;
     HField tdew;

--- a/physics/src/modules/AtmosphereBoundaryModule/include/FluxConfiguredAtmosphere.hpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/include/FluxConfiguredAtmosphere.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file FluxConfiguredAtmosphere.hpp
  *
- * @date Sep 29, 2022
+ * @date 30 Apr 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -42,8 +42,8 @@ public:
     ConfigMap getConfiguration() const override;
 
 protected:
-    //! Performs the implementation specific updates. Does nothing.
-    void update(const TimestepTime&) override { }
+    //! Performs the implementation specific updates.
+    void update(const TimestepTime&) override;
 
 private:
     static double qia0;


### PR DESCRIPTION
# Fixes to FluxConfiguredAtmosphere and ConfiguredAtmosphere

See #375

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

This PR contains minor fixes to FluxConfiguredAtmosphere and ConfiguredAtmosphere related to developing the polynya setup described in #375. This setup can be run with either FluxConfiguredAtmosphere or ConfiguredAtmosphere, but both needed small fixes for it to work. For ConfiguredAtmosphere, I needed to add u and v winds, and for FluxConfiguredAtmosphere, there was a bug that reset the open-water fluxes.

---
# Test Description

Run with the polynya setup in issue375_polynya_working, and confirm that ice forms over open water using FluxConfiguredAtmosphere and that the ice drifts according to the prescribed wind velocities using ConfiguredAtmosphere.

---
# Documentation Impact

N/A

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README