### PR TITLE
Test `stateFromFile` with XIOS

### DIFF
--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -42,16 +42,18 @@ ParaGridIO::~ParaGridIO() = default;
 
 ModelState ParaGridIO::getModelState(const std::string& filePath)
 {
-    ModelState state;
-    ModelMetadata& metadata = ModelMetadata::getInstance();
+    // Close the XIOS context definition, if it hasn't already been closed
     Xios& xiosHandler = Xios::getInstance();
+    xiosHandler.close_context_definition();
 
+    ModelMetadata& metadata = ModelMetadata::getInstance();
     if (metadata.initialFileName != filePath) {
         throw std::runtime_error("ParaGridIO::getModelState: file path '" + filePath
             + "' is inconsistent with model.init_file '" + metadata.initialFileName + "'");
     }
 
     // Get all variables in the file and load them into a new ModelState
+    ModelState state;
     for (const std::string& fieldId : xiosHandler.configGetInputRestartFieldNames()) {
         const ModelArray::Type& type = xiosHandler.getFieldType(fieldId);
         if (type == ModelArray::Type::H) {
@@ -96,8 +98,9 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
 ModelState ParaGridIO::readForcingTimeStatic(
     const std::set<std::string>& forcings, const TimePoint& time, const std::string& filePath)
 {
-    ModelState state;
+    // Close the XIOS context definition, if it hasn't already been closed
     Xios& xiosHandler = Xios::getInstance();
+    xiosHandler.close_context_definition();
 
     if (xiosHandler.forcingFilename != filePath) {
         throw std::runtime_error("ParaGridIO::readForcingTimeStatic: file path '" + filePath
@@ -115,6 +118,7 @@ ModelState ParaGridIO::readForcingTimeStatic(
     }
 
     // Get all forcings and load them into a new ModelState
+    ModelState state;
     const std::set<std::string> forcingFieldIds = xiosHandler.configGetForcingFieldNames();
     for (const std::string& fieldId : forcings) {
         if (forcingFieldIds.count(fieldId) == 0) {
@@ -140,9 +144,11 @@ ModelState ParaGridIO::readForcingTimeStatic(
 
 void ParaGridIO::dumpModelState(const ModelState& state, const std::string& filePath)
 {
-    ModelMetadata& metadata = ModelMetadata::getInstance();
+    // Close the XIOS context definition, if it hasn't already been closed
     Xios& xiosHandler = Xios::getInstance();
+    xiosHandler.close_context_definition();
 
+    ModelMetadata& metadata = ModelMetadata::getInstance();
     if (metadata.finalFileName != filePath) {
         throw std::runtime_error("ParaGridIO::dumpModelState: file path '" + filePath
             + "' is inconsistent with model.restart_file '" + metadata.finalFileName + "'");
@@ -162,7 +168,9 @@ void ParaGridIO::dumpModelState(const ModelState& state, const std::string& file
 
 void ParaGridIO::writeDiagnosticTime(const ModelState& state, const std::string& filePath)
 {
+    // Close the XIOS context definition, if it hasn't already been closed
     Xios& xiosHandler = Xios::getInstance();
+    xiosHandler.close_context_definition();
 
     if (xiosHandler.diagnosticFilename != filePath) {
         throw std::runtime_error("ParaGridIO::writeDiagnosticTime: file path '" + filePath

--- a/core/src/StructureFactory.cpp
+++ b/core/src/StructureFactory.cpp
@@ -8,10 +8,11 @@
 #include "include/Finalizer.hpp"
 #include "include/IStructure.hpp"
 #include "include/NextsimModule.hpp"
-
-#include "include/RectGridIO.hpp"
-
 #include "include/ParaGridIO.hpp"
+#include "include/RectGridIO.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#endif
 
 #include <ncFile.h>
 #include <ncGroupAtt.h>
@@ -46,6 +47,7 @@ ModelState StructureFactory::stateFromFile(const std::string& filePath)
 {
     Finalizer::registerUnique(Module::finalize<IStructure>);
 
+#ifndef USE_XIOS
     std::string structureName = structureNameFromFile(filePath);
     // TODO There must be a better way
     if (RectangularGrid::structureName == structureName) {
@@ -54,16 +56,23 @@ ModelState StructureFactory::stateFromFile(const std::string& filePath)
         gridIn.setIO(new RectGridIO(gridIn));
         return gridIn.getModelState(filePath);
     } else if (ParametricGrid::structureName == structureName) {
+#endif
         Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
         ParametricGrid gridIn;
         gridIn.setIO(new ParaGridIO(gridIn));
+#ifdef USE_XIOS
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.close_context_definition();
+#endif
         return gridIn.getModelState(filePath);
+#ifndef USE_XIOS
     } else {
         throw std::invalid_argument(
             std::string("fileFromName: structure not implemented: ") + structureName);
     }
     throw std::invalid_argument(std::string("fileFromName: structure not implemented: ")
         + structureName + "\nAlso, how did you get here?");
+#endif
     return ModelState();
 }
 

--- a/core/src/StructureFactory.cpp
+++ b/core/src/StructureFactory.cpp
@@ -47,8 +47,11 @@ ModelState StructureFactory::stateFromFile(const std::string& filePath)
 {
     Finalizer::registerUnique(Module::finalize<IStructure>);
 
-#ifndef USE_XIOS
+#ifdef USE_XIOS
+    std::string structureName = ParametricGrid::structureName;
+#else
     std::string structureName = structureNameFromFile(filePath);
+#endif
     // TODO There must be a better way
     if (RectangularGrid::structureName == structureName) {
         Module::setImplementation<IStructure>("Nextsim::RectangularGrid");
@@ -56,23 +59,16 @@ ModelState StructureFactory::stateFromFile(const std::string& filePath)
         gridIn.setIO(new RectGridIO(gridIn));
         return gridIn.getModelState(filePath);
     } else if (ParametricGrid::structureName == structureName) {
-#endif
         Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
         ParametricGrid gridIn;
         gridIn.setIO(new ParaGridIO(gridIn));
-#ifdef USE_XIOS
-        Xios& xiosHandler = Xios::getInstance();
-        xiosHandler.close_context_definition();
-#endif
         return gridIn.getModelState(filePath);
-#ifndef USE_XIOS
     } else {
         throw std::invalid_argument(
             std::string("fileFromName: structure not implemented: ") + structureName);
     }
     throw std::invalid_argument(std::string("fileFromName: structure not implemented: ")
         + structureName + "\nAlso, how did you get here?");
-#endif
     return ModelState();
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -149,7 +149,7 @@ Xios::~Xios() { finalize(); }
 //! Close XIOS context definition once xml config has been read and calendar settings updated
 void Xios::close_context_definition()
 {
-    if (isEnabled) {
+    if (isEnabled && contextStatus == DEFINITION_OPEN) {
 
         // Ensure that base fields have operation type 'instant' if not already defined
         std::set<std::string> fieldIds = configGetInputRestartFieldNames();
@@ -168,6 +168,7 @@ void Xios::close_context_definition()
         }
 
         cxios_context_close_definition();
+        contextStatus = DEFINITION_CLOSED;
     }
 }
 
@@ -209,6 +210,10 @@ void Xios::configure()
 //! Initialize the XIOS context with ID contextId
 void Xios::setupContext()
 {
+    if (contextStatus != PRE_DEFINITION) {
+        throw std::runtime_error("Xios: context was already created");
+    }
+
     // Initialize the XIOS context 'nextSIM-DG'
     cxios_context_initialize(contextId.c_str(), contextId.length(), &clientComm_F);
 
@@ -235,6 +240,8 @@ void Xios::setupContext()
         throw std::runtime_error(
             "Xios: current context ID does not match expected ID '" + contextId + "'");
     }
+
+    contextStatus = DEFINITION_OPEN;
 }
 
 //! Initialize calendar wrapper for the context

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -105,6 +105,12 @@ private:
     void setupClient();
 
     /* Context */
+    enum {
+        PRE_DEFINITION,
+        DEFINITION_OPEN,
+        DEFINITION_CLOSED,
+    };
+    int contextStatus = PRE_DEFINITION;
     const std::string contextId = "nextSIM-DG";
     void setupContext();
 

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -106,9 +106,9 @@ private:
 
     /* Context */
     enum {
-        PRE_DEFINITION,
-        DEFINITION_OPEN,
-        DEFINITION_CLOSED,
+        PRE_DEFINITION, // XIOS context has not yet been initialized
+        DEFINITION_OPEN, // XIOS context has been initialized but the definition has not been closed
+        DEFINITION_CLOSED, // XIOS context definition has been closed
     };
     int contextStatus = PRE_DEFINITION;
     const std::string contextId = "nextSIM-DG";

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -49,10 +49,8 @@ int main(int argc, char* argv[])
         // Construct the Model
 #ifdef USE_MPI
         Nextsim::ModelMPI& modelMPI = Nextsim::ModelMPI::getInstance(MPI_COMM_WORLD);
-        Nextsim::Model model;
-#else
-        Nextsim::Model model;
 #endif
+        Nextsim::Model model;
         // Apply the model configuration
         model.configure();
         // Run the Model

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -79,7 +79,7 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 2)
 
     // Read restarts from file and check they take the expected values
     // NOTE: The ParametricGrid is created and the XIOS context definition is closed in the call to
-    // StructureFactory::stateFromFile()
+    //       StructureFactory::stateFromFile()
     for (const auto [fieldName, modelarray] :
         StructureFactory::stateFromFile(diagnosticFilename).data) {
         REQUIRE(fieldName == hsnowName);

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -12,6 +12,7 @@
 #include "include/ModelMPI.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
+#include "include/StructureFactory.hpp"
 #include "include/Xios.hpp"
 #include "include/gridNames.hpp"
 
@@ -50,6 +51,12 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 2)
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
+    // Check the input file exists
+    if (!std::filesystem::exists(diagnosticFilename)) {
+        throw std::runtime_error(
+            "XiosReadDiagnostic_test: Input file not found. Did you run XiosWrite_test?");
+    }
+
     // Create ModelMPI instance based off the test communicator
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
@@ -59,28 +66,11 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 2)
     model.configureRestarts();
     model.configureTime();
 
-    // Get the Xios singleton instance and check it's initialized
+    // Get the Xios singleton instance and check calendar step is zero initially
     // NOTE: The singleton is created when Xios::getInstance() is first called. In this test, this
     //       happens when the time sets set by ModelMetadata::setTime(). This occurs in the call to
     //       Model::configureTime() above.
     Xios& xiosHandler = Xios::getInstance();
-
-    // Create ParametricGrid and ParaGridIO instances
-    // NOTE: XIOS axes, domains, and grids are created by the ParaGridIO constructor
-    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-    ParametricGrid grid;
-    ParaGridIO* pio = new ParaGridIO(grid);
-    grid.setIO(pio);
-
-    xiosHandler.close_context_definition();
-
-    // Check the input file exists
-    if (!std::filesystem::exists(diagnosticFilename)) {
-        throw std::runtime_error(
-            "XiosReadDiagnostic_test: Input file not found. Did you run XiosWrite_test?");
-    }
-
-    // Check calendar step is zero initially
     REQUIRE(xiosHandler.getCalendarStep() == 0);
 
     // Deduce the local lengths of the two dimensions
@@ -88,7 +78,10 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 2)
     const size_t ny = ModelArray::size(ModelArray::Dimension::Y);
 
     // Read restarts from file and check they take the expected values
-    for (const auto [fieldName, modelarray] : grid.getModelState(diagnosticFilename).data) {
+    // NOTE: The ParametricGrid is created and the XIOS context definition is closed in the call to
+    // StructureFactory::stateFromFile()
+    for (const auto [fieldName, modelarray] :
+        StructureFactory::stateFromFile(diagnosticFilename).data) {
         REQUIRE(fieldName == hsnowName);
         for (size_t j = 0; j < ny; ++j) {
             for (size_t i = 0; i < nx; ++i) {

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -6,12 +6,10 @@
 #include <doctest/extensions/doctest_mpi.h>
 #undef INFO
 
-#include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Finalizer.hpp"
 #include "include/Model.hpp"
 #include "include/ModelMPI.hpp"
 #include "include/NextsimModule.hpp"
-#include "include/ParaGridIO.hpp"
 #include "include/StructureFactory.hpp"
 #include "include/Xios.hpp"
 #include "include/gridNames.hpp"

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -79,7 +79,7 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
 
     // Read restarts from file and check they take the expected values
     // NOTE: The ParametricGrid is created and the XIOS context definition is closed in the call to
-    // StructureFactory::stateFromFile()
+    //       StructureFactory::stateFromFile()
     int rank;
     MPI_Comm_rank(test_comm, &rank);
     float ts = 2; // Corresponds to 2023-03-17T20:10:59Z

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -6,12 +6,10 @@
 #include <doctest/extensions/doctest_mpi.h>
 #undef INFO
 
-#include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Finalizer.hpp"
 #include "include/Model.hpp"
 #include "include/ModelMPI.hpp"
 #include "include/NextsimModule.hpp"
-#include "include/ParaGridIO.hpp"
 #include "include/StructureFactory.hpp"
 #include "include/Xios.hpp"
 #include "include/gridNames.hpp"

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -12,6 +12,7 @@
 #include "include/ModelMPI.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
+#include "include/StructureFactory.hpp"
 #include "include/Xios.hpp"
 #include "include/gridNames.hpp"
 
@@ -48,6 +49,12 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
+    // Check the input file exists
+    if (!std::filesystem::exists(restartFilename)) {
+        throw std::runtime_error(
+            "XiosReadRestart_test: Input file not found. Did you run XiosWrite_test?");
+    }
+
     // Create ModelMPI instance based off the test communicator
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
@@ -57,28 +64,11 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     model.configureRestarts();
     model.configureTime();
 
-    // Get the Xios singleton instance and check it's initialized
+    // Get the Xios singleton instance and check calendar step is zero initially
     // NOTE: The singleton is created when Xios::getInstance() is first called. In this test, this
     //       happens when the time sets set by ModelMetadata::setTime(). This occurs in the call to
     //       Model::configureTime() above.
     Xios& xiosHandler = Xios::getInstance();
-
-    // Create ParametricGrid and ParaGridIO instances
-    // NOTE: XIOS axes, domains, and grids are created by the ParaGridIO constructor
-    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-    ParametricGrid grid;
-    ParaGridIO* pio = new ParaGridIO(grid);
-    grid.setIO(pio);
-
-    xiosHandler.close_context_definition();
-
-    // Check the input file exists
-    if (!std::filesystem::exists(restartFilename)) {
-        throw std::runtime_error(
-            "XiosReadRestart_test: Input file not found. Did you run XiosWrite_test?");
-    }
-
-    // Check calendar step is zero initially
     REQUIRE(xiosHandler.getCalendarStep() == 0);
 
     // Deduce the local lengths of the two dimensions
@@ -88,10 +78,13 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     REQUIRE(ModelArray::size(ModelArray::Dimension::DG) == DGCOMP);
 
     // Read restarts from file and check they take the expected values
+    // NOTE: The ParametricGrid is created and the XIOS context definition is closed in the call to
+    // StructureFactory::stateFromFile()
     int rank;
     MPI_Comm_rank(test_comm, &rank);
     float ts = 2; // Corresponds to 2023-03-17T20:10:59Z
-    for (const auto [fieldName, modelarray] : grid.getModelState(restartFilename).data) {
+    for (const auto [fieldName, modelarray] :
+        StructureFactory::stateFromFile(restartFilename).data) {
         if (fieldName == maskName) {
             for (size_t j = 0; j < ny; ++j) {
                 for (size_t i = 0; i < nx; ++i) {

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -12,6 +12,7 @@
 #include "include/ModelMPI.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/ParaGridIO.hpp"
+#include "include/StructureFactory.hpp"
 #include "include/Xios.hpp"
 #include "include/gridNames.hpp"
 
@@ -74,17 +75,19 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     REQUIRE(ModelArray::nComponents(ModelArray::Type::DG) == DGCOMP);
     REQUIRE(ModelArray::size(ModelArray::Dimension::DG) == DGCOMP);
 
+    // Read initial state from the test input file
+    // NOTE: XIOS axes, domains, and grids are created by the ParaGridIO constructor, which is
+    //       constructed in the call to StructureFactory::stateFromFile(). The XIOS context also
+    //       gets closed in this call.
+    ModelState modelstate = StructureFactory::stateFromFile(inputFilename);
+
     // Create ParametricGrid and ParaGridIO instances
-    // NOTE: XIOS axes, domains, and grids are created by the ParaGridIO constructor
+    // NOTE: We need to create another ParametricGrid because we lose access to the one created by
+    //       StructureFactory::stateFromFile()
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
     ParametricGrid grid;
     ParaGridIO* pio = new ParaGridIO(grid);
     grid.setIO(pio);
-
-    xiosHandler.close_context_definition();
-
-    // Read initial state from the test input file
-    ModelState modelstate = grid.getModelState(inputFilename);
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("readwrite*.nc"));

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -136,8 +136,9 @@ Order of operations for XIOS setup
 ----------------------------------
 
 The required order of operations to set everything up correctly for reading and
-writing files using XIOS is demonstrated in the ``core/test/XiosRead_test.cpp``
-and ``core/test/XiosWrite_test.cpp`` worked examples and is elaborated in the
+writing files using XIOS is demonstrated in the
+``core/test/XiosReadRestart_test.cpp`` and
+``core/test/XiosWriteRestart_test.cpp`` worked examples and is elaborated in the
 following:
 
 1. Set configuration options as for other parts of the model. (See section above
@@ -155,7 +156,10 @@ following:
    member function of ``Xios``, providing the field name as the first argument
    and the ``ModelArray::Type::<TYPE>`` enum as the second argument (replacing
    ``<TYPE>>`` as appropriate).
-8. Call the ``close_context_definition`` member function of ``Xios``.
+8. Call the ``close_context_definition`` member function of ``Xios``. This is
+   not required if files were read with ``StructureFactory::stateFromFile``
+   because that function automatically closes the context definition before
+   reading.
 
 XIOS concepts
 -------------
@@ -232,7 +236,7 @@ Developer notes
   additional fields. This is because the two may have different I/O modes, e.g.,
   reading or writing at a specified frequency (``"instant"```), writing after
   applying a reduction operator (e.g., ``"average"``), or reading or writing
-  once at the start of the time window (`"once"`). We use the 'base' field
+  once at the start of the time window (``"once"``). We use the 'base' field
   associated with the field ID for writing. For reading a field, we create a
   separate 'inherited' field, which has the same name but with ID appended by
   ``"_input"`` or ``"_forcing"``, depending on whether the field is to be read


### PR DESCRIPTION
# Test `stateFromFile` with XIOS

Fixes #1022
Merges into #1017 

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

Added some preprocessor conditionals in `StructureFactory::stateFromFile` to close the XIOS context before calling `getModelState`, as this is required.

Added logic to track the XIOS context status so that we can call `close_context_definition` multiple times and it will only do something the first time.

---
# Test Description

Updated all XIOS tests that call `ParametricGrid::getModelState` to instead call `StructureFactory::stateFromFile`. This is done because it's how restarts are actually read in the model. It's worth noting that the read-write test does this and then creates a separate `ParametricGrid` to handle file writing with no issue.

---
# Documentation Impact

The XIOS doc page has been updated to reflect this change.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] This change conforms to the conventions described in the README
