### PR TITLE
Fix logic for pushing Docker build to ghcr

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -52,18 +52,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           logout: true
 
-      - name: Build container
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6
-        if: github.event_name == 'pull_request'
-        with:
-          push: false
-          file: Dockerfiles/Dockerfile.devenv
-          tags: ghcr.io/nextsimhub/nextsimdg-dev-env:latest
-
       - name: Build container and push to ghcr
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6
-        if: github.event_name == 'push' || github.event_name == 'schedule'
         with:
-          push: ${{ github.ref == 'refs/heads/main' }}
+          push: github.event_name == 'push' || github.event_name == 'schedule'
           file: Dockerfiles/Dockerfile.devenv
           tags: ghcr.io/nextsimhub/nextsimdg-dev-env:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,6 @@ jobs:
       - name: Build container and push to ghcr
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6
         with:
-          push: github.event_name == 'push' || github.event_name == 'schedule'
+          push: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
           file: Dockerfiles/Dockerfile.devenv
           tags: ghcr.io/nextsimhub/nextsimdg-dev-env:latest


### PR DESCRIPTION
Again, the Docker dev-env image https://github.com/nextsimhub/nextsimdg/pkgs/container/nextsimdg-dev-env wasn't updated by recent CI jobs on `develop`. It appears to me that this is because the CI is only configured to push to gchr for runs on `main`.

This PR changes the logic to address this and also allows scheduled runs to update the image.