### PR TITLE
fix XIOS documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,8 +64,8 @@ limitations under the License.
    model-components
    numerical-implementation
    outputs-diagnostics
-   
-   
+   xios
+
 .. toctree::
    :caption: INSTALLATION
    :maxdepth: 1

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -24,6 +24,7 @@ The ``xios`` section contains a single entry, which determines whether or not to
 build nextSIM-DG with XIOS as the I/O driver.
 
 .. code-block::
+
   [xios]
   enable = true
 
@@ -32,6 +33,7 @@ entries relevant to XIOS: ``start`` and ``time_step``. These are used to
 configure the calendar used by XIOS and take the following default values.
 
 .. code-block::
+
   [model]
   start = 1970-01-01T00:00:00Z
   time_step = P0-0T01:00:00
@@ -43,6 +45,7 @@ labelled ``field_A`` and ``field_B``, which are written to file
 ``my_output_file.nc`` every two (simulated) hours.
 
 .. code-block::
+
   [XiosOutput]
   period = P0-0T02:00:00
   filename = my_output_file.nc


### PR DESCRIPTION
fixes #941 

Using the new docker image to build docs locally #942 I noticed there were some issues with xios's documentation.

1. It wasn't actually included in a ToC so it never got displayed in the docs
2. The code blocks were missing a newline which meant they were not rendered

This PR resolves those issues.