### PR TITLE
Local docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,18 @@
 /docs/html/
 /docs/latex/
 /docs/xml/
+/docs/_build/
+
+# ignore all files in docs/api except for manually maintained rst files
+/docs/api/*
+!/docs/api/class.rst
+!/docs/api/counttimercpp.rst
+!/docs/api/function.rst
+!/docs/api/index.rst
+!/docs/api/num.rst
+!/docs/api/structure.rst
+!/docs/api/typedef.rst
+
 /.project
 __pycache__/
 /.pydevproject

--- a/Dockerfiles/Dockerfile.sphinx
+++ b/Dockerfiles/Dockerfile.sphinx
@@ -1,0 +1,16 @@
+FROM sphinxdoc/sphinx
+
+WORKDIR /docs
+ADD requirements.txt /docs
+ADD scripts/build-docs.sh /
+ADD scripts/doxygen_prep.sh /
+RUN pip3 install -r requirements.txt
+
+RUN apt-get update \
+ && apt-get install --no-install-recommends --yes \
+      doxygen \
+ && apt-get autoremove \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["bash", "/build-docs.sh"]

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -252,3 +252,38 @@ If you want to run a subset of tests, you can use the `-R` option with a regular
     ctest -R Xios
 
 For more information on `ctest` options, you can refer to the official `ctest` documentation.
+
+Building the Documentation (Locally)
+------------------------------------
+
+If you would like to build the documentation locally, follow the instructions below.
+
+A Dockerfile is provided in the ``Dockerfiles`` directory to build the documentation i.e., ``Dockerfile.sphinx``.
+
+To build the docker image run the following command from the root of the repository:
+
+.. code-block:: console
+
+    docker build --file Dockerfiles/Dockerfile.sphinx . -t nextsim-docs:latest
+
+This should create a local docker image called ``nextsim-docs:latest``.
+
+To build the documentation, run the following command from the root of the repository:
+
+.. code-block:: console
+
+    docker run --rm -v $PWD:/docs nextsim-docs:latest
+
+Optionally, you can specify the number of jobs to use for building the documentation. For example, to use 4 jobs, run:
+
+.. code-block:: console
+
+    docker run --rm -v $PWD:/docs nextsim-docs:latest 4
+
+Finally, to view the built documentation, open the file ``docs/_build/html/index.html`` in your web browser e.g.,
+
+.. code-block:: console
+
+    xdg-open docs/_build/html/index.html  # Linux
+    open docs/_build/html/index.html      # MacOS
+    start docs\_build\html\index.html     # Windows

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+for EXTENSION in cpp hpp ipp; do
+    find . -name "*.${EXTENSION}" -exec /doxygen_prep.sh {} \;
+done
+cd docs && doxygen
+
+if [ -z "$1" ]; then
+    JOBS=1
+else
+    JOBS=$1
+fi
+sphinx-build -M html . _build --jobs $JOBS


### PR DESCRIPTION
# Build docs locally

Add `Dockerfile` to support building the docs locally. This is extremely helpful for debugging changes to the documentation without having to push to the `docs` branch

- adds `Dockerfiles/Dockerfile.sphinx` to create a docker image
- adds explanation of how to build and run docker image in `docs/installation.rst`

relates to closed issue #436