### PR TITLE
Fix doc build

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,9 +41,7 @@ jobs:
           sudo apt update
           sudo apt install doxygen -y
           pip install -r requirements.txt
-          cp scripts/build-docs.sh .
-          cp scripts/doxygen_prep.sh .
-          ./build-docs.sh
+          ./scripts/build-docs.sh
 
     # tmate can be used to get an interactive ssh session to the GitHub runner
     # for debugging actions. See
@@ -73,9 +71,7 @@ jobs:
           sudo apt update
           sudo apt install doxygen -y
           pip install -r requirements.txt
-          cp scripts/build-docs.sh .
-          cp scripts/doxygen_prep.sh .
-          ./build-docs.sh
+          ./scripts/build-docs.sh
 
     - name: Deploy to GitHub Pages
       if: success() && (github.ref == 'refs/heads/main')

--- a/Dockerfiles/Dockerfile.sphinx
+++ b/Dockerfiles/Dockerfile.sphinx
@@ -1,16 +1,17 @@
 FROM sphinxdoc/sphinx
 
 WORKDIR /docs
-ADD requirements.txt /docs
+ADD requirements.txt .
 ADD scripts/build-docs.sh /
-ADD scripts/doxygen_prep.sh /
-RUN pip3 install -r requirements.txt
 
 RUN apt-get update \
- && apt-get install --no-install-recommends --yes \
-      doxygen \
+ && apt-get install --no-install-recommends -y doxygen git \
  && apt-get autoremove \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install -r requirements.txt
+
+RUN git config --global --add safe.directory /docs
 
 ENTRYPOINT ["bash", "/build-docs.sh"]

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -19,47 +19,6 @@ SOURCE_BROWSER = YES
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
-CLASS_DIAGRAMS         = YES
-MSCGEN_PATH            = 
-DIA_PATH               = 
-HIDE_UNDOC_RELATIONS   = YES
-HAVE_DOT               = YES
-DOT_NUM_THREADS        = 0
-DOT_FONTNAME           = Helvetica
-DOT_FONTSIZE           = 10
-DOT_FONTPATH           = 
-CLASS_GRAPH            = YES
-COLLABORATION_GRAPH    = YES
-GROUP_GRAPHS           = YES
-UML_LOOK               = YES
-UML_LIMIT_NUM_FIELDS   = 50
-TEMPLATE_RELATIONS     = YES
-INCLUDE_GRAPH          = YES
-INCLUDED_BY_GRAPH      = YES
-CALL_GRAPH             = YES
-CALLER_GRAPH           = YES
-GRAPHICAL_HIERARCHY    = YES
-DIRECTORY_GRAPH        = YES
-DOT_IMAGE_FORMAT       = png
-INTERACTIVE_SVG        = NO
-DOT_PATH               = 
-DOTFILE_DIRS           = 
-MSCFILE_DIRS           = 
-DIAFILE_DIRS           = 
-PLANTUML_JAR_PATH      = 
-PLANTUML_INCLUDE_PATH  = 
-DOT_GRAPH_MAX_NODES    = 100
-MAX_DOT_GRAPH_DEPTH    = 0
-DOT_TRANSPARENT        = YES
-DOT_MULTI_TARGETS      = NO
-GENERATE_LEGEND        = YES
-DOT_CLEANUP            = YES
-
-#---------------------------------------------------------------------------
-# Configuration options related to the dot tool
-#---------------------------------------------------------------------------
-CLASS_DIAGRAMS         = YES
-MSCGEN_PATH            = 
 DIA_PATH               = 
 HIDE_UNDOC_RELATIONS   = YES
 HAVE_DOT               = YES

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ breathe
 exhale
 jinja2
 myst_parser>=0.15.2
-netCDF4
+netCDF4<1.7.4
 pyproj
 scipy
 sphinx>=4.4.0

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 for EXTENSION in cpp hpp ipp; do
-  find . -name "*.${EXTENSION}" -exec doxygen_prep.sh {} \;
+  find . -name "*.${EXTENSION}" -exec ./scripts/doxygen_prep.sh {} \;
 done
 cd docs && doxygen
 


### PR DESCRIPTION
# Fix documentation build workflow

Fixes #1008

**Description:**

This PR addresses issues with the documentation build workflow by making several improvements:

1. Simplified CI workflow - Removed unnecessary file copying in the GitHub Actions workflow and directly use scripts from their original location
2. Fixed Docker build - Updated the `Dockerfile.sphinx` to:
    * Install `git` (required for the build process)
    * Add proper safe directory configuration for `git`
    * Lock `netCDF4` version to `<1.7.4` due to compatibility issues with Debian bookworm
3. Removed duplicate `Doxyfile` settings
4. Updated `requirements.txt` - Pinned `netCDF4` version to ensure compatibility
5. Fixed script paths - Updated `build-docs.sh` to use proper relative paths for script execution

These changes ensure the documentation can be built reliably in both CI environments and Docker containers.