### PR TITLE
Introduce static `TimePartition` struct for `Iterator`

### DIFF
--- a/core/src/Iterator.cpp
+++ b/core/src/Iterator.cpp
@@ -1,5 +1,6 @@
 /*!
  * @author  Tim Spain <timothy.spain@nersc.no>
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
  */
 
 #include "include/Iterator.hpp"
@@ -10,37 +11,43 @@ namespace Nextsim {
 
 void Iterator::setStartStopStep(TimePoint startTime, TimePoint stopTime, Duration timestep)
 {
-    this->startTime = startTime;
-    this->stopTime = stopTime;
-    this->timestep = timestep;
+    TimePartition& timePartition = Iterator::getTimePartition();
+    timePartition.startTime = startTime;
+    timePartition.stopTime = stopTime;
+    timePartition.timestep = timestep;
 }
 
 TimePoint Iterator::parseAndSet(const std::string& startTimeStr, const std::string& stopTimeStr,
     const std::string& durationStr, const std::string& stepStr)
 {
+    TimePartition& timePartition = Iterator::getTimePartition();
+
     std::stringstream ss(startTimeStr);
-    ss >> startTime;
+    ss >> timePartition.startTime;
     ss = std::stringstream(stepStr);
-    ss >> timestep;
+    ss >> timePartition.timestep;
     if (!durationStr.empty()) {
         ss = std::stringstream(durationStr);
         Duration duration;
         ss >> duration;
-        stopTime = startTime + duration;
+        timePartition.stopTime = timePartition.startTime + duration;
     } else {
         ss = std::stringstream(stopTimeStr);
-        ss >> stopTime;
+        ss >> timePartition.stopTime;
     }
 
-    return startTime;
+    return timePartition.startTime;
 }
 
 void Iterator::run()
 {
-    iterant.start(startTime);
+    TimePartition& timePartition = Iterator::getTimePartition();
 
-    for (auto t = startTime; t < stopTime; t += timestep) {
-        TimestepTime tsTime = { t, timestep };
+    iterant.start(timePartition.startTime);
+
+    for (auto t = timePartition.startTime; t < timePartition.stopTime;
+         t += timePartition.timestep) {
+        TimestepTime tsTime = { t, timePartition.timestep };
         try {
             iterant.iterate(tsTime);
         } catch (const std::exception& e) {
@@ -50,7 +57,7 @@ void Iterator::run()
         }
     }
 
-    iterant.stop(stopTime);
+    iterant.stop(timePartition.stopTime);
 }
 
 } /* namespace Nextsim */

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -58,11 +58,8 @@ Model::Model()
 
 Model::~Model() { }
 
-void Model::configure()
+void Model::configureTime()
 {
-    // Configure logging
-    Logged::configure();
-
     // Store the start/stop/step configuration directly in ModelConfig before
     // parsing these values to the numerical time values used by the model.
     ModelConfig::startTimeStr
@@ -73,9 +70,17 @@ void Model::configure()
     ModelConfig::stepStr = Configured::getConfiguration(keyMap.at(TIMESTEP_KEY), std::string());
 
     // Set the time correspond to the current (initial) model state
-    TimePoint timeNow = Iterator::parseAndSet(ModelConfig::startTimeStr, ModelConfig::stopTimeStr,
+    TimePoint timeNow = iterator.parseAndSet(ModelConfig::startTimeStr, ModelConfig::stopTimeStr,
         ModelConfig::durationStr, ModelConfig::stepStr);
     m_etadata.setTime(timeNow);
+}
+
+void Model::configure()
+{
+    // Configure logging
+    Logged::configure();
+
+    configureTime();
 
     // Configure the missing data value
     MissingData::setValue(

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -73,7 +73,7 @@ void Model::configure()
     ModelConfig::stepStr = Configured::getConfiguration(keyMap.at(TIMESTEP_KEY), std::string());
 
     // Set the time correspond to the current (initial) model state
-    TimePoint timeNow = iterator.parseAndSet(ModelConfig::startTimeStr, ModelConfig::stopTimeStr,
+    TimePoint timeNow = Iterator::parseAndSet(ModelConfig::startTimeStr, ModelConfig::stopTimeStr,
         ModelConfig::durationStr, ModelConfig::stepStr);
     m_etadata.setTime(timeNow);
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -188,10 +188,9 @@ void Xios::finalize()
 }
 
 /*!
- * Overrides `Configure` method from `Configured`
+ * @brief   Overrides `Configure` method from `Configured`
  *
- * Configure the XIOS server if XIOS is enabled in the settings.
- *
+ * @details Configure the XIOS server if XIOS is enabled in the settings.
  */
 void Xios::configure()
 {
@@ -199,39 +198,11 @@ void Xios::configure()
     istringstream(Configured::getConfiguration(keyMap.at(ENABLED_KEY), std::string()))
         >> std::boolalpha >> isEnabled;
 
-    // Extract the start time from the model configuration
-    // TODO: Deduce from Model.iterator rather than duplicating here?
-    std::string startTimeStr;
-    istringstream(Configured::getConfiguration(keyMap.at(STARTTIME_KEY), std::string()))
-        >> startTimeStr;
-    if (startTimeStr.length() == 0) {
-        Logged::warning("Xios: Setting default start: 1970-01-01T00:00:00Z");
-        startTimeStr = "1970-01-01T00:00:00Z";
-    }
-    startTime = TimePoint(startTimeStr);
-
-    // Extract the timestep from the model configuration
-    // TODO: Deduce from Model.iterator rather than duplicating here?
-    std::string timeStepStr;
-    istringstream(Configured::getConfiguration(keyMap.at(TIME_STEP_KEY), std::string()))
-        >> timeStepStr;
-    if (timeStepStr.length() == 0) {
-        Logged::warning("Xios: Setting default time_step: P0-0T01:00:00");
-        timeStepStr = "P0-0T01:00:00";
-    }
-    timestep = Duration(timeStepStr);
-
-    // Extract the stop time from the model configuration
-    // TODO: Deduce from Model.iterator rather than duplicating here?
-    std::string stopTimeStr;
-    istringstream(Configured::getConfiguration(keyMap.at(STOPTIME_KEY), std::string()))
-        >> stopTimeStr;
-    if (stopTimeStr.length() == 0) {
-        Logged::warning("Xios: Setting default stop: start time plus P0-0T01:00:00");
-        stopTime = startTime + timestep;
-    } else {
-        stopTime = TimePoint(stopTimeStr);
-    }
+    // Extract the time partition information from the Iterator class
+    Iterator::TimePartition& timePartition = Iterator::getTimePartition();
+    startTime = timePartition.startTime;
+    timestep = timePartition.timestep;
+    stopTime = timePartition.stopTime;
 
     if (isEnabled) {
         configureServer();

--- a/core/src/include/Iterator.hpp
+++ b/core/src/include/Iterator.hpp
@@ -1,5 +1,6 @@
 /*!
  * @author  Tim Spain <timothy.spain@nersc.no>
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
  */
 
 #ifndef SRC_INCLUDE_ITERATOR_HPP
@@ -34,7 +35,7 @@ public:
      * @param stopTime Stop time point.
      * @param timestep Timestep length.
      */
-    void setStartStopStep(TimePoint startTime, TimePoint stopTime, Duration timestep);
+    static void setStartStopStep(TimePoint startTime, TimePoint stopTime, Duration timestep);
     /*!
      * @brief Sets the time parameters as a start time, run length and timestep
      * length.
@@ -57,18 +58,28 @@ public:
      * @param durationStr string to parse for the model run duration.
      * @param stepStr string to parse for the model time step length.
      */
-    TimePoint parseAndSet(const std::string& startTimeStr, const std::string& stopTimeStr,
+    static TimePoint parseAndSet(const std::string& startTimeStr, const std::string& stopTimeStr,
         const std::string& durationStr, const std::string& stepStr);
     //! Run the Iterant over the specified time period.
     void run();
 
 private:
+    // A struct to hold information related to the time partition.
+    struct TimePartition {
+        TimePoint startTime;
+        TimePoint stopTime;
+        Duration timestep;
+    };
     Iterant& iterant;
-    TimePoint startTime;
-    TimePoint stopTime;
-    Duration timestep;
 
 public:
+    //! Returns a reference to the static TimePartition instance.
+    static TimePartition& getTimePartition()
+    {
+        static TimePartition instance;
+        return instance;
+    }
+
     //! A base class for classes that specify what happens during one timestep.
     class Iterant {
     public:

--- a/core/src/include/Iterator.hpp
+++ b/core/src/include/Iterator.hpp
@@ -63,16 +63,13 @@ public:
     //! Run the Iterant over the specified time period.
     void run();
 
-private:
     // A struct to hold information related to the time partition.
     struct TimePartition {
         TimePoint startTime;
         TimePoint stopTime;
         Duration timestep;
     };
-    Iterant& iterant;
 
-public:
     //! Returns a reference to the static TimePartition instance.
     static TimePartition& getTimePartition()
     {
@@ -80,6 +77,10 @@ public:
         return instance;
     }
 
+private:
+    Iterant& iterant;
+
+public:
     //! A base class for classes that specify what happens during one timestep.
     class Iterant {
     public:

--- a/core/src/include/Model.hpp
+++ b/core/src/include/Model.hpp
@@ -31,6 +31,8 @@ public:
 #endif
     ~Model(); // Finalize the model. Collect data and so on.
 
+    void configureTime();
+
     void configure() override;
 
     enum {

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -15,6 +15,7 @@
 #if USE_XIOS
 
 #include "include/Configured.hpp"
+#include "include/Iterator.hpp"
 #include "include/Logged.hpp"
 #include "include/ModelArray.hpp"
 #include "include/ModelConfig.hpp"

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -95,7 +95,11 @@ if(ENABLE_MPI)
         target_compile_definitions(testXiosAxis_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
             testXiosAxis_MPI3
-            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+            PRIVATE
+                ${PHYSICS_INCLUDE_DIRS}
+                "${MODEL_INCLUDE_DIR}"
+                "${XIOS_INCLUDE_LIST}"
+                "${ModulesRoot}/StructureModule"
         )
         target_link_libraries(testXiosAxis_MPI3 PRIVATE nextsimlib doctest::doctest)
 
@@ -103,7 +107,11 @@ if(ENABLE_MPI)
         target_compile_definitions(testXiosGrid_MPI2 PRIVATE USE_XIOS)
         target_include_directories(
             testXiosGrid_MPI2
-            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+            PRIVATE
+                ${PHYSICS_INCLUDE_DIRS}
+                "${MODEL_INCLUDE_DIR}"
+                "${XIOS_INCLUDE_LIST}"
+                "${ModulesRoot}/StructureModule"
         )
         target_link_libraries(testXiosGrid_MPI2 PRIVATE nextsimlib doctest::doctest)
 
@@ -111,7 +119,11 @@ if(ENABLE_MPI)
         target_compile_definitions(testXiosField_MPI3 PRIVATE USE_XIOS)
         target_include_directories(
             testXiosField_MPI3
-            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+            PRIVATE
+                ${PHYSICS_INCLUDE_DIRS}
+                "${MODEL_INCLUDE_DIR}"
+                "${XIOS_INCLUDE_LIST}"
+                "${ModulesRoot}/StructureModule"
         )
         target_link_libraries(testXiosField_MPI3 PRIVATE nextsimlib doctest::doctest)
 
@@ -119,7 +131,11 @@ if(ENABLE_MPI)
         target_compile_definitions(testXiosFile_MPI2 PRIVATE USE_XIOS)
         target_include_directories(
             testXiosFile_MPI2
-            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+            PRIVATE
+                ${PHYSICS_INCLUDE_DIRS}
+                "${MODEL_INCLUDE_DIR}"
+                "${XIOS_INCLUDE_LIST}"
+                "${ModulesRoot}/StructureModule"
         )
         target_link_libraries(testXiosFile_MPI2 PRIVATE nextsimlib doctest::doctest)
 
@@ -131,7 +147,11 @@ if(ENABLE_MPI)
         )
         target_include_directories(
             testXiosRead_MPI2
-            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+            PRIVATE
+                ${PHYSICS_INCLUDE_DIRS}
+                "${MODEL_INCLUDE_DIR}"
+                "${XIOS_INCLUDE_LIST}"
+                "${ModulesRoot}/StructureModule"
         )
         target_link_libraries(testXiosRead_MPI2 PRIVATE nextsimlib doctest::doctest)
 
@@ -139,7 +159,11 @@ if(ENABLE_MPI)
         target_compile_definitions(testXiosWrite_MPI2 PRIVATE USE_XIOS)
         target_include_directories(
             testXiosWrite_MPI2
-            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+            PRIVATE
+                ${PHYSICS_INCLUDE_DIRS}
+                "${MODEL_INCLUDE_DIR}"
+                "${XIOS_INCLUDE_LIST}"
+                "${ModulesRoot}/StructureModule"
         )
         target_link_libraries(testXiosWrite_MPI2 PRIVATE nextsimlib doctest::doctest)
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -83,7 +83,11 @@ if(ENABLE_MPI)
         target_compile_definitions(testXiosCalendar_MPI1 PRIVATE USE_XIOS)
         target_include_directories(
             testXiosCalendar_MPI1
-            PRIVATE "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}" "${ModulesRoot}/StructureModule"
+            PRIVATE
+                ${PHYSICS_INCLUDE_DIRS}
+                "${MODEL_INCLUDE_DIR}"
+                "${XIOS_INCLUDE_LIST}"
+                "${ModulesRoot}/StructureModule"
         )
         target_link_libraries(testXiosCalendar_MPI1 PRIVATE nextsimlib doctest::doctest)
 

--- a/core/test/Iterator_test.cpp
+++ b/core/test/Iterator_test.cpp
@@ -52,7 +52,7 @@ TEST_CASE("Count iterator testing")
     Duration overall(dt);
     overall *= nSteps;
     TimePoint stop = start + overall;
-    iterator.setStartStopStep(start, start + overall, dt);
+    Iterator::setStartStopStep(start, start + overall, dt);
     iterator.run();
 
     REQUIRE(dt.seconds() == 1);

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -12,7 +12,10 @@
 
 #include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Finalizer.hpp"
+#include "include/Model.hpp"
 #include "include/Xios.hpp"
+
+#include <mpi.h>
 
 namespace Nextsim {
 
@@ -27,7 +30,19 @@ namespace Nextsim {
  */
 MPI_TEST_CASE("TestXiosAxis", 3)
 {
+    // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
+    std::stringstream config;
+    config << "[model]" << std::endl;
+    config << "start = 2023-03-17T17:11:00Z" << std::endl;
+    config << "stop = 2023-03-17T18:11:00Z" << std::endl;
+    config << "time_step = P0-0T01:00:00" << std::endl;
+    std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
+    Configurator::addStream(std::move(pcstream));
+
+    // Create a Model and configure it so that time partition options are parsed
+    Model model(MPI_COMM_WORLD);
+    model.configureTime();
 
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -13,7 +13,10 @@
 #include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Configurator.hpp"
 #include "include/Finalizer.hpp"
+#include "include/Model.hpp"
 #include "include/Xios.hpp"
+
+#include <mpi.h>
 
 namespace Nextsim {
 
@@ -33,9 +36,14 @@ MPI_TEST_CASE("TestXiosCalendar", 1)
     std::stringstream config;
     config << "[model]" << std::endl;
     config << "start = 2023-03-17T17:11:00Z" << std::endl;
+    config << "stop = 2023-03-17T18:11:00Z" << std::endl;
     config << "time_step = P0-0T01:00:00" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
+
+    // Create a Model and configure it so that time partition options are parsed
+    Model model(MPI_COMM_WORLD);
+    model.configureTime();
 
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();

--- a/core/test/XiosField_test.cpp
+++ b/core/test/XiosField_test.cpp
@@ -12,7 +12,10 @@
 
 #include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Finalizer.hpp"
+#include "include/Model.hpp"
 #include "include/Xios.hpp"
+
+#include <mpi.h>
 
 namespace Nextsim {
 
@@ -30,12 +33,20 @@ MPI_TEST_CASE("TestXiosField", 3)
     // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
     std::stringstream config;
+    config << "[model]" << std::endl;
+    config << "start = 2023-03-17T17:11:00Z" << std::endl;
+    config << "stop = 2023-03-17T18:11:00Z" << std::endl;
+    config << "time_step = P0-0T01:00:00" << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "period = P0-0T03:00:00" << std::endl;
     config << "filename = xios_test_output" << std::endl;
     config << "field_names = field_A" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
+
+    // Create a Model and configure it so that time partition options are parsed
+    Model model(MPI_COMM_WORLD);
+    model.configureTime();
 
     // Get the Xios singleton instance and check it's initialized
     Xios& xiosHandler = Xios::getInstance();

--- a/core/test/XiosFile_test.cpp
+++ b/core/test/XiosFile_test.cpp
@@ -13,8 +13,10 @@
 #include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Configurator.hpp"
 #include "include/Finalizer.hpp"
-#include "include/ModelMetadata.hpp"
+#include "include/Model.hpp"
 #include "include/Xios.hpp"
+
+#include <mpi.h>
 
 using namespace doctest;
 
@@ -36,6 +38,7 @@ MPI_TEST_CASE("TestXiosFile", 2)
     std::stringstream config;
     config << "[model]" << std::endl;
     config << "start = 2023-03-17T17:11:00Z" << std::endl;
+    config << "stop = 2023-03-17T18:11:00Z" << std::endl;
     config << "time_step = P0-0T01:30:00" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "period = P0-0T03:00:00" << std::endl;
@@ -47,6 +50,10 @@ MPI_TEST_CASE("TestXiosFile", 2)
     config << "field_names = field_2D" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
+
+    // Create a Model and configure it so that options are parsed
+    Model model(MPI_COMM_WORLD);
+    model.configureTime(); // TODO: Use Model.configure to parse restart files this way, too?
 
     // Create ModelMetadata instance based off a partition metadata file
     ModelMetadata metadata("xios_test_partition_metadata_2.nc", test_comm);

--- a/core/test/XiosGrid_test.cpp
+++ b/core/test/XiosGrid_test.cpp
@@ -11,8 +11,11 @@
 #undef INFO
 
 #include "include/Finalizer.hpp"
+#include "include/Model.hpp"
 #include "include/ModelMetadata.hpp"
 #include "include/Xios.hpp"
+
+#include <mpi.h>
 
 namespace Nextsim {
 
@@ -27,7 +30,19 @@ namespace Nextsim {
  */
 MPI_TEST_CASE("TestXiosGrid", 2)
 {
+    // Enable XIOS in the 'config' and provide parameters to configure it
     enableXios();
+    std::stringstream config;
+    config << "[model]" << std::endl;
+    config << "start = 2023-03-17T17:11:00Z" << std::endl;
+    config << "stop = 2023-03-17T18:11:00Z" << std::endl;
+    config << "time_step = P0-0T01:00:00" << std::endl;
+    std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
+    Configurator::addStream(std::move(pcstream));
+
+    // Create a Model and configure it so that time partition options are parsed
+    Model model(MPI_COMM_WORLD);
+    model.configureTime();
 
     // Create ModelMetadata instance based off a partition metadata file
     ModelMetadata metadata("xios_test_partition_metadata_2.nc", test_comm);

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -11,13 +11,14 @@
 
 #include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Finalizer.hpp"
-#include "include/ModelMetadata.hpp"
+#include "include/Model.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
 #include "include/Xios.hpp"
 #include "include/gridNames.hpp"
 
 #include <filesystem>
+#include <mpi.h>
 
 const std::string testFilesDir = TEST_FILES_DIR;
 const std::string filename = testFilesDir + "/xios_test_input.nc";
@@ -37,12 +38,17 @@ MPI_TEST_CASE("TestXiosRead", 2)
     std::stringstream config;
     config << "[model]" << std::endl;
     config << "start = 2023-03-17T17:11:00Z" << std::endl;
+    config << "stop = 2023-03-17T23:11:00Z" << std::endl;
     config << "time_step = P0-0T01:30:00" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "filename = xios_test_input.nc" << std::endl;
     config << "field_names = hice" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
+
+    // Create a Model and configure it so that options are parsed
+    Model model(MPI_COMM_WORLD);
+    model.configureTime(); // TODO: Use Model.configure to parse restart files this way, too?
 
     // Create ParametricGrid and ParaGridIO instances
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");

--- a/core/test/XiosRead_test.cpp
+++ b/core/test/XiosRead_test.cpp
@@ -43,6 +43,7 @@ MPI_TEST_CASE("TestXiosRead", 2)
     config << "[XiosInput]" << std::endl;
     config << "filename = xios_test_input.nc" << std::endl;
     config << "field_names = hice" << std::endl;
+    config << "period = P0-0T01:30:00" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -79,12 +80,6 @@ MPI_TEST_CASE("TestXiosRead", 2)
     // Create HField and ZField instances to read the data into
     HField hice(ModelArray::Type::H);
     hice.resize();
-
-    // Setup ModelState with field above
-    ModelState state = { {
-                             { hiceName, hice },
-                         },
-        {} };
 
     // Check calendar step is zero initially
     REQUIRE(xiosHandler.getCalendarStep() == 0);

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -11,13 +11,14 @@
 
 #include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Finalizer.hpp"
-#include "include/ModelMetadata.hpp"
+#include "include/Model.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
 #include "include/Xios.hpp"
 #include "include/gridNames.hpp"
 
 #include <filesystem>
+#include <mpi.h>
 
 namespace Nextsim {
 
@@ -34,12 +35,17 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     std::stringstream config;
     config << "[model]" << std::endl;
     config << "start = 2023-03-17T17:11:00Z" << std::endl;
+    config << "stop = 2023-03-17T23:11:00Z" << std::endl;
     config << "time_step = P0-0T01:30:00" << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "filename = xios_test_output.nc" << std::endl;
     config << "field_names = hice" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
+
+    // Create a Model and configure it so that options are parsed
+    Model model(MPI_COMM_WORLD);
+    model.configureTime(); // TODO: Use Model.configure to parse restart files this way, too?
 
     // Create ParametricGrid and ParaGridIO instances
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");

--- a/core/test/XiosWrite_test.cpp
+++ b/core/test/XiosWrite_test.cpp
@@ -40,6 +40,7 @@ MPI_TEST_CASE("TestXiosWrite", 2)
     config << "[XiosOutput]" << std::endl;
     config << "filename = xios_test_output.nc" << std::endl;
     config << "field_names = hice" << std::endl;
+    config << "period = P0-0T01:30:00" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -27,13 +27,14 @@ build nextSIM-DG with XIOS as the I/O driver.
   [xios]
   enable = true
 
-The ``model`` section, which is used elsewhere in nextSIM-DG, contains two
-entries relevant to XIOS: ``start`` and ``time_step``. These are used to
-configure the calendar used by XIOS and take the following default values.
+The ``model`` section, which is used elsewhere in nextSIM-DG, contains three
+entries relevant to XIOS: ``start``, ``stop``, and ``time_step``. These are
+used to configure the calendar used by XIOS. For example,
 
 .. code-block::
   [model]
   start = 1970-01-01T00:00:00Z
+  stop = 1970-01-01T01:00:00Z
   time_step = P0-0T01:00:00
 
 Files and fields to be read and written to files are configured via
@@ -49,6 +50,11 @@ labelled ``field_A`` and ``field_B``, which are written to file
   fields = field_A,field_B
 
 Note that both the ``XiosInput`` and ``XiosOutput`` sections are optional.
+
+As elsewhere in the model, these configuration values are parsed by calling the
+``Model.configure`` member function. Since building with XIOS implies also
+building with MPI, you will need to pass the MPI communicator to this member
+function when calling it.
 
 Developer notes
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Introduce static `TimePartition` struct for `Iterator`

Fixes #925

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

This PR follows the recommendation in #925 to reduce duplication of configuration code by introducing a `TimePartition` struct and a static instance of it associated with the `Iterator` class. This gets set up during `Model.configure` and may be accessed from other classes via the `Iterator::getTimePartition` interface.

---
# Test Description

The XIOS tests are updated to be configured by `Model`, so all of them now create an instance of this at the start. However, they currently use a reduced `configureTime` because setting up restart and partition files seems unnecessary for most of them.

---
# Documentation Impact

The XIOS doc pages are updated to reflect these changes.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] This change conforms to the conventions described in the README