### PR TITLE
Fix race condition in computeGradientOfSeaSurfaceHeight

### DIFF
--- a/dynamics/src/CGDynamicsKernel.cpp
+++ b/dynamics/src/CGDynamicsKernel.cpp
@@ -215,9 +215,9 @@ void CGDynamicsKernel<DGadvection>::computeGradientOfSeaSurfaceHeight(
         yGradSeaSurfaceHeight = vGrad;
     } else {
         // outer nodes
-        size_t icg1 = 0;
 #pragma omp parallel for
         for (size_t iy = 0; iy <= smesh->ny; ++iy) {
+            size_t icg1 = (smesh->nx + 1) * iy;
             size_t icg2 = (2 * smesh->nx + 1) * 2 * iy;
             for (size_t ix = 0; ix <= smesh->nx; ++ix, ++icg1, icg2 += 2) {
                 xGradSeaSurfaceHeight(icg2) = uGrad(icg1);


### PR DESCRIPTION
# Fixed race condition in computeGradientOfSeaSurfaceHeight

Fixes #1012
---
# Change Description

The index variable was moved inside the ```omp parallel for``` scope so that each thread has its own to iterate on. This was already done for the updates along lines and midpoints and just wrong for the outer nodes.

---
# Test Description

I verified that the results are now deterministic.