### PR TITLE
Add a "unit" attribute to the time variable

### DIFF
--- a/core/src/ParaGridIO.cpp
+++ b/core/src/ParaGridIO.cpp
@@ -448,6 +448,9 @@ void ParaGridIO::writeDiagnosticTime(
 #endif
     timeVar.putVar({ nt }, { 1 }, &secondsSinceEpoch);
 
+    if (isNew)
+        timeVar.putAtt("units", "seconds since 1970-01-01 00:00:00");
+
     // Write the data
     for (auto entry : state.data) {
         ModelArray::Type type = entry.second.getType();

--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -407,6 +407,9 @@ void ParaGridIO::writeDiagnosticTime(
 #endif
     timeVar.putVar({ nt }, { 1 }, &secondsSinceEpoch);
 
+    if (isNew)
+        timeVar.putAtt("units", "seconds since 1970-01-01 00:00:00");
+
     // Write the data
     for (auto entry : state.data) {
         ModelArray::Type type = entry.second.getType();


### PR DESCRIPTION
# Pull Request Title

Fixes #905 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

Add a "unit" attribute to the time variable

---
# Test Description

Run the integration test with the following config file:

```
[model]
init_file = init_25km_NH.nc
start = 2010-01-01T00:00:00Z
stop = 2010-01-01T01:00:00Z
time_step = P0-0T00:20:00
restart_file = out.integration_test.nc


[Modules]
DiagnosticOutputModule = Nextsim::ConfigOutput
DynamicsModule = Nextsim::BBMDynamics
IceThermodynamicsModule = Nextsim::ThermoWinton
AtmosphereBoundaryModule = Nextsim::ERA5Atmosphere
OceanBoundaryModule = Nextsim::TOPAZOcean

[ConfigOutput]
period = P0-0T00:20:00
start = 2000-01-01T00:00:00Z
#field_names = hsnow,hice,tice,cice,u,v,damage
filename = 25km_NH.diagnostic.nc

[ERA5Atmosphere]
file = 25km_NH.ERA5_2010-01-01T000000_test_data.nc

[TOPAZOcean]
file = 25km_NH.TOPAZ4_2010-01-01T000000_test_data.nc
```

With the new code, ncview, Panoply, and xarray are all able to deduce the correct times from the time axis.

---
# Documentation Impact

None

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] This change conforms to the conventions described in the README