### PR TITLE
Add missing Python requirements

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -111,7 +111,7 @@ Python dependencies
 -------------------
 
 To install the Python dependencies, first ensure that you have a Python
-environment set up. You can use `conda` or `virtualenv` for this purpose. Once
+environment set up. You can use ``conda`` or ``virtualenv`` for this purpose. Once
 you have created and activated your Python environment, you can install the
 required Python packages with
 .. code::

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -44,10 +44,7 @@ If your package manager is `Homebrew`_ :
         brew install eigen
 
 
-**Installing dependencies on Ubuntu**
-
-Compilation on a Debian-based Linux distribution (Debian, Ubuntu, etc)
-----------------------------------------------------------------------
+**Installing dependencies on a Debian-based Linux distribution (Debian, Ubuntu, etc)**
 
 You must have root privilege :
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -107,6 +107,17 @@ To unload an environment you can use the handy (and very fun) alias of ``despack
 information on using ``spack`` environments please see `using environments
 <https://spack.readthedocs.io/en/latest/environments.html#using-environments>`_.
 
+Python dependencies
+-------------------
+
+To install the Python dependencies, first ensure that you have a Python
+environment set up. You can use `conda` or `virtualenv` for this purpose. Once
+you have created and activated your Python environment, you can install the
+required Python packages with
+.. code::
+
+        pip install -r requirements.txt
+
 Building the code
 -----------------
 After all dependencies have been installed, we can build the code:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
-sphinx>=4.4.0
-myst_parser>=0.15.2
-sphinx_rtd_theme
 breathe
-Jinja2<3.1
 exhale
+Jinja2<3.1
+myst_parser>=0.15.2
+netCDF4
+pyproj
+scipy
+sphinx>=4.4.0
+sphinx_rtd_theme


### PR DESCRIPTION
@niravshah241 pointed out that `netCDF4` is missing from the list of Python requirements. I noticed a couple of others that should be added, too, and applied `sort`. I also added a section to the docs on installing Python dependencies.