### PR TITLE
Fix typos and unclear output array names

### DIFF
--- a/core/src/modules/include/ProtectedArrayNames.ipp
+++ b/core/src/modules/include/ProtectedArrayNames.ipp
@@ -34,8 +34,8 @@
     { "qdw", "SLAB_QDW" }, // Slab ocean temperature nudging heat flux, W m⁻²
     { "fdw", "SLAB_FDW" }, // Slab ocean salinity nudging water flux, kg s⁻¹ m⁻²
     { "ssh", "SSH" }, // Sea-surface height [m]
-    { "taux", "IO_STRESS_X" }, // Ice-ocean stress x(east) direction, Pa
-    { "tauy", "IO_STRESS_Y" }, // Ice-ocean stress y(north) direction, Pa
+    { "taux_io", "IO_STRESS_X" }, // Ice-ocean stress x(east) direction, Pa
+    { "tauy_io", "IO_STRESS_Y" }, // Ice-ocean stress y(north) direction, Pa
     { "shear", "SHEAR" }, // The instantaneous share rate, s⁻¹
     { "divergence", "DIV" }, // The instantaneous divergence, s⁻¹
     { "sigma_I", "SIGMAI" }, // The first stress invariant, Pa

--- a/core/src/modules/include/SharedArrayNames.ipp
+++ b/core/src/modules/include/SharedArrayNames.ipp
@@ -22,5 +22,5 @@
     { "new_ice", "NEW_ICE" }, // Volume of new ice formed [m]
     { "qsw_base", "Q_SW_BASE" }, // Short-wave flux through ice base W m⁻²
     { "qsw_ow", "Q_SW_OW" }, // Short-wave flux into ice free ocean W m⁻²
-    { "taux_ow", "OW_STRESS_Y" }, // y(north)-ward open ocean stress, Pa
-    { "tauy_ow", "OW_STRESS_X" }, // x(east)-ward open ocean stress, Pa
+    { "taux_ow", "OW_STRESS_X" }, // x(east)-ward open ocean stress, Pa
+    { "tauy_ow", "OW_STRESS_Y" }, // y(north)-ward open ocean stress, Pa


### PR DESCRIPTION
# Fix typos and unclear output array names

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

There was a typo in ``SharedArrayNames.ipp``, and the name for ice-ocean stress in ``ProtectedArrayNames.ipp`` was misleading (Guillaume and I thought it was the total stress seen by the ocean, but it's just the ice-ocean stress). I've come up with something I think is more descriptive.

---
# Test Description

I ran the model with ``ConfigOutput`` and ``fieldnames = taux_io, taux_ow, tauy_io, tauy_ow`` and everything works as expected.

---
# Documentation Impact

None

---
# Other Details

N/A

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] This change conforms to the conventions described in the README