### PR TITLE
bug: replace nullptr with MPI_COMM_NULL

### DIFF
--- a/core/src/include/ModelMPI.hpp
+++ b/core/src/include/ModelMPI.hpp
@@ -27,7 +27,7 @@ private:
     static bool doOnce();
 
 public:
-    inline static ModelMPI& getInstance(MPI_Comm comm = nullptr)
+    inline static ModelMPI& getInstance(MPI_Comm comm = MPI_COMM_NULL)
     {
         static ModelMPI instance = ModelMPI(comm);
         if (instance.isInitialized) {


### PR DESCRIPTION
Replace `nullptr` with `MPI_COMM_NULL` to stop failing conversion from `nullptr` to `int`

Fixes #986 

Thanks @docguibou for raising the issue.

Please can you confirm if this fixes your compilation issue.
