### PR TITLE
Correctly skip land points in the stress update

### DIFF
--- a/dynamics/src/include/BBMStressUpdateStep.hpp
+++ b/dynamics/src/include/BBMStressUpdateStep.hpp
@@ -53,7 +53,7 @@ public:
 #pragma omp parallel for
         for (size_t i = 0; i < smesh.nelements; ++i) {
 
-            if (smesh.landmask[i])
+            if (!smesh.landmask[i])
                 continue;
 
             //! Evaluate values in Gauss points (3 point Gauss rule in 2d => 9 points)

--- a/dynamics/src/include/MEVPStressUpdateStep.hpp
+++ b/dynamics/src/include/MEVPStressUpdateStep.hpp
@@ -49,7 +49,7 @@ public:
 #pragma omp parallel for
         for (size_t i = 0; i < smesh.nelements; ++i) {
 
-            if (smesh.landmask[i])
+            if (!smesh.landmask[i])
                 continue;
 
             // Here, one should check if it is enough to use a 2-point Gauss rule.


### PR DESCRIPTION
# Correctly skip land points in the stress update

Related to #883 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

The previous version skipped _ocean_ points and not land points. So I added a not (!) to the commit in PR #884.

---
# Test Description

The instabilities in #883 are back, but the polynya test case (#797) now runs correctly again.

---
# Documentation Impact

None

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README
