### PR TITLE
XIOS: Determine output field types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,6 +169,16 @@ set(NextsimIncludeDirs "")
 # At least one test shell script runs the full binary. This variable contains the path to it.
 set(NEXTSIM_BINARY_PATH "${CMAKE_CURRENT_BINARY_DIR}/nextsim")
 
+# Add XIOS includes if enabled
+if(ENABLE_XIOS)
+    set(XIOS_INCLUDE_LIST
+        "${xios_INCLUDES}"
+        "${xios_EXTERNS}/blitz/"
+        "${xios_EXTERNS}/rapidxml/include"
+    )
+    set(NextsimIncludeDirs "${NextsimIncludeDirs}" "${XIOS_INCLUDE_LIST}")
+endif()
+
 # Build the core model. Defines the 'parse_modules' target
 add_subdirectory("core")
 

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -1,12 +1,6 @@
 # Sources for the main neXtSIM model
 
 if(ENABLE_XIOS)
-    set(XIOS_INCLUDE_LIST
-        "${xios_INCLUDES}"
-        "${xios_EXTERNS}/blitz/"
-        "${xios_EXTERNS}/rapidxml/include"
-    )
-    set(NextsimIncludeDirs "${NextsimIncludeDirs}" "${XIOS_INCLUDE_LIST}")
     set(ParaGridIOImplSource "${CMAKE_CURRENT_SOURCE_DIR}/ParaGridIO_Xios.cpp")
 else()
     set(ParaGridIOImplSource "${CMAKE_CURRENT_SOURCE_DIR}/ParaGridIO.cpp")

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -119,14 +119,17 @@ void Model::configure()
 
     configureRestarts();
 
+    // Configure parameters related to the temporal discretisation
+    configureTime();
+
+    // Configure prognostic data
     pData.configure();
 
     auto& metadata = ModelMetadata::getInstance();
     modelStep.init();
     modelStep.setInitFile(metadata.initialFileName);
 
-    configureTime();
-
+    // Read the initial state from file
     ModelState initialState(StructureFactory::stateFromFile(metadata.initialFileName));
 
     // Get the coordinates from the ModelState for persistence

--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -54,7 +54,7 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
 
     // Get all variables in the file and load them into a new ModelState
     ModelState state;
-    for (const std::string& fieldId : xiosHandler.configGetInputRestartFieldNames()) {
+    for (const std::string& fieldId : xiosHandler.inputRestartFieldNames) {
         const ModelArray::Type& type = xiosHandler.getFieldType(fieldId);
         if (type == ModelArray::Type::H) {
             HField field(ModelArray::Type::H);
@@ -83,10 +83,9 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
     }
 
     // Assume that all fields in the supplied ModelState are necessary, and so read them from file.
-    const std::set<std::string> inputFieldIds = xiosHandler.configGetInputRestartFieldNames();
     for (auto& [fieldId, modelarray] : state.data) {
         const std::string inputFieldId = fieldId + "_input";
-        if (inputFieldIds.count(fieldId) == 0) {
+        if (xiosHandler.inputRestartFieldNames.count(fieldId) == 0) {
             throw std::runtime_error(
                 "ParaGridIO::getModelState: field " + fieldId + " is not configured as a restart.");
         }
@@ -119,9 +118,8 @@ ModelState ParaGridIO::readForcingTimeStatic(
 
     // Get all forcings and load them into a new ModelState
     ModelState state;
-    const std::set<std::string> forcingFieldIds = xiosHandler.configGetForcingFieldNames();
     for (const std::string& fieldId : forcings) {
-        if (forcingFieldIds.count(fieldId) == 0) {
+        if (xiosHandler.forcingFieldNames.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::readForcingTimeStatic: field " + fieldId
                 + " is not configured as a forcing.");
         }
@@ -162,9 +160,8 @@ void ParaGridIO::dumpModelState(const ModelState& state, const std::string& file
     }
 
     // Assume that all fields in the supplied ModelState are necessary, and so write them to file.
-    const std::set<std::string> outputFieldIds = xiosHandler.configGetOutputRestartFieldNames();
     for (const auto& [fieldId, modelarray] : state.data) {
-        if (outputFieldIds.count(fieldId) == 0) {
+        if (xiosHandler.outputRestartFieldNames.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::dumpModelState: field " + fieldId
                 + " is not configured as a restart.");
         }
@@ -185,9 +182,8 @@ void ParaGridIO::writeDiagnosticTime(const ModelState& state, const std::string&
     }
 
     // Assume that all fields in the supplied ModelState are necessary, and so write them to file.
-    const std::set<std::string> diagnosticFieldIds = xiosHandler.configGetDiagnosticFieldNames();
     for (const auto& [fieldId, modelarray] : state.data) {
-        if (diagnosticFieldIds.count(fieldId) == 0) {
+        if (xiosHandler.diagnosticFieldNames.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::writeDiagnosticTime: field " + fieldId
                 + " is not configured as a diagnostic.");
         }

--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -55,8 +55,7 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
     // Get all variables in the file and load them into a new ModelState
     ModelState state;
     for (const std::string& fieldId : xiosHandler.configGetInputRestartFieldNames()) {
-        const std::string inputFieldId = fieldId + "_input";
-        const ModelArray::Type& type = xiosHandler.getFieldType(inputFieldId);
+        const ModelArray::Type& type = xiosHandler.getFieldType(fieldId);
         if (type == ModelArray::Type::H) {
             HField field(ModelArray::Type::H);
             field.resize();
@@ -165,12 +164,11 @@ void ParaGridIO::dumpModelState(const ModelState& state, const std::string& file
     // Assume that all fields in the supplied ModelState are necessary, and so write them to file.
     const std::set<std::string> outputFieldIds = xiosHandler.configGetOutputRestartFieldNames();
     for (const auto& [fieldId, modelarray] : state.data) {
-        const std::string outputFieldId = fieldId;
         if (outputFieldIds.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::dumpModelState: field " + fieldId
                 + " is not configured as a restart.");
         }
-        xiosHandler.write(outputFieldId, modelarray);
+        xiosHandler.write(fieldId, modelarray);
     }
 }
 
@@ -189,12 +187,11 @@ void ParaGridIO::writeDiagnosticTime(const ModelState& state, const std::string&
     // Assume that all fields in the supplied ModelState are necessary, and so write them to file.
     const std::set<std::string> diagnosticFieldIds = xiosHandler.configGetDiagnosticFieldNames();
     for (const auto& [fieldId, modelarray] : state.data) {
-        const std::string diagnosticFieldId = fieldId;
         if (diagnosticFieldIds.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::writeDiagnosticTime: field " + fieldId
                 + " is not configured as a diagnostic.");
         }
-        xiosHandler.write(diagnosticFieldId, modelarray);
+        xiosHandler.write(fieldId, modelarray);
     }
 }
 

--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -77,6 +77,9 @@ void PrognosticData::configure()
 #ifdef USE_XIOS
     // Set XIOS field types
     Xios& xiosHandler = Xios::getInstance();
+    xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
+    xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
+    xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(hiceName, ModelArray::Type::DG);
     xiosHandler.setPrognosticFieldType(ciceName, ModelArray::Type::DG);
     xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::DG);

--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -77,8 +77,10 @@ void PrognosticData::configure()
 #ifdef USE_XIOS
     // Set XIOS field types
     Xios& xiosHandler = Xios::getInstance();
+    xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
     xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
+    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(hiceName, ModelArray::Type::DG);
     xiosHandler.setPrognosticFieldType(ciceName, ModelArray::Type::DG);

--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -9,6 +9,9 @@
 #include "include/Finalizer.hpp"
 #include "include/ModelArrayRef.hpp"
 #include "include/NextsimModule.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#endif
 #include "include/gridNames.hpp"
 
 namespace Nextsim {
@@ -70,6 +73,15 @@ void PrognosticData::configure()
             { "concentration", &cice },
         });
     }
+
+#ifdef USE_XIOS
+    // Set XIOS field types
+    Xios& xiosHandler = Xios::getInstance();
+    xiosHandler.setPrognosticFieldType(hiceName, ModelArray::Type::DG);
+    xiosHandler.setPrognosticFieldType(ciceName, ModelArray::Type::DG);
+    xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::DG);
+    xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::Type::DG);
+#endif
 }
 
 // Copies an HField from a source ModelArray that is either an HField or a DGField.

--- a/core/src/PrognosticData.cpp
+++ b/core/src/PrognosticData.cpp
@@ -82,10 +82,10 @@ void PrognosticData::configure()
     xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
-    xiosHandler.setPrognosticFieldType(hiceName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(ciceName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::Type::DG);
+    xiosHandler.setPrognosticFieldType(hiceName, ModelArray::AdvectionType);
+    xiosHandler.setPrognosticFieldType(ciceName, ModelArray::AdvectionType);
+    xiosHandler.setPrognosticFieldType(damageName, ModelArray::AdvectionType);
+    xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::AdvectionType);
 #endif
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1073,6 +1073,11 @@ ModelArray::Type Xios::getFieldType(const std::string& fieldId)
 void Xios::setFieldType(
     const std::string& fieldId, const ModelArray::Type& fieldType, const int ioType)
 {
+    if (fieldNames.count(fieldId) == 0) {
+        Logged::warning("Xios::setFieldType: Cannot set field type for field '" + fieldId
+            + "' because it is not in the config.");
+        return;
+    }
     std::string ioFieldId = fieldId;
     if (ioType == INPUT_RESTART) {
         ioFieldId += "_input";

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1616,7 +1616,6 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
     if (modelarray.nDimensions() != 2) {
         throw std::invalid_argument("Only ModelArrays of dimension 2 are supported");
     }
-    auto& dims = modelarray.dimensions();
     const ModelArray::Type& type = modelarray.getType();
     const ModelArray::Type& expectedType = getFieldType(fieldId);
 
@@ -1630,7 +1629,8 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
             throw std::runtime_error(
                 "Xios::read: field '" + fieldId + "' was expected to be converted to a DGField");
         }
-        ModelArray inputarray;
+        HField inputarray(ModelArray::Type::H);
+        auto& dims = inputarray.dimensions();
         cxios_read_data_k82(
             fieldId.c_str(), fieldId.length(), inputarray.getData(), dims[0], dims[1]);
         // FIXME: Conversion with overloaded '=' operator is known to be problematic
@@ -1639,6 +1639,7 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
     }
 
     // Other field types should not need converting
+    auto& dims = modelarray.dimensions();
     if (type != expectedType) {
         throw std::runtime_error(
             "Xios::read: field '" + fieldId + "' does not have the expected type");

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1084,6 +1084,9 @@ void Xios::setFieldType(
     } else if (ioType == FORCING) {
         ioFieldId += "_forcing";
     }
+    if (fieldTypes.count(ioFieldId) > 0) {
+        Logged::warning("Xios::setFieldType: Overwriting field type for field '" + ioFieldId + "'");
+    }
     fieldTypes[ioFieldId] = fieldType;
     setFieldGridRef(ioFieldId, gridIds[fieldType]);
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -187,7 +187,7 @@ void Xios::close_context_definition()
                         getField(inputFieldId), fieldId.c_str(), fieldId.length());
                 } else if (baseType == ModelArray::Type::DG && inputType == ModelArray::Type::H) {
                     // Record fields read in as HField but treated as DGField
-                    inputFieldsToConvert.insert(fieldId);
+                    inputFieldsToConvert.insert(inputFieldId);
                 } else {
                     throw std::runtime_error(
                         "Xios: Inconsistent field types for reading and writing field '" + fieldId
@@ -1621,11 +1621,11 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
 
     // Account for fields to be read in as HField but converted to DGField
     if (inputFieldsToConvert.count(fieldId)) {
-        if (type != ModelArray::Type::H) {
+        if (expectedType != ModelArray::Type::H) {
             throw std::runtime_error(
                 "Xios::read: field '" + fieldId + "' was expected to be read as a HField");
         }
-        if (expectedType != ModelArray::Type::DG) {
+        if (type != ModelArray::Type::DG) {
             throw std::runtime_error(
                 "Xios::read: field '" + fieldId + "' was expected to be converted to a DGField");
         }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1633,6 +1633,7 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
         auto& dims = inputarray.dimensions();
         cxios_read_data_k82(
             fieldId.c_str(), fieldId.length(), inputarray.getData(), dims[0], dims[1]);
+        modelarray = 0;
         // FIXME: Conversion with overloaded '=' operator is known to be problematic
         modelarray = inputarray;
         return;

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -153,9 +153,8 @@ void Xios::close_context_definition()
 
         // Special handling of input fields
         for (int ioType : { INPUT_RESTART, FORCING }) {
-            const std::set<std::string> fieldIds = (ioType == INPUT_RESTART)
-                ? configGetInputRestartFieldNames()
-                : configGetForcingFieldNames();
+            const std::set<std::string> fieldIds
+                = (ioType == INPUT_RESTART) ? inputRestartFieldNames : forcingFieldNames;
             for (const std::string& fieldId : fieldIds) {
                 const std::string inputFieldId
                     = (ioType == INPUT_RESTART) ? fieldId + "_input" : fieldId + "_forcing";
@@ -229,17 +228,53 @@ void Xios::finalize()
  * Overrides `Configure` method from `Configured`
  *
  * Configure the XIOS server if XIOS is enabled in the settings.
- *
  */
 void Xios::configure()
 {
     if (isEnabled) {
+        parseConfig();
         setupClient();
         setupContext();
         setupCalendar();
         setupFiles();
         setupFields();
     }
+}
+
+// Split a string into a set by some delimiter.
+std::set<std::string> str2set(const std::string& asStr, const char& delim = ',')
+{
+    std::set<std::string> asSet;
+    if (asStr.length() > 0) {
+        const char delim = ',';
+        std::istringstream iss(asStr);
+        std::string item;
+        while (std::getline(iss, item, delim)) {
+            asSet.insert(item);
+        }
+    }
+    return asSet;
+}
+
+/*!
+ * Parse the config and stores the field names for each I/O type.
+ */
+void Xios::parseConfig()
+{
+    inputRestartFieldNames
+        = str2set(Configured::getConfiguration(keyMap.at(INPUT_FIELD_NAMES_KEY), std::string()));
+    outputRestartFieldNames
+        = str2set(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()));
+    forcingFieldNames
+        = str2set(Configured::getConfiguration(keyMap.at(FORCING_FIELD_NAMES_KEY), std::string()));
+    diagnosticFieldNames = str2set(
+        Configured::getConfiguration(keyMap.at(DIAGNOSTIC_FIELD_NAMES_KEY), std::string()));
+
+    // Combine all field names into a single set for easier checking later on
+    fieldNames = inputRestartFieldNames;
+    fieldNames.insert(outputRestartFieldNames.begin(), outputRestartFieldNames.end());
+    fieldNames.insert(forcingFieldNames.begin(), forcingFieldNames.end());
+    fieldNames.insert(diagnosticFieldNames.begin(), diagnosticFieldNames.end());
 }
 
 //! Initialize the XIOS context with ID contextId
@@ -751,46 +786,6 @@ xios::CField* Xios::getField(const std::string& fieldId)
     return field;
 }
 
-// Split a string into a set by some delimiter.
-std::set<std::string> str2set(const std::string& asStr, const char& delim = ',')
-{
-    std::set<std::string> asSet;
-    if (asStr.length() > 0) {
-        const char delim = ',';
-        std::istringstream iss(asStr);
-        std::string item;
-        while (std::getline(iss, item, delim)) {
-            asSet.insert(item);
-        }
-    }
-    return asSet;
-}
-
-// Extract the field_names entry from the XiosInput section of the config.
-std::set<std::string> Xios::configGetInputRestartFieldNames()
-{
-    return str2set(Configured::getConfiguration(keyMap.at(INPUT_FIELD_NAMES_KEY), std::string()));
-}
-
-// Extract the field_names entry from the XiosForcing section of the config.
-std::set<std::string> Xios::configGetForcingFieldNames()
-{
-    return str2set(Configured::getConfiguration(keyMap.at(FORCING_FIELD_NAMES_KEY), std::string()));
-}
-
-// Extract the field_names entry from the XiosOutput section of the config.
-std::set<std::string> Xios::configGetOutputRestartFieldNames()
-{
-    return str2set(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()));
-}
-
-// Extract the field_names entry from the XiosDiagnostic section of the config.
-std::set<std::string> Xios::configGetDiagnosticFieldNames()
-{
-    return str2set(
-        Configured::getConfiguration(keyMap.at(DIAGNOSTIC_FIELD_NAMES_KEY), std::string()));
-}
-
 /*!
  * Create a field with some ID
  *
@@ -805,16 +800,16 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
     std::set<std::string> fieldNames;
     std::string ioName;
     if (ioType == INPUT_RESTART) {
-        fieldNames = configGetInputRestartFieldNames();
+        fieldNames = inputRestartFieldNames;
         ioName = "input restart";
     } else if (ioType == OUTPUT_RESTART) {
-        fieldNames = configGetOutputRestartFieldNames();
+        fieldNames = outputRestartFieldNames;
         ioName = "output restart";
     } else if (ioType == FORCING) {
-        fieldNames = configGetForcingFieldNames();
+        fieldNames = forcingFieldNames;
         ioName = "forcing";
     } else if (ioType == DIAGNOSTIC) {
-        fieldNames = configGetDiagnosticFieldNames();
+        fieldNames = diagnosticFieldNames;
         ioName = "diagnostic";
     } else {
         throw std::runtime_error("Xios: Unknown I/O type for field '" + fieldId + "'");
@@ -1144,10 +1139,10 @@ void Xios::setupFields()
         std::set<std::string> configFieldIds;
         int ioType;
         if (filename == metadata.initialFileName) {
-            configFieldIds = configGetInputRestartFieldNames();
+            configFieldIds = inputRestartFieldNames;
             ioType = INPUT_RESTART;
         } else {
-            configFieldIds = configGetForcingFieldNames();
+            configFieldIds = forcingFieldNames;
             ioType = FORCING;
         }
         try {
@@ -1313,13 +1308,13 @@ void Xios::createFile(const std::string& fileId)
     // Get the fieldIds
     std::set<std::string> fieldIds;
     if (ioType == INPUT_RESTART) {
-        fieldIds = configGetInputRestartFieldNames();
+        fieldIds = inputRestartFieldNames;
     } else if (ioType == OUTPUT_RESTART) {
-        fieldIds = configGetOutputRestartFieldNames();
+        fieldIds = outputRestartFieldNames;
     } else if (ioType == FORCING) {
-        fieldIds = configGetForcingFieldNames();
+        fieldIds = forcingFieldNames;
     } else if (ioType == DIAGNOSTIC) {
-        fieldIds = configGetDiagnosticFieldNames();
+        fieldIds = diagnosticFieldNames;
     }
 
     // Determine the file output frequency

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1583,6 +1583,15 @@ void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
     auto& dims = modelarray.dimensions();
     const ModelArray::Type& type = modelarray.getType();
     domainWritten[domainIds[type]] = true;
+
+    // Check the field type
+    const ModelArray::Type& expectedType = getFieldType(fieldId);
+    if (expectedType != type) {
+        throw std::runtime_error(
+            "Xios::read: field '" + fieldId + "' does not have the expected type");
+    }
+
+    // Write out according to field type
     if ((type == ModelArray::Type::H) || (type == ModelArray::Type::CG)) {
         cxios_write_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1], -1);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -73,7 +73,7 @@ public:
     size_t getAxisSize(const std::string& axisId);
 
     /* Field */
-    std::set<std::string> configGetForcingFieldNames();
+    std::set<std::string> forcingFieldNames;
     void setPrognosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
     void setDiagnosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
 
@@ -100,6 +100,9 @@ private:
     int mpi_rank { 0 };
     int mpi_size { 0 };
     int cStrLen { 20 }; // Length of C-strings passed to XIOS
+
+    /* Configuration */
+    void parseConfig();
 
     /* Client */
     const std::string clientId = "client";
@@ -164,9 +167,10 @@ private:
     /* Field */
     xios::CFieldGroup* getFieldGroup();
     xios::CField* getField(const std::string& fieldId);
-    std::set<std::string> configGetOutputRestartFieldNames();
-    std::set<std::string> configGetInputRestartFieldNames();
-    std::set<std::string> configGetDiagnosticFieldNames();
+    std::set<std::string> outputRestartFieldNames;
+    std::set<std::string> inputRestartFieldNames;
+    std::set<std::string> diagnosticFieldNames;
+    std::set<std::string> fieldNames;
     void createField(const std::string& fieldId, const std::string& fileId);
     std::string createInputField(const std::string& fieldId, const int ioType);
     void setFieldOperation(const std::string& fieldId, const int ioType);

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -7,6 +7,9 @@
 
 #include "include/ModelComponent.hpp"
 #include "include/Time.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#endif
 #include "include/gridNames.hpp"
 
 #include <limits>
@@ -46,6 +49,13 @@ public:
         getStore().registerArray(Protected::SHEAR, &shear, RO);
         getStore().registerArray(Protected::SIGMAI, &sigmaI, RO);
         getStore().registerArray(Protected::SIGMAII, &sigmaII, RO);
+
+#ifdef USE_XIOS
+        // Set XIOS field types
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::U);
+        xiosHandler.setPrognosticFieldType(vName, ModelArray::Type::V);
+#endif
     }
     virtual ~IDynamics() = default;
 

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -52,7 +52,7 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 3)
     // Check the input file exists
     if (!std::filesystem::exists(diagnosticFilename)) {
         throw std::runtime_error(
-            "XiosReadDiagnostic_test: Input file not found. Did you run XiosWrite_test?");
+            "XiosReadDiagnostic_test: Input file not found. Did you run XiosWriteDiagnostic_test?");
     }
 
     // Create ModelMPI instance based off the test communicator

--- a/core/test/XiosReadForcing_test.cpp
+++ b/core/test/XiosReadForcing_test.cpp
@@ -88,14 +88,13 @@ MPI_TEST_CASE("TestXiosReadForcing", 2)
     // Simulate 4 iterations (timesteps), reading forcing data at each
     ModelMetadata& metadata = ModelMetadata::getInstance();
     const Duration& timestep = metadata.stepLength();
-    // TODO: Avoid making configGetForcingFieldNames public?
-    auto forcingFieldNames = xiosHandler.configGetForcingFieldNames();
     for (int ts = 0; ts <= 4; ts++) {
 
         // Read forcings from file and check they take the expected values
+        // TODO: Avoid making forcingFieldNames public?
         const TimePoint& time = xiosHandler.getCurrentDate();
         const ModelState forcings
-            = pio->readForcingTimeStatic(forcingFieldNames, time, forcingFilename);
+            = pio->readForcingTimeStatic(xiosHandler.forcingFieldNames, time, forcingFilename);
         for (const auto& [fieldName, modelarray] : forcings.data) {
             REQUIRE(fieldName == hsnowName);
             for (size_t j = 0; j < ny; ++j) {

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -43,7 +43,7 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
            << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
@@ -100,7 +100,7 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
                     REQUIRE(modelarray(i, j) == doctest::Approx(j >= 1 ? 1.0 : 0.0));
                 }
             }
-        } else if (fieldName == gridAzimuthName) {
+        } else if (fieldName == coordsName) {
             for (size_t j = 0; j < ny + 1; ++j) {
                 for (size_t i = 0; i < nx + 1; ++i) {
                     float expected_x;

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -43,8 +43,8 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -92,6 +92,12 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
             for (size_t j = 0; j < ny; ++j) {
                 for (size_t i = 0; i < nx; ++i) {
                     REQUIRE(modelarray(i, j) == doctest::Approx(j));
+                }
+            }
+        } else if (fieldName == gridAzimuthName) {
+            for (size_t j = 0; j < ny; ++j) {
+                for (size_t i = 0; i < nx; ++i) {
+                    REQUIRE(modelarray(i, j) == doctest::Approx(0.0));
                 }
             }
         } else if (fieldName == maskName) {

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -51,7 +51,7 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     // Check the input file exists
     if (!std::filesystem::exists(restartFilename)) {
         throw std::runtime_error(
-            "XiosReadRestart_test: Input file not found. Did you run XiosWrite_test?");
+            "XiosReadRestart_test: Input file not found. Did you run XiosWriteRestart_test?");
     }
 
     // Create ModelMPI instance based off the test communicator

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -69,8 +69,6 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     REQUIRE(xiosHandler.getCalendarStep() == 0);
 
     // Set ModelArray dimensions
-    const size_t nx = ModelArray::size(ModelArray::Dimension::X);
-    const size_t ny = ModelArray::size(ModelArray::Dimension::Y);
     REQUIRE(ModelArray::nComponents(ModelArray::Type::DG) == DGCOMP);
     REQUIRE(ModelArray::size(ModelArray::Dimension::DG) == DGCOMP);
 

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -45,11 +45,11 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
            << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
            << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -45,12 +45,12 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -77,9 +77,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
 
     // Set field types for restarts
-    xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
-    xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
-    xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
+    // TODO: Set these in modules rather than here
     xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::VERTEX);
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -78,8 +78,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
 
     // Set field types for restarts
     // TODO: Set these in modules rather than here
-    xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
-    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);
 

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -45,11 +45,11 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
            << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
            << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
@@ -78,7 +78,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
 
     // Set field types for restarts
     // TODO: Set these in modules rather than here
-    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::VERTEX);
+    xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);
 
@@ -112,8 +112,8 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     damage.resize();
     DGField hsnow(ModelArray::Type::DG);
     hsnow.resize();
-    VertexField grid_azimuth(ModelArray::Type::VERTEX);
-    grid_azimuth.resize();
+    VertexField coords(ModelArray::Type::VERTEX);
+    coords.resize();
     DGSField tice(ModelArray::Type::DGSTRESS);
     tice.resize();
     CGField uice(ModelArray::Type::CG);
@@ -149,11 +149,11 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
         for (size_t j = 0; j < ny + 1; ++j) {
             for (size_t i = 0; i < nx + 1; ++i) {
                 if (rank == 0) {
-                    grid_azimuth.components({ i, j })[0] = 1.0 * ts * i;
-                    grid_azimuth.components({ i, j })[1] = 1.0 * ts * j;
+                    coords.components({ i, j })[0] = 1.0 * ts * i;
+                    coords.components({ i, j })[1] = 1.0 * ts * j;
                 } else {
-                    grid_azimuth.components({ i, j })[0] = 1.0 * ts * (i + 2);
-                    grid_azimuth.components({ i, j })[1] = 1.0 * ts * j;
+                    coords.components({ i, j })[0] = 1.0 * ts * (i + 2);
+                    coords.components({ i, j })[1] = 1.0 * ts * j;
                 }
             }
         }
@@ -187,7 +187,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                                     { hiceName, hice },
                                     { damageName, damage },
                                     { hsnowName, hsnow },
-                                    { gridAzimuthName, grid_azimuth },
+                                    { coordsName, coords },
                                     { ticeName, tice },
                                     { uName, uice },
                                 },

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -45,12 +45,12 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -79,6 +79,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     // Set field types for restarts
     // TODO: Set these in modules rather than here
     xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
+    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);
 
@@ -97,6 +98,9 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
             latitude(i, j) = j;
         }
     }
+    HField grid_azimuth(ModelArray::Type::H);
+    grid_azimuth.resize();
+    grid_azimuth = 0;
     HField mask(ModelArray::Type::H);
     mask.resize();
     for (size_t j = 0; j < ny; ++j) {
@@ -183,6 +187,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                                     { maskName, mask },
                                     { longitudeName, longitude },
                                     { latitudeName, latitude },
+                                    { gridAzimuthName, grid_azimuth },
                                     { ciceName, cice },
                                     { hiceName, hice },
                                     { damageName, damage },

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -43,6 +43,10 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     config << "restart_file = " << outputFilename << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
+    config << "[XiosInput]" << std::endl;
+    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
+           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
            << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
@@ -55,8 +59,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
 
     // Create a Model and configure it so that time options are parsed
     Model model;
-    model.configureRestarts();
-    model.configureTime();
+    model.configure();
 
     // Get the Xios singleton instance and check it's initialized
     // NOTE: The singleton is created when Xios::getInstance() is first called. In this test, this
@@ -77,10 +80,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
-    xiosHandler.setPrognosticFieldType(ciceName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(hiceName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::Type::DG);
     xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::VERTEX);
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -51,10 +51,10 @@ variables:
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
-  // DGField variables
-  float cice(y_dim, x_dim, dg_comp) ;
+  float cice(y_dim, x_dim) ;
 		cice:online_operation = "once" ;
-		cice:coordinates = "lat lon dg_comp" ;
+		cice:coordinates = "lat lon" ;
+  // DGField variables
   float hice(y_dim, x_dim, dg_comp) ;
 		hice:online_operation = "once" ;
 		hice:coordinates = "lat lon dg_comp" ;
@@ -100,17 +100,11 @@ data:
   0, 0, 0, 0,
   1, 1, 1, 1 ;
 
- // DGField variables
-
  cice =
-  0, 1, 2, 3, 4, 5,
-  6, 7, 8, 9, 10, 11,
-  0, 1, 2, 3, 4, 5,
-  6, 7, 8, 9, 10, 11,
-  12, 13, 14, 15, 16, 17,
-  18, 19, 20, 21, 22, 23,
-  12, 13, 14, 15, 16, 17,
-  18, 19, 20, 21, 22, 23 ;
+  0, 1, 2, 3,
+  4, 5, 6, 7 ;
+
+ // DGField variables
 
  hice =
   0, 1, 2, 3, 4, 5,

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -65,9 +65,9 @@ variables:
 		hsnow:online_operation = "once" ;
 		hsnow:coordinates = "lat lon dg_comp" ;
   // VertexField variables
-	float grid_azimuth(y_vertex, x_vertex, ncoords) ;
-		grid_azimuth:online_operation = "once" ;
-		grid_azimuth:coordinates = "lat lon ncoords" ;
+	float coords(y_vertex, x_vertex, ncoords) ;
+		coords:online_operation = "once" ;
+		coords:coordinates = "lat lon ncoords" ;
   // DGStressField variables
 	float tice(y_dim, x_dim, dgstress_comp) ;
 		tice:online_operation = "once" ;
@@ -138,7 +138,7 @@ data:
 
  // VertexField variables
 
- grid_azimuth =
+ coords =
   0, 0,
   1, 0,
   2, 0,

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -48,6 +48,9 @@ variables:
   float latitude(y_dim, x_dim) ;
     latitude:online_operation = "once" ;
     latitude:coordinates = "lat lon" ;
+  float grid_azimuth(y_dim, x_dim) ;
+    grid_azimuth:online_operation = "once" ;
+    grid_azimuth:coordinates = "lat lon" ;
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
@@ -95,6 +98,10 @@ data:
  latitude =
   0, 0, 0, 0,
   1, 1, 1, 1 ;
+
+ grid_azimuth =
+  0, 0, 0, 0,
+  0, 0, 0, 0 ;
 
  mask =
   0, 0, 0, 0,

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -13,7 +13,7 @@ API calls to reduce user requirements.
 
 .. _XIOS: https://forge.ipsl.fr/ioserver
 
-The integration of XIOS into nextSIM-DG's is built around a static ``Xios``
+The integration of XIOS into nextSIM-DG is built around a static ``Xios``
 handler class, which provides a C++ API for the various XIOS functions. When the
 handler is instantiated, the configuration sections (see section below) are
 parsed. Based on the values that are parsed, the handler object will
@@ -47,7 +47,7 @@ to generate an XML file:
 where ``DGCOMP`` is the integer number of DG components (e.g., 6),
 ``DGSTRESSCOMP`` is the integer number of DG stress components (e.g., 8), and
 ``OUTPUT_FILE_NAME`` is the output file name, including its path, e.g.,
-``build/core/test/iodef.xml``.
+``build/core/test/iodef.xml`` or ``run/iodef.xml``.
 
 NextSIM-DG configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,28 +94,21 @@ building without XIOS. That is, the ``model`` section should include
   restart_file = my_restart_file.nc
   restart_period = P0-0T02:00:00
 
-In the cases of forcing and diagnostics files, the file names are configured
-differently, via the ``filename`` entry in the ``XiosForcing`` and/or
-``XiosDiagnostic`` sections, respectively. For example,
+Information related to fields to be read from and written to files are
+configured via the ``XiosInput``, ``XiosOutput``, ``XiosForcing``, and
+``XiosDiagnostic`` sections, where the first two refer to restarts. Note that
+all of these sections are optional.
+
+For restart files, the filename is determined from the ``restart_file`` entry in
+the ``model`` section mentioned above. In the cases of forcing and diagnostics
+files, the file names are configured differently, via the ``filename`` entry in
+the ``XiosForcing`` and/or ``XiosDiagnostic`` sections, respectively. For
+example,
 
 .. code-block::
 
    [XiosForcing]
    filename = my_forcing_file.nc
-
-The fields to be read from and written to files are configured via the
-``XiosInput``, ``XiosOutput``, and ``XiosForcing`` sections, where the first two
-refer to restarts. For example, we could specify that two fields labelled
-``field_A`` and ``field_B`` are to be written into restart files as follows:
-
-.. code-block::
-
-  [XiosOutput]
-  field_names = field_A,field_B
-
-The ``field_names`` entry may contain a single field name or a comma-separated
-list. Note that all of the ``XiosOutput``, ``XiosInput``, ``XiosDiagnostic``,
-and ``XiosForcing`` sections are optional.
 
 Restart and diagnostic file names may include format strings such as
 ``restart%Y-%m-%dT%H:%M:%SZ.nc`` or ``diagnostic%Y-%m-%dT%H:%M:%SZ.nc`` (in
@@ -127,8 +120,21 @@ provided format string. Restart files contain the state at the beginning of the
 time window, whereas diagnostics files are averaged over the timesteps in the
 window.
 
+In addition to specifying file names, we need to specify which fields are to be
+read or written using each I/O type. For example, we could specify that two
+fields labelled ``field_A`` and ``field_B`` are to be written into restart files
+as follows:
+
+.. code-block::
+
+  [XiosOutput]
+  field_names = field_A,field_B
+
+The ``field_names`` entry may contain a single field name or a comma-separated
+list.
+
 As elsewhere in the model, the configuration values above are all parsed by
-calling the ``Model.configure`` member function. Note that this function will
+calling the ``Model.configure()`` member function. Note that this function will
 automatically initialize the model state based on the ``input_file`` entry and
 any ``field_names`` listed in the ``[XiosInput]`` configuration section. You
 will need to ensure that variables defining the grid are read here, i.e.,
@@ -147,23 +153,21 @@ following:
 
 1. Set configuration options as for other parts of the model. (See section above
    for options.)
-2. Get the ``ModelMetadata`` singleton instance by calling the static
-   ``ModelMetadata::getInstance`` member function, passing the MPI partition
-   metadata file as an argument.
-3. Configure the ``Model`` by constructing it and calling its ``configure``
+2. Configure the ``Model`` by constructing it and calling its ``configure``
    member function.
-4. Construct a ``ParametricGrid`` and a new ``ParaGridIO`` pointer.
-5. Associate the ``ParaGridIO`` pointer with the ``ParametricGrid`` instance
+3. Construct a ``ParametricGrid`` and a new ``ParaGridIO`` pointer.
+4. Associate the ``ParaGridIO`` pointer with the ``ParametricGrid`` instance
    using the latter's ``setIO`` member function.
-6. Get the ``Xios`` handler singleton using ``Xios::getInstance``.
-7. For each field to be written to file with XIOS, call the ``setFieldType``
-   member function of ``Xios``, providing the field name as the first argument
+5. Get the ``Xios`` handler singleton using ``Xios::getInstance``.
+6. For each field to be written to file with XIOS, call the
+   ``setPrognosticFieldType`` or ``setDiagnosticFieldType`` member function of
+   ``Xios`` as appropriate, providing the field name as the first argument
    and the ``ModelArray::Type::<TYPE>`` enum as the second argument (replacing
-   ``<TYPE>>`` as appropriate).
-8. Call the ``close_context_definition`` member function of ``Xios``. This is
-   not required if files were read with ``StructureFactory::stateFromFile``
-   because that function automatically closes the context definition before
-   reading.
+   ``<TYPE>>`` with the desired type).
+
+There is no need to explicitly close the XIOS context definition because this
+happens automatically upon reading or writing. As such, all XIOS configuration
+must take place before any files are read from or written to.
 
 XIOS concepts
 -------------
@@ -212,8 +216,9 @@ An instance of the Field type is based on a Grid and is associated with a
 ``ModelArray::Type``. Fields are created automatically upon configuring the
 ``Model``. For fields that are read from file, the field type is determined
 automatically during the file read. For fields that are written, it's required
-to call the ``setFieldType`` member function of the ``Xios`` singleton,
-providing the field name and ``ModelArray::Type``.
+to call the ``setPrognosticFieldType`` or ``setDiagnosticFieldType`` member
+function of the ``Xios`` singleton, providing the field name and
+``ModelArray::Type``.
 
 XIOS File concept
 ^^^^^^^^^^^^^^^^^

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -8,6 +8,9 @@
 
 #include "include/CheckingModelComponent.hpp"
 #include "include/constants.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#endif
 #include "include/gridNames.hpp"
 
 namespace Nextsim {
@@ -71,6 +74,13 @@ public:
         getStore().registerArray(Protected::SSH, &ssh, RO);
         getStore().registerArray(Shared::Q_SW_OW, &qswow, RW);
         getStore().registerArray(Shared::Q_SW_BASE, &qswBase, RW);
+
+#ifdef USE_XIOS
+        // Set XIOS field types
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(sssName, ModelArray::Type::H);
+        xiosHandler.setPrognosticFieldType(sstName, ModelArray::Type::H);
+#endif
     }
     virtual ~IOceanBoundary() = default;
 


### PR DESCRIPTION
# XIOS: Determine output field types

Fixes #1026
Merges into #1037 

### Task List
- [ ] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [ ] Implemented the source code change that satisfies the tests
- [ ] Documented the feature by providing worked example
- [ ] Updated the README or other documentation
- [ ] Completed the pre-Request checklist below

---
# Change Description

TODO

---
# Test Description

`setPrognosticFieldType` calls are removed from the XIOS write test to check that they are set correctly in `PrognosticData`. For this to be picked up, the test needed to call `Model.configure()` and `Model.configureTime()` needed to be called earlier within it.

---
# Documentation Impact

TODO

---
### Pre-Request Checklist

- [ ] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [ ] No new warnings are generated
- [ ] The documentation has been updated (or an issue has been created to track the corresponding change)
- [ ] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [ ] This change conforms to the conventions described in the README