### PR TITLE
Drop Trilinos from Spack config

### DIFF
--- a/Dockerfiles/spack.yaml
+++ b/Dockerfiles/spack.yaml
@@ -10,7 +10,6 @@ spack:
   - netcdf-cxx4@4.3.1
   - netcdf-fortran
   - openmpi@4.1.6
-  - trilinos
   - zlib-ng@2.1.4
   - zoltan
   concretizer:

--- a/spack.yaml
+++ b/spack.yaml
@@ -10,7 +10,6 @@ spack:
   - netcdf-cxx4@4.3.1
   - netcdf-fortran
   - openmpi@4.1.6
-  - trilinos
   - zlib-ng@2.1.4
   - zoltan
   concretizer:


### PR DESCRIPTION
Closes https://github.com/nextsimhub/domain_decomp/issues/79.

The Zoltan partitioner is needed by `domain_decomp`, so we include it in the Spack configuration for nextSIM-DG. One way to install Zoltan is by installing Trilinos and providing the appropriate options. (See https://sandialabs.github.io/Zoltan/ug_html/ug_usage.html#Building%20the%20Library) When building from source, we can tell the Trilinos build system not to install all its functionality and instead only to install Zoltan. This is what's done in the `domain_decomp` Mac CI.

In the Spack config, however, we include both `zoltan` and `trilinos` as entries. Whenever I rebuild my Spack config, I find that `trilinos` is a real bottleneck that takes a long time as well as much processing power. But it's unnecessary as far as nextSIM-DG or `domain_decomp` are concerned because `zoltan` is already included in the Spack config. I propose that we drop it. I've done this and rerun the tests locally, which seem to be fine.