### PR TITLE
ERA5 interpolation at the prime meridian

### DIFF
--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -210,11 +210,11 @@ if __name__ == "__main__":
                 v_data_source = v_file["v10"][time_index, :, :]
                 # Fix the polar row winds by copying the pole-adjacent row
                 # Pole in the first row
-                if abs(source_lats[0]) > 89.8:
+                if np.isclose(abs(source_lats[0]), 90., atol = 0.125):
                     u_data_source[0, :] = u_data_source[1, :]
                     v_data_source[0, :] = u_data_source[1, :]
                 # Pole in the last row
-                if abs(source_lats[-1]) > 89.8:
+                if np.isclose(abs(source_lats[-1]), 90., atol = 0.125):
                     u_data_source[-1, :] = u_data_source[-2, :]
                     v_data_source[-1, :] = u_data_source[-2, :]
                 # Now interpolate the source data to the target grid

--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -210,11 +210,11 @@ if __name__ == "__main__":
                 v_data_source = v_file["v10"][time_index, :, :]
                 # Fix the polar row winds by copying the pole-adjacent row
                 # Pole in the first row
-                if abs(source_lats[0]) == 90.:
+                if abs(source_lats[0]) > 89.8:
                     u_data_source[0, :] = u_data_source[1, :]
                     v_data_source[0, :] = u_data_source[1, :]
                 # Pole in the last row
-                if abs(source_lats[-1]) == 90.:
+                if abs(source_lats[-1]) > 89.8:
                     u_data_source[-1, :] = u_data_source[-2, :]
                     v_data_source[-1, :] = u_data_source[-2, :]
                 # Now interpolate the source data to the target grid

--- a/run/era5_topaz4_maker.py
+++ b/run/era5_topaz4_maker.py
@@ -211,12 +211,12 @@ if __name__ == "__main__":
                 # Fix the polar row winds by copying the pole-adjacent row
                 # Pole in the first row
                 if abs(source_lats[0]) == 90.:
-                    u_data_source[:, 0] = u_data_source[:, 1]
-                    v_data_source[:, 0] = u_data_source[:, 1]
+                    u_data_source[0, :] = u_data_source[1, :]
+                    v_data_source[0, :] = u_data_source[1, :]
                 # Pole in the last row
                 if abs(source_lats[-1]) == 90.:
-                    u_data_source[:, -1] = u_data_source[:, -2]
-                    v_data_source[:, -1] = u_data_source[:, -2]
+                    u_data_source[-1, :] = u_data_source[-2, :]
+                    v_data_source[-1, :] = u_data_source[-2, :]
                 # Now interpolate the source data to the target grid
                 u_data_target = np.zeros((ny, nx))
                 u_data_target = era5_interpolate(element_lon, element_lat, u_data_source, source_lons, source_lats)

--- a/run/interpolators.py
+++ b/run/interpolators.py
@@ -116,7 +116,7 @@ def rotate_velocities(u, v, angle):
 def rotate_pole_to_greenland(lat, lon):
     """
     Rotates the mesh such that the singularities are in Greenland / Antarctica at 75N / 40W and 75S / 140E
-    This is a copy of ParametricMesh::RotatePoleToGreenland in ParametricMesh.cpp. It's here for testing purposes only.
+    This is a copy of ParametricMesh::RotatePoleToGreenland in dynamics/src/include/ParametricMesh.hpp. It's here for testing purposes only.
 
     :param lat: Latitudes of the mesh
     :param lon: Longitudes of the mesh

--- a/run/interpolators.py
+++ b/run/interpolators.py
@@ -112,3 +112,32 @@ def rotate_velocities(u, v, angle):
     """
 
     return (u * np.cos(angle) + v * np.sin(angle), -u * np.sin(angle) + v * np.cos(angle))
+
+def rotate_pole_to_greenland(lat, lon):
+    """
+    Rotates the mesh such that the singularities are in Greenland / Antarctica at 75N / 40W and 75S / 140E
+    This is a copy of ParametricMesh::RotatePoleToGreenland in ParametricMesh.cpp. It's here for testing purposes only.
+
+    :param lat: Latitudes of the mesh
+    :param lon: Longitudes of the mesh
+    :return: A tuple of the rotated latitudes and longitudes.
+    """
+
+    latr = np.deg2rad(lat)
+    lonr = np.deg2rad(lon)
+
+    x = np.cos(latr) * np.cos(lonr)
+    y = np.cos(latr) * np.sin(lonr)
+    z = np.sin(latr)
+
+    aw = 40.0 * np.pi / 180.0
+    x1 = np.cos(aw) * x - np.sin(aw) * y
+    y1 = np.sin(aw) * x + np.cos(aw) * y
+    z1 = z
+
+    bw = 15.0 * np.pi / 180.0
+    x2 = np.cos(bw) * x1 - np.sin(bw) * z1
+    y2 = y1
+    z2 = np.sin(bw) * x1 + np.cos(bw) * z1
+
+    return (np.rad2deg(np.arcsin(z2)), np.rad2deg(np.arctan2(y2, x2)))

--- a/run/interpolators.py
+++ b/run/interpolators.py
@@ -130,12 +130,12 @@ def rotate_pole_to_greenland(lat, lon):
     y = np.cos(latr) * np.sin(lonr)
     z = np.sin(latr)
 
-    aw = 40.0 * np.pi / 180.0
+    aw = np.deg2rad(40.0)
     x1 = np.cos(aw) * x - np.sin(aw) * y
     y1 = np.sin(aw) * x + np.cos(aw) * y
     z1 = z
 
-    bw = 15.0 * np.pi / 180.0
+    bw = np.deg2rad(15.0)
     x2 = np.cos(bw) * x1 - np.sin(bw) * z1
     y2 = y1
     z2 = np.sin(bw) * x1 + np.cos(bw) * z1


### PR DESCRIPTION
# ERA5 interpolation at the prime meridian

Fixes #888 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---

There was a small bug in handling the interpolation of ERA5 fields. In ERA5, there is a row of values at the north pole, but you can't define the wind direction there using a lat/lon coordinate system. To address this, we wanted to copy the row south of the pole to this pole-row, as a crude fix, but the code copied the column along the prime meridian instead, which led to strange results there.

I've fixed this, so the copying happens as intended. It's not a perfect solution, but it's good enough for now.

---
# Test Description

Run the old and new versions of the era5_topaz4_maker.py script, and confirm that in the new version, the field is continuous across the prime meridian, while the old version produced a jump there.

---
# Documentation Impact
None

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] File dates have been updated to reflect modification date
- [x] This change conforms to the conventions described in the README