### PR TITLE
Add Halo Exchange to Dynamics

### DIFF
--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -19,6 +19,10 @@
 
 #include <limits>
 
+#ifdef USE_MPI
+#include "include/Halo.hpp"
+#endif
+
 namespace Nextsim {
 
 template <int DGadvection>
@@ -272,6 +276,14 @@ template <int DGadvection> void CGDynamicsKernel<DGadvection>::prepareIteration(
     Interpolations::DG2CG(*smesh, cgA, data.at(ciceName));
     VectorManipulations::CGAveragePeriodic(*smesh, cgA);
 
+#ifdef USE_MPI
+    // Halo object only depends on shape of the array, so we can share it for all CGVectors of the
+    // same shape
+    Halo halo(cgH);
+    halo.exchangeHalos(cgH);
+    halo.exchangeHalos(cgA);
+#endif
+
     // Reinit the gradient of the sea surface height. Not done by
     // DataMap as seaSurfaceHeight is always dG(0)
     computeGradientOfSeaSurfaceHeight(DynamicsKernel<DGadvection, DGstressComp>::seaSurfaceHeight);
@@ -431,6 +443,12 @@ template <int DGadvection>
 DGVector<DGadvection>& CGDynamicsKernel<DGadvection>::advectDGVField(
     double timestep, DGVector<DGadvection>& field, double lowerLimit, double upperLimit)
 {
+
+#ifdef USE_MPI
+    Halo halo(field);
+    halo.exchangeHalos(field);
+#endif
+
     dgtransport->step(timestep, field);
 
     //! Slope Limiting

--- a/dynamics/src/include/BrittleCGDynamicsKernel.hpp
+++ b/dynamics/src/include/BrittleCGDynamicsKernel.hpp
@@ -15,6 +15,10 @@
 #include "include/constants.hpp"
 #include <cmath>
 
+#ifdef USE_MPI
+#include "include/Halo.hpp"
+#endif
+
 namespace Nextsim {
 
 // The brittle momentum solver for CG velocity fields
@@ -124,6 +128,12 @@ public:
         avgU.zero();
         avgV.zero();
 
+#ifdef USE_MPI
+        // Note: we only need to create one halo object per array type,
+        // dimensionality and size.
+        Halo halo(u);
+#endif
+
         for (size_t subStep = 0; subStep < params.nSteps; ++subStep) {
 
             projectVelocityToStrain();
@@ -139,6 +149,11 @@ public:
             updateMomentum(tst);
 
             applyBoundaries();
+
+#ifdef USE_MPI
+            halo.exchangeHalos(u);
+            halo.exchangeHalos(v);
+#endif
 
             // Land mask
         }


### PR DESCRIPTION
# Add Halo Exchange to Dynamics

Fixes #120 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [ ] ~Defined the tests that specify a complete and functioning change~ will be done in separate follow up PR (see issue #1071 
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

This PR adds halo exchange functionality to the dynamics and for advected fields.

After adding halo exchange into the dynamics we fix fields like `hice` for example.

<img width="1236" height="522" alt="image" src="https://github.com/user-attachments/assets/207651f1-2c16-4056-bf2d-607e2819e3c9" />

**Figure 1** `hice` (left) before halo exchange is added to dyanmics and (right) after.

After adding halo exchange into the `advectField` function we also fix it for advected fields like `tbottom`, `tsurf` and `tinterior`, for example.

<img width="1236" height="522" alt="image" src="https://github.com/user-attachments/assets/94366faa-db96-4eec-9d0e-dad1eb08a82e" />

**Figure 2** `tbottom` (left) before halo exchange is added to `advectField` and (right) after.

---
# Test Description

None currently

---
# Documentation Impact

None currently

---
# Other Details

### :warning: Open Problems:
* AFAIK for `Interpolations::DG2CG(smesh, cgVector, DGVector)` values inside the "inner" domain (i.e., not halo cells) depends on vertices set outside the inner cells i.e., from neighbouring points on the lattice. This means that you have to halo exchange the DGVector before you halo exchange the CGVector. It is not equivalent to first interpolate from DGVector onto CGVector and then halo exchange the CGVector.
*  We still don't have a solution for how to set vertices outside the main domain (so inner halo boundaries are fine, but points along the edge are not (also periodic boundaries would be an issue)
* When should halo exchange take place?
  * @Thanduriel raised point that we perhaps need to exchange after dynamics rather than before
  * @timspainNERSC think it should be before and possibly after
  * @TomMelt thinks just before should be enough
  * @einola either should work

### Todo

- [x] add halo exchange automatically for advected fields
- [ ] ~Need some scientific/statistical/sense tests to ensure correctness (raised in issue #247) -- perhaps an idealized test case?~ will be done in separate follow up PR (see issue #1071 