### PR TITLE
Only trigger Docker workflow if related files change

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,11 @@ on:
   # Build the Docker container upon merging into main or develop
   push:
     branches: [ main, develop ]
+    paths:
+      - .github/workflows/docker.yml
+      - Dockerfiles/Dockerfile.devenv
+      - Dockerfiles/install-xios.sh
+      - Dockerfiles/spack.yaml
 
   # Build the Docker container whenever commits are pushed to an open PR that changes one of the files listed
   pull_request:


### PR DESCRIPTION
Currently, the Docker build workflow will trigger when *any* PR is merged into `main` or `develop`. This is excessive because in most cases those PRs don't touch the relevant files. This PR configures the CI workflow triggers to avoid this behaviour.