### PR TITLE
XIOS: test `StructureFactory::fileFromState()` and `Model::configure()`

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -176,7 +176,13 @@ void Xios::close_context_definition()
 void Xios::context_finalize()
 {
     if (isEnabled) {
+        // Close the context definition, if it wasn't already closed
+        close_context_definition();
+
+        // Ensure the dimension and variable names are correct in the output files
         postprocessOutputFiles();
+
+        // Finalize the XIOS context
         cxios_context_finalize();
     }
 }

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -56,7 +56,6 @@ MPI_TEST_CASE("TestXiosAxis", 3)
     REQUIRE(xiosHandler.getAxisSize("DGSAxis") == 8);
     REQUIRE(xiosHandler.getAxisSize("VertexAxis") == 2);
 
-    xiosHandler.close_context_definition();
     xiosHandler.context_finalize();
     Finalizer::finalize();
 }

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -62,6 +62,7 @@ MPI_TEST_CASE("TestXiosCalendar", 1)
     ModelMetadata& metadata = ModelMetadata::getInstance();
     REQUIRE(metadata.stepLength().seconds() == 3600.0); // Read from config
 
+    // NOTE: Needs calling before Xios::getCurrentDate()
     xiosHandler.close_context_definition();
 
     // --- Tests for getCurrentDate method

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -59,7 +59,6 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 2)
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
     // Create a Model and configure it so that time options are parsed
-    // TODO: Use Model.configure for consistency with the rest of the model
     Model model;
     model.configureRestarts();
     model.configureTime();

--- a/core/test/XiosReadForcing_test.cpp
+++ b/core/test/XiosReadForcing_test.cpp
@@ -71,6 +71,7 @@ MPI_TEST_CASE("TestXiosReadForcing", 2)
     ParaGridIO* pio = new ParaGridIO(grid);
     grid.setIO(pio);
 
+    // NOTE: Needs calling before Xios::getCurrentDate()
     xiosHandler.close_context_definition();
 
     // Check the input file exists

--- a/core/test/XiosReadForcing_test.cpp
+++ b/core/test/XiosReadForcing_test.cpp
@@ -53,7 +53,6 @@ MPI_TEST_CASE("TestXiosReadForcing", 2)
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
     // Create a Model and configure it so that time options are parsed
-    // TODO: Use Model.configure for consistency with the rest of the model
     Model model;
     model.configureRestarts();
     model.configureTime();

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -42,8 +42,9 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "[XiosInput]" << std::endl;
-    config << "field_names = " << maskName << "," << coordsName << "," << hiceName << ","
-           << ticeName << "," << uName << std::endl;
+    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
+           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -57,15 +58,13 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
     // Create a Model and configure it so that time options are parsed
-    // TODO: Use Model.configure for consistency with the rest of the model
     Model model;
-    model.configureRestarts();
-    model.configureTime();
+    model.configure();
 
     // Get the Xios singleton instance and check calendar step is zero initially
     // NOTE: The singleton is created when Xios::getInstance() is first called. In this test, this
     //       happens when the time sets set by ModelMetadata::setTime(). This occurs in the call to
-    //       Model::configureTime() above.
+    //       Model::configure() above.
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.getCalendarStep() == 0);
 
@@ -83,13 +82,25 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     float ts = 2; // Corresponds to 2023-03-17T20:10:59Z
     for (const auto [fieldName, modelarray] :
         StructureFactory::stateFromFile(restartFilename).data) {
-        if (fieldName == maskName) {
+        if (fieldName == longitudeName) {
+            for (size_t j = 0; j < ny; ++j) {
+                for (size_t i = 0; i < nx; ++i) {
+                    REQUIRE(modelarray(i, j) == doctest::Approx(i));
+                }
+            }
+        } else if (fieldName == latitudeName) {
+            for (size_t j = 0; j < ny; ++j) {
+                for (size_t i = 0; i < nx; ++i) {
+                    REQUIRE(modelarray(i, j) == doctest::Approx(j));
+                }
+            }
+        } else if (fieldName == maskName) {
             for (size_t j = 0; j < ny; ++j) {
                 for (size_t i = 0; i < nx; ++i) {
                     REQUIRE(modelarray(i, j) == doctest::Approx(j >= 1 ? 1.0 : 0.0));
                 }
             }
-        } else if (fieldName == coordsName) {
+        } else if (fieldName == gridAzimuthName) {
             for (size_t j = 0; j < ny + 1; ++j) {
                 for (size_t i = 0; i < nx + 1; ++i) {
                     float expected_x;
@@ -103,7 +114,8 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
                     REQUIRE(modelarray.components({ i, j })[1] == doctest::Approx(expected_y));
                 }
             }
-        } else if (fieldName == hiceName) {
+        } else if (fieldName == ciceName || fieldName == hiceName || fieldName == damageName
+            || fieldName == hsnowName) {
             for (size_t j = 0; j < ny; ++j) {
                 for (size_t i = 0; i < nx; ++i) {
                     for (size_t d = 0; d < DGCOMP; ++d) {

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -44,11 +44,13 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosInput]" << std::endl;
-    config << "field_names = " << maskName << "," << coordsName << "," << hiceName << ","
-           << ticeName << "," << uName << std::endl;
+    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
+           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
-    config << "field_names = " << maskName << "," << coordsName << "," << hiceName << ","
-           << ticeName << "," << uName << std::endl;
+    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
+           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -56,16 +58,15 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
     // Create a Model and configure it so that time options are parsed
-    // TODO: Use Model.configure for consistency with the rest of the model
     Model model;
-    model.configureRestarts();
-    model.configureTime();
+    model.configure();
 
-    // Get the Xios singleton instance and check it's initialized
+    // Get the Xios singleton instance and check calendar step is zero initially
     // NOTE: The singleton is created when Xios::getInstance() is first called. In this test, this
     //       happens when the time sets set by ModelMetadata::setTime(). This occurs in the call to
-    //       Model::configureTime() above.
+    //       Model::configure() above.
     Xios& xiosHandler = Xios::getInstance();
+    REQUIRE(xiosHandler.getCalendarStep() == 0);
 
     // Set ModelArray dimensions
     const size_t nx = ModelArray::size(ModelArray::Dimension::X);
@@ -81,9 +82,6 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("readwrite*.nc"));
-
-    // Check calendar step is zero initially
-    REQUIRE(xiosHandler.getCalendarStep() == 0);
 
     // Simulate 4 iterations (timesteps)
     ModelMetadata& metadata = ModelMetadata::getInstance();

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -6,12 +6,10 @@
 #include <doctest/extensions/doctest_mpi.h>
 #undef INFO
 
-#include "StructureModule/include/ParametricGrid.hpp"
 #include "include/Finalizer.hpp"
 #include "include/Model.hpp"
 #include "include/ModelMPI.hpp"
 #include "include/NextsimModule.hpp"
-#include "include/ParaGridIO.hpp"
 #include "include/StructureFactory.hpp"
 #include "include/Xios.hpp"
 #include "include/gridNames.hpp"
@@ -81,14 +79,6 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     //       gets closed in this call.
     ModelState modelstate = StructureFactory::stateFromFile(inputFilename);
 
-    // Create ParametricGrid and ParaGridIO instances
-    // NOTE: We need to create another ParametricGrid because we lose access to the one created by
-    //       StructureFactory::stateFromFile()
-    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-    ParametricGrid grid;
-    ParaGridIO* pio = new ParaGridIO(grid);
-    grid.setIO(pio);
-
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("readwrite*.nc"));
 
@@ -101,7 +91,7 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     int rank;
     MPI_Comm_rank(test_comm, &rank);
     for (int ts = 0; ts <= 4; ts++) {
-        grid.dumpModelState(modelstate, outputFilename, true);
+        StructureFactory::fileFromState(modelstate, outputFilename, true);
 
         // Update the current timestep and verify it's updated in XIOS
         metadata.incrementTime(timestep);

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -53,7 +53,6 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
     // Create a Model and configure it so that time options are parsed
-    // TODO: Use Model.configure for consistency with the rest of the model
     Model model;
     model.configureRestarts();
     model.configureTime();

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -80,8 +80,6 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     // Set field type for diagnostics
     xiosHandler.setFieldType(hsnowName, ModelArray::Type::H);
 
-    xiosHandler.close_context_definition();
-
     // Create some fake data to test writing methods
     HField mask(ModelArray::Type::H);
     mask.resize();

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -11,7 +11,7 @@
 #include "include/Model.hpp"
 #include "include/ModelMPI.hpp"
 #include "include/NextsimModule.hpp"
-#include "include/ParaGridIO.hpp"
+#include "include/StructureFactory.hpp"
 #include "include/Xios.hpp"
 #include "include/gridNames.hpp"
 
@@ -70,12 +70,8 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     REQUIRE(ModelArray::nComponents(ModelArray::Type::DG) == DGCOMP);
     REQUIRE(ModelArray::size(ModelArray::Dimension::DG) == DGCOMP);
 
-    // Create ParametricGrid and ParaGridIO instances
-    // NOTE: XIOS axes, domains, and grids are created by the ParaGridIO constructor
+    // The ParametricGrid structure is required by XIOS
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-    ParametricGrid grid;
-    ParaGridIO* pio = new ParaGridIO(grid);
-    grid.setIO(pio);
 
     // Set field types for restarts
     xiosHandler.setFieldType(maskName, ModelArray::Type::H);
@@ -83,8 +79,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     xiosHandler.setFieldType(hiceName, ModelArray::Type::DG);
     xiosHandler.setFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setFieldType(uName, ModelArray::Type::CG);
-
-    xiosHandler.close_context_definition();
 
     // Create some fake data to test writing methods
     HField mask(ModelArray::Type::H);
@@ -163,7 +157,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                                     { uName, uice },
                                 },
             {} };
-        grid.dumpModelState(restarts, outputFilename, true);
+        StructureFactory::fileFromState(restarts, outputFilename, true);
 
         // Update the current timestep and verify it's updated in XIOS
         metadata.incrementTime(timestep);

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -44,8 +44,9 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosOutput]" << std::endl;
-    config << "field_names = " << maskName << "," << coordsName << "," << hiceName << ","
-           << ticeName << "," << uName << std::endl;
+    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
+           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -53,7 +54,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
     // Create a Model and configure it so that time options are parsed
-    // TODO: Use Model.configure for consistency with the rest of the model
     Model model;
     model.configureRestarts();
     model.configureTime();
@@ -74,13 +74,32 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
 
     // Set field types for restarts
+    xiosHandler.setFieldType(longitudeName, ModelArray::Type::H);
+    xiosHandler.setFieldType(latitudeName, ModelArray::Type::H);
     xiosHandler.setFieldType(maskName, ModelArray::Type::H);
-    xiosHandler.setFieldType(coordsName, ModelArray::Type::VERTEX);
+    xiosHandler.setFieldType(ciceName, ModelArray::Type::DG);
     xiosHandler.setFieldType(hiceName, ModelArray::Type::DG);
+    xiosHandler.setFieldType(damageName, ModelArray::Type::DG);
+    xiosHandler.setFieldType(hsnowName, ModelArray::Type::DG);
+    xiosHandler.setFieldType(gridAzimuthName, ModelArray::Type::VERTEX);
     xiosHandler.setFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setFieldType(uName, ModelArray::Type::CG);
 
     // Create some fake data to test writing methods
+    HField longitude(ModelArray::Type::H);
+    longitude.resize();
+    for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+            longitude(i, j) = i;
+        }
+    }
+    HField latitude(ModelArray::Type::H);
+    latitude.resize();
+    for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+            latitude(i, j) = j;
+        }
+    }
     HField mask(ModelArray::Type::H);
     mask.resize();
     for (size_t j = 0; j < ny; ++j) {
@@ -88,16 +107,20 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
             mask(i, j) = j >= 1 ? 1.0 : 0.0;
         }
     }
-    VertexField coordinates(ModelArray::Type::VERTEX);
-    coordinates.resize();
+    DGField cice(ModelArray::Type::DG);
+    cice.resize();
     DGField hice(ModelArray::Type::DG);
     hice.resize();
+    DGField damage(ModelArray::Type::DG);
+    damage.resize();
+    DGField hsnow(ModelArray::Type::DG);
+    hsnow.resize();
+    VertexField grid_azimuth(ModelArray::Type::VERTEX);
+    grid_azimuth.resize();
     DGSField tice(ModelArray::Type::DGSTRESS);
     tice.resize();
     CGField uice(ModelArray::Type::CG);
     uice.resize();
-    HField hsnow(ModelArray::Type::H);
-    hsnow.resize();
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("restart*.nc"));
@@ -112,25 +135,42 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     MPI_Comm_rank(test_comm, &rank);
     for (int ts = 0; ts <= 4; ts++) {
 
-        // Update restart fields
-        for (size_t j = 0; j < ny + 1; ++j) {
-            for (size_t i = 0; i < nx + 1; ++i) {
-                if (rank == 0) {
-                    coordinates.components({ i, j })[0] = 1.0 * ts * i;
-                    coordinates.components({ i, j })[1] = 1.0 * ts * j;
-                } else {
-                    coordinates.components({ i, j })[0] = 1.0 * ts * (i + 2);
-                    coordinates.components({ i, j })[1] = 1.0 * ts * j;
-                }
-            }
-        }
+        // Update DGField restarts
         for (size_t j = 0; j < ny; ++j) {
             for (size_t i = 0; i < nx; ++i) {
                 for (size_t d = 0; d < DGCOMP; ++d) {
-                    hice.components({ i, j })[d] = 1.0 * ts * (d + DGCOMP * (i + nx * j));
+                    const float value = 1.0 * ts * (d + DGCOMP * (i + nx * j));
+                    cice.components({ i, j })[d] = value;
+                    hice.components({ i, j })[d] = value;
+                    damage.components({ i, j })[d] = value;
+                    hsnow.components({ i, j })[d] = value;
                 }
             }
         }
+
+        // Update VertexField restarts
+        for (size_t j = 0; j < ny + 1; ++j) {
+            for (size_t i = 0; i < nx + 1; ++i) {
+                if (rank == 0) {
+                    grid_azimuth.components({ i, j })[0] = 1.0 * ts * i;
+                    grid_azimuth.components({ i, j })[1] = 1.0 * ts * j;
+                } else {
+                    grid_azimuth.components({ i, j })[0] = 1.0 * ts * (i + 2);
+                    grid_azimuth.components({ i, j })[1] = 1.0 * ts * j;
+                }
+            }
+        }
+
+        // Update DGSField restarts
+        for (size_t j = 0; j < ny; ++j) {
+            for (size_t i = 0; i < nx; ++i) {
+                for (size_t d = 0; d < DGSTRESSCOMP; ++d) {
+                    tice.components({ i, j })[d] = 2.0 * ts * (d + DGSTRESSCOMP * (i + nx * j));
+                }
+            }
+        }
+
+        // Update CGField restarts
         for (size_t j = 0; j < CGDEGREE * ny + 1; ++j) {
             for (size_t i = 0; i < CGDEGREE * nx + 1; ++i) {
                 if (rank == 0) {
@@ -140,19 +180,17 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                 }
             }
         }
-        for (size_t j = 0; j < ny; ++j) {
-            for (size_t i = 0; i < nx; ++i) {
-                for (size_t d = 0; d < DGSTRESSCOMP; ++d) {
-                    tice.components({ i, j })[d] = 2.0 * ts * (d + DGSTRESSCOMP * (i + nx * j));
-                }
-            }
-        }
 
         // Set up ModelState for restarts and write out
         ModelState restarts = { {
                                     { maskName, mask },
-                                    { coordsName, coordinates },
+                                    { longitudeName, longitude },
+                                    { latitudeName, latitude },
+                                    { ciceName, cice },
                                     { hiceName, hice },
+                                    { damageName, damage },
+                                    { hsnowName, hsnow },
+                                    { gridAzimuthName, grid_azimuth },
                                     { ticeName, tice },
                                     { uName, uice },
                                 },

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -41,18 +41,38 @@ variables:
 		y_cg:standard_name = "CG latitude" ;
 		y_cg:long_name = "Continuous Galerkin latitude" ;
 		y_cg:units = "degrees_north" ;
-	float coords(y_vertex, x_vertex, ncoords) ;
-		coords:online_operation = "once" ;
-		coords:coordinates = "lat lon ncoords" ;
-  float hice(y_dim, x_dim, dg_comp) ;
-		hice:online_operation = "once" ;
-		hice:coordinates = "lat lon dg_comp" ;
+  // HField variables
+  float longitude(y_dim, x_dim) ;
+    longitude:online_operation = "once" ;
+    longitude:coordinates = "lat lon" ;
+  float latitude(y_dim, x_dim) ;
+    latitude:online_operation = "once" ;
+    latitude:coordinates = "lat lon" ;
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
+  // DGField variables
+  float cice(y_dim, x_dim, dg_comp) ;
+		cice:online_operation = "once" ;
+		cice:coordinates = "lat lon dg_comp" ;
+  float hice(y_dim, x_dim, dg_comp) ;
+		hice:online_operation = "once" ;
+		hice:coordinates = "lat lon dg_comp" ;
+  float damage(y_dim, x_dim, dg_comp) ;
+		damage:online_operation = "once" ;
+		damage:coordinates = "lat lon dg_comp" ;
+  float hsnow(y_dim, x_dim, dg_comp) ;
+		hsnow:online_operation = "once" ;
+		hsnow:coordinates = "lat lon dg_comp" ;
+  // VertexField variables
+	float grid_azimuth(y_vertex, x_vertex, ncoords) ;
+		grid_azimuth:online_operation = "once" ;
+		grid_azimuth:coordinates = "lat lon ncoords" ;
+  // DGStressField variables
 	float tice(y_dim, x_dim, dgstress_comp) ;
 		tice:online_operation = "once" ;
 		tice:coordinates = "lat lon dgstress_comp" ;
+  // CGField variables
 	float u(y_cg, x_cg) ;
 		u:online_operation = "once" ;
 		u:coordinates = "lat lon" ;
@@ -66,7 +86,65 @@ variables:
 
 data:
 
- coords =
+ // HField variables
+
+ longitude =
+  0, 1, 2, 3,
+  0, 1, 2, 3 ;
+
+ latitude =
+  0, 0, 0, 0,
+  1, 1, 1, 1 ;
+
+ mask =
+  0, 0, 0, 0,
+  1, 1, 1, 1 ;
+
+ // DGField variables
+
+ cice =
+  0, 1, 2, 3, 4, 5,
+  6, 7, 8, 9, 10, 11,
+  0, 1, 2, 3, 4, 5,
+  6, 7, 8, 9, 10, 11,
+  12, 13, 14, 15, 16, 17,
+  18, 19, 20, 21, 22, 23,
+  12, 13, 14, 15, 16, 17,
+  18, 19, 20, 21, 22, 23 ;
+
+ hice =
+  0, 1, 2, 3, 4, 5,
+  6, 7, 8, 9, 10, 11,
+  0, 1, 2, 3, 4, 5,
+  6, 7, 8, 9, 10, 11,
+  12, 13, 14, 15, 16, 17,
+  18, 19, 20, 21, 22, 23,
+  12, 13, 14, 15, 16, 17,
+  18, 19, 20, 21, 22, 23 ;
+
+ damage =
+  0, 1, 2, 3, 4, 5,
+  6, 7, 8, 9, 10, 11,
+  0, 1, 2, 3, 4, 5,
+  6, 7, 8, 9, 10, 11,
+  12, 13, 14, 15, 16, 17,
+  18, 19, 20, 21, 22, 23,
+  12, 13, 14, 15, 16, 17,
+  18, 19, 20, 21, 22, 23 ;
+
+ hsnow =
+  0, 1, 2, 3, 4, 5,
+  6, 7, 8, 9, 10, 11,
+  0, 1, 2, 3, 4, 5,
+  6, 7, 8, 9, 10, 11,
+  12, 13, 14, 15, 16, 17,
+  18, 19, 20, 21, 22, 23,
+  12, 13, 14, 15, 16, 17,
+  18, 19, 20, 21, 22, 23 ;
+
+ // VertexField variables
+
+ grid_azimuth =
   0, 0,
   1, 0,
   2, 0,
@@ -83,19 +161,7 @@ data:
   3, 2,
   4, 2 ;
 
- hice =
-  0, 1, 2, 3, 4, 5,
-  6, 7, 8, 9, 10, 11,
-  0, 1, 2, 3, 4, 5,
-  6, 7, 8, 9, 10, 11,
-  12, 13, 14, 15, 16, 17,
-  18, 19, 20, 21, 22, 23,
-  12, 13, 14, 15, 16, 17,
-  18, 19, 20, 21, 22, 23 ;
-
- mask =
-  0, 0, 0, 0,
-  1, 1, 1, 1 ;
+ // DGStressField variables
 
  tice =
   0, 2, 4, 6, 8, 10, 12, 14,
@@ -106,6 +172,8 @@ data:
   48, 50, 52, 54, 56, 58, 60, 62,
   32, 34, 36, 38, 40, 42, 44, 46,
   48, 50, 52, 54, 56, 58, 60, 62 ;
+
+ // CGField variables
 
  u =
   1, 2, 3, 4, 5, 6, 7, 8, 9,

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -128,9 +128,13 @@ time window, whereas diagnostics files are averaged over the timesteps in the
 window.
 
 As elsewhere in the model, the configuration values above are all parsed by
-calling the ``Model.configure`` member function. Since building with XIOS
-implies also building with MPI, you will need to pass the MPI communicator to
-this member function when calling it.
+calling the ``Model.configure`` member function. Note that this function will
+automatically initialize the model state based on the ``input_file`` entry and
+any ``field_names`` listed in the ``[XiosInput]`` configuration section. You
+will need to ensure that variables defining the grid are read here, i.e.,
+``longitude`` and ``latitude`` and possibly ``coords`` and ``grid_azimuth``. The
+XIOS I/O implementation does not currently support Cartesian grids (based on
+``x_dim`` and ``y_dim``).
 
 Order of operations for XIOS setup
 ----------------------------------


### PR DESCRIPTION
# XIOS: test `StructureFactory::fileFromState()` and `Model::configure()`

Fixes #1027
Merges into #1023

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

Minor code change: call `close_context_definition` in XIOS' finalizer, if it hasn't already been called before.

---
# Test Description

The XIOS tests are reworked to make use of `StructureFactory::fileFromState` instead of `ParametricGrid::dumpModelState` in a couple of places. This is done because it's how restarts are actually written in the model.

For further consistency with the model, we call `Model::configure()` in the restart tests rather than `Model::configureRestarts()` followed by `Model::configureTime()`. To enable that, I needed to rework how the fields are defined, e.g., the `Model` expects `cice`, `hice`, `damage`, and `hsnow` to be DG fields. Also, the grid fields need to be defined correctly.

---
# Documentation Impact

The XIOS docs page has been updated to mention `Model::configure()` and also the fact that the XIOS I/O implementation doesn't currently support Cartesian grids, i.e., those based on `x_dim` and `y_dim` rather than `longitude` and `latitude`. (This limitation is because we haven't defined XIOS domains that `x_dim` and `y_dim` could live on as variables.)

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] This change conforms to the conventions described in the README
