### PR TITLE
Tweak CI test triggers

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -74,8 +74,7 @@ jobs:
         apt install -y python3-venv
         python3 -m venv ~/nextsim
         . $HOME/nextsim/bin/activate
-        pip install numpy
-        pip install netCDF4
+        pip install netCDF4 numpy
 
     - name: run serial tests
       run: |
@@ -157,7 +156,7 @@ jobs:
         apt install -y python3-venv
         python3 -m venv ~/nextsim
         . $HOME/nextsim/bin/activate
-        pip install jinja2
+        pip install jinja2 netCDF4
 
     - name: build domain_decomp
       run: |

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -223,7 +223,7 @@ jobs:
     # [here](https://github.com/mxschmitt/action-tmate) for more information.
     # uncomment these lines to debug mac build
     # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
+    #   uses: mxschmitt/action-tmate@c0afd6f790e3a5564914980036ebf83216678101 # v3
 
     # Note that eigen@3 is keg-only, which means it was not symlinked into
     # /opt/homebrew. Therefore we need to add it to CMAKE_PREFIX_PATH so CMake

--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -22,14 +22,20 @@ on:
   pull_request:
     paths:
       - '.github/workflows/test_suite.yml'
+      - 'core/*.sh'
+      - 'dynamics/codegeneration/*.sh'
+      - 'run/*.sh'
       - '**.cdl'
       - '**.cfg'
       - '**.cpp'
       - '**.hpp'
       - '**.py'
-      - '**.sh'
       - '**.xml'
       - '**CMakeLists.txt'
+
+  # Build the Docker container at 02:00 on the first day of every 3 months, following the periodic Docker build
+  schedule:
+    - cron: '0 2 1 */3 *'
 
   # Enable running this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Currently, if the `install-xios.sh` script is changed (e.g., in #1030) then the test suite gets triggered because of its `.sh` extension. However, this is redundant for the following reasons:

1. The `install-xios.sh` script updates XIOS in the Docker image.
2. However, before a PR is merged, the Docker build CI workflow only checks that it can be built. It doesn't push the image to ghcr.
3. If the tests are run before the PR is merged, they use the old version of the Docker image and don't pick up any updates to it.

A similar thing happens with changes to shell scripts in the `docs` subdirectory.

This PR changes the triggers so that the test suite gets triggered by changes to shell scripts in the `core`, `run`, and `dynamics` subdirectories, but not `docs` or `Dockerfiles`.

I added a periodic trigger two hours after the 3-monthly Docker build run so that the suite can test that the new image is working as expected.