### PR TITLE
Test XIOS reading and writing with different ranks

### DIFF
--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -233,21 +233,21 @@ if(ENABLE_MPI)
         )
         target_link_libraries(testXiosReadForcing_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosReadDiagnostic_MPI2 "XiosReadDiagnostic_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosReadDiagnostic_MPI2
+        add_executable(testXiosReadDiagnostic_MPI3 "XiosReadDiagnostic_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosReadDiagnostic_MPI3
             PRIVATE
                 USE_XIOS
                 TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"
         )
         target_include_directories(
-            testXiosReadDiagnostic_MPI2
+            testXiosReadDiagnostic_MPI3
             PRIVATE
                 ${PHYSICS_INCLUDE_DIRS}
                 "${MODEL_INCLUDE_DIR}"
                 "${XIOS_INCLUDE_LIST}"
                 "${ModulesRoot}/StructureModule"
         )
-        target_link_libraries(testXiosReadDiagnostic_MPI2 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosReadDiagnostic_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosReadRestart_MPI2 "XiosReadRestart_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosReadRestart_MPI2
@@ -302,7 +302,7 @@ if(ENABLE_MPI)
             testXiosAxis_MPI3
             testXiosField_MPI3
             testXiosReadForcing_MPI2
-            testXiosReadDiagnostic_MPI2
+            testXiosReadDiagnostic_MPI3
             testXiosReadRestart_MPI2
             testXiosWriteDiagnostic_MPI2
             testXiosWriteRestart_MPI2
@@ -312,7 +312,7 @@ if(ENABLE_MPI)
 
         # Ensure XiosWrite<Diagnostic/Restart>_test are run before XiosRead<Diagnostic/Restart>_test
         set_tests_properties(testXiosReadRestart_MPI2 PROPERTIES DEPENDS testXiosWriteRestart_MPI2)
-        set_tests_properties(testXiosReadDiagnostic_MPI2
+        set_tests_properties(testXiosReadDiagnostic_MPI3
                              PROPERTIES DEPENDS testXiosWriteDiagnostic_MPI2)
     else()
         add_executable(testHaloExchangeCB_MPI3

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -34,7 +34,7 @@ namespace Nextsim {
  * 2. Test the file writing functionality via `writeDiagnosticTime` in the sense of checking that
  *    time-averaging is applied.
  */
-MPI_TEST_CASE("TestXiosReadDiagnostic", 2)
+MPI_TEST_CASE("TestXiosReadDiagnostic", 3)
 {
     std::stringstream config;
     config << "[model]" << std::endl;
@@ -43,7 +43,7 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 2)
     config << "time_step = P0-0T01:30:00" << std::endl;
     config << "init_file = " << diagnosticFilename << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
-    config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
+    config << "partition_file = xios_test_partition_metadata_3.nc" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << hsnowName << std::endl;
     config << "period = P0-0T03:00:00" << std::endl;


### PR DESCRIPTION
Fixes #1004.
~~Merges into #1011.~~

This PR modifies the diagnostic reading test to use a different number of MPI ranks from the corresponding write test (3 vs. 2) to check this is possible.

We aren't currently able to do the same for the restart tests because the information they encode depends on the rank.