### PR TITLE
Expand and restructure gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,22 +1,32 @@
-/build*
+# .gitignore
+
+# Directories
 */build
-Results
+/build*
 /.cproject
+/docs/html/
+/docs/latex/
+/docs/xml/
 /.project
+__pycache__/
 /.pydevproject
-/.settings/*
-/*/src/modules/include/*Module.hpp
-/*/src/modules/*/module.cpp
-/run/*.nc
-/run/nextsim
+/run/applications/*
 /run/.DS_Store
 /run/*.log
-/run/applications/*
-*.vtk
-*.smesh
+/run/*.nc
+/run/nextsim
+/.settings/*
+
+# File types
 *.DS_Store
+*.log
 *.nc
-__pycache__/
 *.sif
+*.smesh
 .*sw?
-/run/*.cdl
+*.vtk
+
+# Specific files
+Results
+/*/src/modules/include/*Module.hpp
+/*/src/modules/*/module.cpp


### PR DESCRIPTION
I recently built the nextSIM-DG docs and found that the current `.gitignore` does not ignore the various XML, HTML, etc. files that are generated, so I thought it'd be good to add these.

While I was at it, I restructured and sorted the gitignore more generally. I dropped `run/*.cdl` because this seems to me like something we do want to track.