### PR TITLE
Skip land points in stress update

### DIFF
--- a/dynamics/src/include/BBMStressUpdateStep.hpp
+++ b/dynamics/src/include/BBMStressUpdateStep.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file BBMStressUpdateStep.hpp
  *
- * @date 27 May 2025
+ * @date 15 Jul 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  * @author Tim Williams <timothy.williams@nersc.no>
  */
@@ -52,6 +52,9 @@ public:
 //! Stress and Damage Update
 #pragma omp parallel for
         for (size_t i = 0; i < smesh.nelements; ++i) {
+
+            if (smesh.landmask[i])
+                continue;
 
             //! Evaluate values in Gauss points (3 point Gauss rule in 2d => 9 points)
             const Eigen::Matrix<double, 1, nGauss * nGauss> hGauss

--- a/dynamics/src/include/MEVPStressUpdateStep.hpp
+++ b/dynamics/src/include/MEVPStressUpdateStep.hpp
@@ -1,7 +1,7 @@
 /*!
  * @file MEVPStressUpdateStep.hpp
  *
- * @date 19 Nov 2024
+ * @date 15 Jul 2025
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 
@@ -48,6 +48,9 @@ public:
         //! Stress Update
 #pragma omp parallel for
         for (size_t i = 0; i < smesh.nelements; ++i) {
+
+            if (smesh.landmask[i])
+                continue;
 
             // Here, one should check if it is enough to use a 2-point Gauss rule.
             // We're dealing with dG2, 3-point Gauss should be required.


### PR DESCRIPTION
# Skip land points in stress update

Fixes #883 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

This PR  adds an ``if(landmaks) continue`` statement at the top of the stressUpdateHighOrder functions of the BBM and mEVP stress update step classes. This prevents the instabilities noted in issue #883 from forming.

---
# Test Description

Run the model using 

```
[model]
init_file = init_25km_NH.nc
start = 2010-01-01T00:00:00Z
stop = 2010-01-05T00:00:00Z
time_step = P0-0T00:20:00
missing_value = 1e9

[debug]
check_fields = true

[Modules]
DiagnosticOutputModule = Nextsim::ConfigOutput
DynamicsModule = Nextsim::MEVPDynamics
IceThermodynamicsModule = Nextsim::ThermoIce0
AtmosphereBoundaryModule = Nextsim::ERA5Atmosphere
OceanBoundaryModule = Nextsim::TOPAZOcean

[ConfigOutput]
period = P0-0T0:20:00
start = 2000-01-01T00:00:00Z
#field_names = hsnow,hice,tice,cice,u,v,damage
filename = 25km_NH.diagnostic.nc

[ERA5Atmosphere]
file = 25km_NH.ERA5_2010-01-01_2010-01-10.nc
check_fields = true

[TOPAZOcean]
file = 25km_NH.TOPAZ4_2010-01-01_2010-01-10.nc
check_fields = true

[nextsim_thermo]
use_thermo_forcing = false
```

And confirm that before this PR the instabilities in #883 form, while after applying it they don't.

<img width="1572" height="1650" alt="image" src="https://github.com/user-attachments/assets/f1b3de31-81a4-488a-b369-5f67c7650243" />

There are still a few strange features, but only the straight line along the prime meridian from the pole is of any concern. This is almost certainly related to poor interpolation of the wind (this line is also visible in the wind field).

---
# Documentation Impact

None
---
# Other Details
None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README