### PR TITLE
ci: fix mac ci workflow to detect venv

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -208,8 +208,7 @@ jobs:
         . $HOME/nextsim/bin/activate
         mkdir -p build
         cd build
-        # added Python_ROOT_DIR to help cmake find correct Python in the mac VM
-        cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_MPI=OFF -DENABLE_XIOS=OFF -DPython_ROOT_DIR=/Library/Frameworks/Python.framework/Versions/Current/bin ..
+        cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_MPI=OFF -DENABLE_XIOS=OFF ..
         make -j 4
     - name: run serial tests
       run: |


### PR DESCRIPTION
## Fix failing mac CI

- previous CI was failing because it could not detect `netCDF4` package in the python venv
- This caused the integration test to fail when they couldn't load the auto-generated `.nc` files

This PR fixes that by correctly locating the venv in the CMake build stage

### Notes

`-DPython_ROOT_DIR=/Library/Frameworks/Python.framework/Versions/Current/bin` is no longer required. This was used when we were trying to use the system python. But venv's will be prioritized by default.