### PR TITLE
Further XIOS Docker improvements

### DIFF
--- a/Dockerfiles/Dockerfile.devenv
+++ b/Dockerfiles/Dockerfile.devenv
@@ -1,18 +1,21 @@
 # Build stage with Spack pre-installed and ready to be used
 FROM spack/ubuntu-noble:latest AS builder
 
-# Install software from spack_devenv.yaml
+# Install perl and subversion
+RUN apt update \
+    && apt install -y --no-install-recommends libany-uri-escape-perl subversion \
+    && rm -rf /var/lib/apt/lists/*
+
+# Pre-fetch XIOS source code
+RUN svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk /xios
+
+# Install software from spack.yaml
 RUN mkdir /opt/spack-environment
 COPY Dockerfiles/spack.yaml /opt/spack-environment/spack.yaml
 RUN cd /opt/spack-environment \
     && spack env activate . \
     && spack install --fail-fast \
     && spack gc -y
-
-# Install perl URI lib
-RUN apt update \
-    && apt install -y --no-install-recommends libany-uri-escape-perl \
-    && rm -rf /var/lib/apt/lists/*
 
 # Download and install domain_decomp and XIOS
 COPY Dockerfiles/install-xios.sh .

--- a/Dockerfiles/install-xios.sh
+++ b/Dockerfiles/install-xios.sh
@@ -61,7 +61,7 @@ cat <<EOF >arch/arch-GCC_LINUX.fcm
 %DEV_CFLAGS     -g -O2
 %DEBUG_CFLAGS   -fPIC -g
 
-%BASE_FFLAGS    -D__NONE__
+%BASE_FFLAGS    -D__NONE__ -ffree-line-length-312
 %PROD_FFLAGS    -fPIC -O3
 %DEV_FFLAGS     -g -O2
 %DEBUG_FFLAGS   -fPIC -g

--- a/Dockerfiles/install-xios.sh
+++ b/Dockerfiles/install-xios.sh
@@ -1,5 +1,7 @@
 #!/bin/env bash
 
+set -eu
+
 # Checkout (clone) current version of XIOS using Subversion (svn)
 INSTALLDIR="/xios"
 if [ ! -d "${INSTALLDIR}" ]; then

--- a/Dockerfiles/install-xios.sh
+++ b/Dockerfiles/install-xios.sh
@@ -4,7 +4,7 @@
 INSTALLDIR="/xios"
 if [ ! -d "${INSTALLDIR}" ]; then
   cd /
-  svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk ${INSTALLDIR}
+  svn checkout -r 2880 http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk ${INSTALLDIR}
 fi
 cd ${INSTALLDIR}
 

--- a/Dockerfiles/install-xios.sh
+++ b/Dockerfiles/install-xios.sh
@@ -4,7 +4,7 @@
 INSTALLDIR="/xios"
 if [ ! -d "${INSTALLDIR}" ]; then
   cd /
-  svn checkout -r 2880 http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk ${INSTALLDIR}
+  svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk ${INSTALLDIR}
 fi
 cd ${INSTALLDIR}
 

--- a/Dockerfiles/install-xios.sh
+++ b/Dockerfiles/install-xios.sh
@@ -1,9 +1,11 @@
 #!/bin/env bash
 
 # Checkout (clone) current version of XIOS using Subversion (svn)
-cd /
-INSTALLDIR="xios"
-svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk ${INSTALLDIR}
+INSTALLDIR="/xios"
+if [ ! -d "${INSTALLDIR}" ]; then
+  cd /
+  svn checkout http://forge.ipsl.fr/ioserver/svn/XIOS3/trunk ${INSTALLDIR}
+fi
 cd ${INSTALLDIR}
 
 # Create a file for exporting paths to the include and lib directories for XIOS' dependencies

--- a/Dockerfiles/spack.yaml
+++ b/Dockerfiles/spack.yaml
@@ -1,7 +1,6 @@
 spack:
   specs:
   - boost@1.80.0+log+program_options
-  - catch2
   - 'cmake@3.20:'
   - eigen@3.4.0
   - gmake

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,7 +1,6 @@
 spack:
   specs:
   - boost@1.80.0+log+program_options
-  - catch2
   - 'cmake@3.20:'
   - eigen@3.4.0
   - gmake


### PR DESCRIPTION
While the CI went green for #1020, there's actually a compile error for the latest version of XIOS that's buried in the log that just passes silently by and means that the build is invalid:
https://github.com/nextsimhub/nextsimdg/actions/runs/21171077630/job/60887695501
```
#13 94.57 mpif90 -o xios_interfaces.o -I/xios/inc -D__NONE__ -fPIC -g -I /opt/software/linux-icelake/netcdf-c-4.9.2-feq3oeblknumop7mleuadfmucslifvg4/include -I /opt/software/linux-icelake/netcdf-fortran-4.6.2-4zi4ypagr27nzq3bnw3tweeouraetemn/include   -I/xios/extern/boost_extraction/include -I/xios/extern/blitz -c /xios/ppsrc/xios/interface/fortran/ixios_interfaces.f90
#13 94.60 /xios/ppsrc/xios/interface/fortran/ixios_interfaces.f90:53:132:
#13 94.60 
#13 94.60    53 | USE iextract_domain_attr, ONLY : xios_set_extract_domain_attr_hdl, xios_get_extract_domain_attr_hdl, xios_is_defined_extract_domain_attr_hdl
#13 94.60       |                                                                                                                                    1
#13 94.60 Error: Line truncated at (1) [-Werror=line-truncation]
#13 94.66 /xios/ppsrc/xios/interface/fortran/ixios_interfaces.f90:53:100:
#13 94.66 
#13 94.66    53 | USE iextract_domain_attr, ONLY : xios_set_extract_domain_attr_hdl, xios_get_extract_domain_attr_hdl, xios_is_defined_extract_domain_attr_hdl
#13 94.66       |                                                                                                    1
#13 94.66 Error: Symbol ‘xios_is_defined_extract_domain_’ referenced at (1) not found in module ‘iextract_domain_attr’
#13 94.70 /xios/ppsrc/xios/interface/fortran/ixios_interfaces.f90:178:58:
#13 94.70 
#13 94.70   178 |                    xios_is_defined_expand_domain_attr_hdl, xios_is_defined_extract_domain_attr_hdl, &
#13 94.70       |                                                          1
#13 94.70 Error: Procedure ‘xios_is_defined_extract_domain_attr_hdl’ in generic interface 'xios_is_defined_attr' at (1) is neither function nor subroutine
#13 94.71 f951: some warnings being treated as errors
```

This PR avoids this issue by ~~reverting to revision 2880, which I've been using locally and know to work well~~ extending the maximum line length with `-ffree-line-length-312`.

While I was at it, I thought it would be immensely valuable to pre-fetch XIOS before starting the Spack build because sometimes connectivity issues cause this to fail. I added `set -eu` in the XIOS installation script to ensure such failures get picked up and don't slide by silently.

I also dropped the Catch2 dependency, that's not been needed since https://github.com/nextsimhub/domain_decomp/pull/62 was merged.