### PR TITLE
Build docs on pushing to develop

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,9 +2,9 @@
 name: Build docs
 
 on:
-  # Trigger the workflow upon merging into main or docs
+  # Trigger the workflow upon merging into main, develop, or docs
   push:
-    branches: [ main, docs ]
+    branches: [ main, develop, docs ]
 
   # Trigger the workflow whenever commits are pushed to an open PR that changes one of the file types listed
   pull_request:


### PR DESCRIPTION
I noticed that the docs only ever get deployed upon pushing to `main` or `docs`, but we agreed that this should also happen upon pushing to `develop`, i.e., when a PR gets merged into `develop`.