### PR TITLE
Set snow thickness in kernel when using mEVP

### DIFF
--- a/core/src/modules/DynamicsModule/MEVPDynamics.cpp
+++ b/core/src/modules/DynamicsModule/MEVPDynamics.cpp
@@ -97,6 +97,7 @@ void MEVPDynamics::setData(const ModelState::DataMap& ms)
     // Set the DG field data
     kernel.setDGArray(hiceName, hiceDG.allComponents());
     kernel.setDGArray(ciceName, ciceDG.allComponents());
+    kernel.setDGArray(hsnowName, hsnowDG.allComponents());
 }
 
 void MEVPDynamics::update(const TimestepTime& tst)


### PR DESCRIPTION
# Set snow thickness in kernel when using mEVP

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

The snow thickness was not set by the mEVP implementation. This now causes the model to crash when using the MEVPDynamics module, because the model tries (correctly) to advect snow, but there's no data there to advect. Easily fixed.

---
# Test Description

The model now runs again when using the MEVPDynamics module.

---
# Documentation Impact

None

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] This change conforms to the conventions described in the README