### PR TITLE
Don't delete XIOS source files

### DIFF
--- a/Dockerfiles/install-xios.sh
+++ b/Dockerfiles/install-xios.sh
@@ -85,6 +85,5 @@ rm -r \
   /xios/inputs \
   /xios/obj \
   /xios/ppsrc \
-  /xios/src \
   /xios/tools \
   /xios/xios_test_suite


### PR DESCRIPTION
I'm currently debugging #1017 in test PR #1019. Thanks to @TomMelt for helping to set up MPI debugging with [mdb](github.com/TomMelt/mdb) within a [tmate](https://github.com/tmate-io/tmate) session.

I'm getting backtraces that trace back into XIOS and provide line numbers for where the errors crop up. However, in the `nextsimdg-dev-env` Docker image we delete the `/xios/src` directory to save space, so I can't see what the file contents actually are. Also, the XIOS revision is sufficiently different from my local checkout and from trunk.

Given that the `nextsimdg-dev-env` Docker image is 2.43GB and the `src` subdirectory only around 9MB, I the small memory footprint reduction is not worth the hassle of difficult debugging, so propose to keep it in there.

In updating the Docker spec, this PR should also rebuild the image with the latest XIOS version, which might just make my issue go away :crossed_fingers: