### PR TITLE
Parallelizing overElements

### DIFF
--- a/core/src/include/ModelComponent.hpp
+++ b/core/src/include/ModelComponent.hpp
@@ -196,6 +196,7 @@ public:
 protected:
     inline static void overElements(IteratedFn fn, const TimestepTime& tst)
     {
+#pragma omp parallel for
         for (size_t i = 0; i < nOcean; ++i) {
             fn(oceanIndex[i], tst);
         }


### PR DESCRIPTION
# OpenMP parallelization of Thermodynamics

Fixes #334 

---
# Change Description

We parallelized the function overElements() with a simple OpenMP directive, which accelerates the thermodynamics module.

---
# Test Description

The thermodynamics test case was conducted on a bigger domain, the results of the parallelized code were identical to the previous output.

---
# Documentation Impact

None.

---
# Other Details

None.

---
