### PR TITLE
Avoid land nodes when calculating ice-ocean stress

### DIFF
--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -17,7 +17,6 @@
 #include "include/VectorManipulations.hpp"
 #include "include/cgVector.hpp"
 
-#include <cmath>
 #include <limits>
 
 namespace Nextsim {

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -17,6 +17,7 @@
 #include "include/VectorManipulations.hpp"
 #include "include/cgVector.hpp"
 
+#include <cmath>
 #include <limits>
 
 namespace Nextsim {
@@ -448,6 +449,9 @@ void CGDynamicsKernel<DGadvection>::updateIceOceanStress(
 
 #pragma omp parallel for
     for (int i = 0; i < uIceOceanStress.rows(); ++i) {
+        if (pmap->cglandmask(i) == 0)
+            continue;
+
         const FloatType uOceanRel = uOcean(i) - uIce(i);
         const FloatType vOceanRel = vOcean(i) - vIce(i);
         const FloatType cPrime = FOcean * std::hypot(uOceanRel, vOceanRel);

--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -41,25 +41,39 @@ void CGDynamicsKernel<DGadvection>::initialise(
     pmap->InitializeCGLandmask();
 
     u.resize_by_mesh(*smesh);
+    u.setZero();
     v.resize_by_mesh(*smesh);
+    v.setZero();
 
     cgH.resize_by_mesh(*smesh);
+    cgH.setZero();
     cgA.resize_by_mesh(*smesh);
+    cgA.setZero();
 
     xGradSeaSurfaceHeight.resize_by_mesh(*smesh);
+    xGradSeaSurfaceHeight.setZero();
     yGradSeaSurfaceHeight.resize_by_mesh(*smesh);
+    yGradSeaSurfaceHeight.setZero();
 
     dStressX.resize_by_mesh(*smesh);
+    dStressX.setZero();
     dStressY.resize_by_mesh(*smesh);
+    dStressY.setZero();
 
     uOcean.resize_by_mesh(*smesh);
+    uOcean.setZero();
     vOcean.resize_by_mesh(*smesh);
+    vOcean.setZero();
 
     uAtmos.resize_by_mesh(*smesh);
+    uAtmos.setZero();
     vAtmos.resize_by_mesh(*smesh);
+    vAtmos.setZero();
 
     uIceOceanStress.resize_by_mesh(*smesh);
+    uIceOceanStress.setZero();
     vIceOceanStress.resize_by_mesh(*smesh);
+    vIceOceanStress.setZero();
 
     cosOceanAngle = std::cos(radians(baseParams.oceanTurningAngle));
     sinOceanAngle = std::sin(radians(baseParams.oceanTurningAngle));


### PR DESCRIPTION
# Avoid land nodes when calculating ice-ocean stress

Fixes #964 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---

I set all the CGDynamicsKernel CG variables to zero in the initialise call and then added an "if on land continue" clause to ``updateIceOceanStress``.

---
# Test Description

This has little effect in my setup, since the CG variables are set to all zero on resize by the compiler. There is, however, no guaranty that this happens on different platforms - it's a compiler specific behaviour. I suspect that it may be causing problems on our HPC, but testing is diffucult. I can only do it when Guillaume is back from holidays! I'm putting this in anyway, because it's a reasonable change to make.

---
# Documentation Impact

None

---
# Other Details

None

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] This change conforms to the conventions described in the README