### PR TITLE
fix failing mac ci

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -191,6 +191,8 @@ jobs:
         brew install eigen
         brew install netcdf
         brew install netcdf-cxx
+        python3 -m venv ~/nextsim
+        . $HOME/nextsim/bin/activate
         pip install netCDF4
         pip install numpy
 
@@ -203,6 +205,7 @@ jobs:
 
     - name: make
       run: |
+        . $HOME/nextsim/bin/activate
         mkdir -p build
         cd build
         # added Python_ROOT_DIR to help cmake find correct Python in the mac VM
@@ -210,6 +213,7 @@ jobs:
         make -j 4
     - name: run serial tests
       run: |
+        . $HOME/nextsim/bin/activate
         cd build
         ctest -V
         mv ../test .


### PR DESCRIPTION
This PR fixes the failing mac CI build

- adds a virtual env for `numpy` and `netCDF4`
- uses venv in CMake build and running of tests

Original workflow was failing because CMake autodetects the latest version of python `3.14` but default `pip` installs into `3.13`