### PR TITLE
XIOS: allow a field to be read and written with different types (take 2)

### DIFF
--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -55,7 +55,8 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
     // Get all variables in the file and load them into a new ModelState
     ModelState state;
     for (const std::string& fieldId : xiosHandler.configGetInputRestartFieldNames()) {
-        const ModelArray::Type& type = xiosHandler.getFieldType(fieldId);
+        const std::string inputFieldId = fieldId + "_input";
+        const ModelArray::Type& type = xiosHandler.getFieldType(inputFieldId);
         if (type == ModelArray::Type::H) {
             HField field(ModelArray::Type::H);
             field.resize();
@@ -125,11 +126,18 @@ ModelState ParaGridIO::readForcingTimeStatic(
             throw std::runtime_error("ParaGridIO::readForcingTimeStatic: field " + fieldId
                 + " is not configured as a forcing.");
         }
+        const std::string forcingFieldId = fieldId + "_forcing";
+        const ModelArray::Type& type = xiosHandler.getFieldType(forcingFieldId);
         // ASSUME all forcings are HFields: finite volume fields on the same
         // grid as ice thickness
-        HField field(ModelArray::Type::H);
-        field.resize();
-        state.merge(ModelState { { { fieldId, field } }, {} });
+        if (type == ModelArray::Type::H) {
+            HField field(ModelArray::Type::H);
+            field.resize();
+            state.merge(ModelState { { { fieldId, field } }, {} });
+        } else {
+            throw std::runtime_error("ParaGridIO::readForcingTimeStatic: field type for field "
+                + fieldId + " is not supported.");
+        }
     }
 
     // Read all forcings from file

--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -55,8 +55,7 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
     // Get all variables in the file and load them into a new ModelState
     ModelState state;
     for (const std::string& fieldId : xiosHandler.configGetInputRestartFieldNames()) {
-        const std::string inputFieldId = fieldId + "_input";
-        const ModelArray::Type& type = xiosHandler.getFieldType(inputFieldId);
+        const ModelArray::Type& type = xiosHandler.getFieldType(fieldId);
         if (type == ModelArray::Type::H) {
             HField field(ModelArray::Type::H);
             field.resize();
@@ -165,12 +164,11 @@ void ParaGridIO::dumpModelState(const ModelState& state, const std::string& file
     // Assume that all fields in the supplied ModelState are necessary, and so write them to file.
     const std::set<std::string> outputFieldIds = xiosHandler.configGetOutputRestartFieldNames();
     for (const auto& [fieldId, modelarray] : state.data) {
-        const std::string outputFieldId = fieldId;
         if (outputFieldIds.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::dumpModelState: field " + fieldId
                 + " is not configured as a restart.");
         }
-        xiosHandler.write(outputFieldId, modelarray);
+        xiosHandler.write(fieldId, modelarray);
     }
 }
 
@@ -189,12 +187,11 @@ void ParaGridIO::writeDiagnosticTime(const ModelState& state, const std::string&
     // Assume that all fields in the supplied ModelState are necessary, and so write them to file.
     const std::set<std::string> diagnosticFieldIds = xiosHandler.configGetDiagnosticFieldNames();
     for (const auto& [fieldId, modelarray] : state.data) {
-        const std::string diagnosticFieldId = fieldId;
         if (diagnosticFieldIds.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::writeDiagnosticTime: field " + fieldId
                 + " is not configured as a diagnostic.");
         }
-        xiosHandler.write(diagnosticFieldId, modelarray);
+        xiosHandler.write(fieldId, modelarray);
     }
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1588,7 +1588,7 @@ void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
     const ModelArray::Type& expectedType = getFieldType(fieldId);
     if (expectedType != type) {
         throw std::runtime_error(
-            "Xios::read: field '" + fieldId + "' does not have the expected type");
+            "Xios::write: field '" + fieldId + "' does not have the expected type");
     }
 
     // Write out according to field type

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -172,8 +172,11 @@ void Xios::close_context_definition()
                 }
 
                 // Link the input field to the base field if their types align
-                const ModelArray::Type& inputType = getFieldType(inputFieldId);
                 const ModelArray::Type& baseType = getFieldType(fieldId);
+                if (ioType == FORCING && baseType != ModelArray::Type::H) {
+                    throw std::runtime_error("Xios: Forcing fields must be treated as HFields");
+                }
+                const ModelArray::Type& inputType = getFieldType(inputFieldId);
                 if (inputType == baseType) {
                     cxios_set_field_field_ref(
                         getField(inputFieldId), fieldId.c_str(), fieldId.length());

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1616,7 +1616,6 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
     if (modelarray.nDimensions() != 2) {
         throw std::invalid_argument("Only ModelArrays of dimension 2 are supported");
     }
-    auto& dims = modelarray.dimensions();
     const ModelArray::Type& type = modelarray.getType();
     const ModelArray::Type& expectedType = getFieldType(fieldId);
 
@@ -1630,7 +1629,8 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
             throw std::runtime_error(
                 "Xios::read: field '" + fieldId + "' was expected to be converted to a DGField");
         }
-        ModelArray inputarray;
+        HField inputarray(ModelArray::Type::H);
+        auto& dims = inputarray.dimensions();
         cxios_read_data_k82(
             fieldId.c_str(), fieldId.length(), inputarray.getData(), dims[0], dims[1]);
         // FIXME: Conversion with overloaded '=' operator is known to be problematic
@@ -1639,6 +1639,7 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
     }
 
     // Other field types should not need converting
+    auto& dims = modelarray.dimensions();
     if (type != expectedType) {
         throw std::runtime_error(
             "Xios::read: field '" + fieldId + "' does not have the expected type");

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -171,11 +171,16 @@ void Xios::close_context_definition()
                     setFieldGridRef(fieldId, getFieldGridRef(inputFieldId));
                 }
 
+                // Check the field types
+                const ModelArray::Type& inputType = getFieldType(inputFieldId);
+                if (fieldTypes.count(fieldId) == 0) {
+                    setFieldType(fieldId, inputType, NOT_READ);
+                }
                 const ModelArray::Type& baseType = getFieldType(fieldId);
                 if (ioType == FORCING && baseType != ModelArray::Type::H) {
                     throw std::runtime_error("Xios: Forcing fields must be treated as HFields");
                 }
-                const ModelArray::Type& inputType = getFieldType(inputFieldId);
+
                 if (inputType == baseType) {
                     // Link the input field to the base field if their types align
                     cxios_set_field_field_ref(
@@ -1054,7 +1059,14 @@ Duration Xios::getFieldFreqOffset(const std::string& fieldId)
  * @param the field ID
  * @return ModelArray::Type used for the corresponding field
  */
-ModelArray::Type Xios::getFieldType(const std::string& fieldId) { return fieldTypes[fieldId]; }
+ModelArray::Type Xios::getFieldType(const std::string& fieldId)
+{
+    if (fieldTypes.count(fieldId) == 0) {
+        throw std::runtime_error(
+            "Xios::getFieldType: Undefined field type for field '" + fieldId + "'");
+    }
+    return fieldTypes[fieldId];
+}
 
 /*!
  * Set the field type associated with a field with a given ID

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1061,14 +1061,14 @@ ModelArray::Type Xios::getFieldType(const std::string& fieldId) { return fieldTy
 void Xios::setFieldType(
     const std::string& fieldId, const ModelArray::Type& fieldType, const int ioType)
 {
-    fieldTypes[fieldId] = fieldType;
+    std::string ioFieldId = fieldId;
     if (ioType == INPUT_RESTART) {
-        setFieldGridRef(fieldId + "_input", gridIds[fieldType]);
+        ioFieldId += "_input";
     } else if (ioType == FORCING) {
-        setFieldGridRef(fieldId + "_forcing", gridIds[fieldType]);
-    } else {
-        setFieldGridRef(fieldId, gridIds[fieldType]);
+        ioFieldId += "_forcing";
     }
+    fieldTypes[ioFieldId] = fieldType;
+    setFieldGridRef(ioFieldId, gridIds[fieldType]);
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1620,7 +1620,7 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
 {
     if (!getFieldReadAccess(fieldId)) {
         throw std::runtime_error("Xios::read: field '" + fieldId
-            + "'' is not configured for reading, but is being read from file.");
+            + "' is not configured for reading, but is being read from file.");
     };
     if (modelarray.nDimensions() != 2) {
         throw std::invalid_argument("Only ModelArrays of dimension 2 are supported");

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -168,21 +168,20 @@ void Xios::close_context_definition()
 
                 // Ensure that base fields have a grid reference if not already defined
                 if (!cxios_is_defined_field_grid_ref(field)) {
-                    const std::string gridRef = getFieldGridRef(inputFieldId);
-                    cxios_set_field_grid_ref(field, gridRef.c_str(), gridRef.length());
+                    setFieldGridRef(fieldId, getFieldGridRef(inputFieldId));
                 }
 
-                // Link the input field back to the base field with a field reference
-                xios::CField* inputField = getField(inputFieldId);
-                if (cxios_is_defined_field_field_ref(inputField)) {
+                // Link the input field to the base field if their types align
+                const ModelArray::Type& inputType = getFieldType(inputFieldId);
+                const ModelArray::Type& baseType = getFieldType(fieldId);
+                if (inputType == baseType) {
+                    cxios_set_field_field_ref(
+                        getField(inputFieldId), fieldId.c_str(), fieldId.length());
+                } else {
+                    // TODO: Support having a HField for reading and a DGField for writing
                     throw std::runtime_error(
-                        "Xios: Field reference already exists for input field '" + inputFieldId
+                        "Xios: Inconsistent field types for reading and writing field '" + fieldId
                         + "'");
-                }
-                cxios_set_field_field_ref(inputField, fieldId.c_str(), fieldId.length());
-                if (!cxios_is_defined_field_field_ref(inputField)) {
-                    throw std::runtime_error(
-                        "Xios: Failed to set reference for input field '" + inputFieldId + "'");
                 }
             }
         }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -815,12 +815,12 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
     }
 
     if (ioType == INPUT_RESTART || ioType == FORCING) {
-        // Create an inherited field and set it's operation type and read access and associate it
+        // Create an input field and set it's operation type and read access and associate it
         // with the file
-        const std::string inheritedFieldId = createInheritedField(fieldId, ioType);
-        setFieldOperation(inheritedFieldId, ioType);
-        setFieldReadAccess(inheritedFieldId, true);
-        fileAddField(fileId, inheritedFieldId);
+        const std::string inputFieldId = createInputField(fieldId, ioType);
+        setFieldOperation(inputFieldId, ioType);
+        setFieldReadAccess(inputFieldId, true);
+        fileAddField(fileId, inputFieldId);
     } else {
         // Set the field operation type and read access and associate the field with the file
         setFieldOperation(fieldId, ioType);
@@ -859,71 +859,67 @@ void Xios::setFieldOperation(const std::string& fieldId, const int ioType)
 }
 
 /*
- * Create an inherited field for reading.
+ * Create an input field for reading.
  *
  * @param   fieldId the base field ID
  * @param   ioType the enum for the I/O type
- * @return  inheritedFieldId the inherited field ID
+ * @return  inputFieldId the input field ID
  * @details When reading a field from file, we need to define a separate field that references the
  *          'base' field, but has it's own I/O operation mode and read access properties.
  */
-std::string Xios::createInheritedField(const std::string& fieldId, const int ioType)
+std::string Xios::createInputField(const std::string& fieldId, const int ioType)
 {
-    std::string inheritedFieldId;
+    std::string inputFieldId;
     if (ioType == INPUT_RESTART) {
-        inheritedFieldId = fieldId + "_input";
+        inputFieldId = fieldId + "_input";
     } else if (ioType == FORCING) {
-        inheritedFieldId = fieldId + "_forcing";
+        inputFieldId = fieldId + "_forcing";
     } else if (ioType == OUTPUT_RESTART || ioType == DIAGNOSTIC) {
-        throw std::runtime_error(
-            "Xios: Inherited output field not needed for field '" + fieldId + "'");
+        throw std::runtime_error("Xios: Input field inconsistent with I/O type");
     } else {
         throw std::runtime_error("Xios: Unknown I/O type for field '" + fieldId + "'");
     }
 
-    // Check if the inherited field already exists
+    // Check if the input field already exists
     bool exists;
-    cxios_field_valid_id(&exists, inheritedFieldId.c_str(), inheritedFieldId.length());
+    cxios_field_valid_id(&exists, inputFieldId.c_str(), inputFieldId.length());
     if (exists) {
-        throw std::runtime_error("Xios: Inherited field '" + inheritedFieldId + "' already exists");
+        throw std::runtime_error("Xios: input field '" + inputFieldId + "' already exists");
     }
 
-    // Attempt to create the inherited field
-    xios::CField* inheritedField = NULL;
+    // Attempt to create the input field
+    xios::CField* inputField = NULL;
     cxios_xml_tree_add_field(
-        getFieldGroup(), &inheritedField, inheritedFieldId.c_str(), inheritedFieldId.length());
-    if (!inheritedField) {
-        throw std::runtime_error(
-            "Xios: Null pointer for inherited field '" + inheritedFieldId + "'");
+        getFieldGroup(), &inputField, inputFieldId.c_str(), inputFieldId.length());
+    if (!inputField) {
+        throw std::runtime_error("Xios: Null pointer for input field '" + inputFieldId + "'");
     }
-    cxios_field_valid_id(&exists, inheritedFieldId.c_str(), inheritedFieldId.length());
+    cxios_field_valid_id(&exists, inputFieldId.c_str(), inputFieldId.length());
     if (!exists) {
-        throw std::runtime_error(
-            "Xios: Failed to create inherited field '" + inheritedFieldId + "'");
+        throw std::runtime_error("Xios: Failed to create input field '" + inputFieldId + "'");
     }
 
-    // Set inherited field name
-    if (cxios_is_defined_field_name(inheritedField)) {
-        Logged::warning("Xios: Overwriting name for inherited field '" + inheritedFieldId + "'");
+    // Set input field name
+    if (cxios_is_defined_field_name(inputField)) {
+        Logged::warning("Xios: Overwriting name for input field '" + inputFieldId + "'");
     }
-    cxios_set_field_name(inheritedField, fieldId.c_str(), fieldId.length());
-    if (!cxios_is_defined_field_name(inheritedField)) {
-        throw std::runtime_error(
-            "Xios: Failed to set name for inherited field '" + inheritedFieldId + "'");
-    }
-
-    // Link the inherited field back to the base field with a field reference
-    if (cxios_is_defined_field_field_ref(inheritedField)) {
-        throw std::runtime_error(
-            "Xios: Field reference already exists for inherited field '" + inheritedFieldId + "'");
-    }
-    cxios_set_field_field_ref(inheritedField, fieldId.c_str(), fieldId.length());
-    if (!cxios_is_defined_field_field_ref(inheritedField)) {
-        throw std::runtime_error(
-            "Xios: Failed to set reference for inherited field '" + inheritedFieldId + "'");
+    cxios_set_field_name(inputField, fieldId.c_str(), fieldId.length());
+    if (!cxios_is_defined_field_name(inputField)) {
+        throw std::runtime_error("Xios: Failed to set name for input field '" + inputFieldId + "'");
     }
 
-    return inheritedFieldId;
+    // Link the input field back to the base field with a field reference
+    if (cxios_is_defined_field_field_ref(inputField)) {
+        throw std::runtime_error(
+            "Xios: Field reference already exists for input field '" + inputFieldId + "'");
+    }
+    cxios_set_field_field_ref(inputField, fieldId.c_str(), fieldId.length());
+    if (!cxios_is_defined_field_field_ref(inputField)) {
+        throw std::runtime_error(
+            "Xios: Failed to set reference for input field '" + inputFieldId + "'");
+    }
+
+    return inputFieldId;
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -187,7 +187,7 @@ void Xios::close_context_definition()
                         getField(inputFieldId), fieldId.c_str(), fieldId.length());
                 } else if (baseType == ModelArray::Type::DG && inputType == ModelArray::Type::H) {
                     // Record fields read in as HField but treated as DGField
-                    inputFieldsToConvert.insert(fieldId);
+                    inputFieldsToConvert.insert(inputFieldId);
                 } else {
                     throw std::runtime_error(
                         "Xios: Inconsistent field types for reading and writing field '" + fieldId
@@ -1621,11 +1621,11 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
 
     // Account for fields to be read in as HField but converted to DGField
     if (inputFieldsToConvert.count(fieldId)) {
-        if (type != ModelArray::Type::H) {
+        if (expectedType != ModelArray::Type::H) {
             throw std::runtime_error(
                 "Xios::read: field '" + fieldId + "' was expected to be read as a HField");
         }
-        if (expectedType != ModelArray::Type::DG) {
+        if (type != ModelArray::Type::DG) {
             throw std::runtime_error(
                 "Xios::read: field '" + fieldId + "' was expected to be converted to a DGField");
         }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1633,6 +1633,7 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
         auto& dims = inputarray.dimensions();
         cxios_read_data_k82(
             fieldId.c_str(), fieldId.length(), inputarray.getData(), dims[0], dims[1]);
+        modelarray = 0;
         // FIXME: Conversion with overloaded '=' operator is known to be problematic
         modelarray = inputarray;
         return;

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -157,6 +157,8 @@ void Xios::close_context_definition()
                 ? configGetInputRestartFieldNames()
                 : configGetForcingFieldNames();
             for (const std::string& fieldId : fieldIds) {
+                const std::string inputFieldId
+                    = (ioType == INPUT_RESTART) ? fieldId + "_input" : fieldId + "_forcing";
 
                 // Ensure that base fields have operation type 'instant' if not already defined
                 xios::CField* field = getField(fieldId);
@@ -164,9 +166,13 @@ void Xios::close_context_definition()
                     cxios_set_field_operation(field, "instant", strlen("instant"));
                 }
 
+                // Ensure that base fields have a grid reference if not already defined
+                if (!cxios_is_defined_field_grid_ref(field)) {
+                    const std::string gridRef = getFieldGridRef(inputFieldId);
+                    cxios_set_field_grid_ref(field, gridRef.c_str(), gridRef.length());
+                }
+
                 // Link the input field back to the base field with a field reference
-                const std::string inputFieldId
-                    = (ioType == INPUT_RESTART) ? fieldId + "_input" : fieldId + "_forcing";
                 xios::CField* inputField = getField(inputFieldId);
                 if (cxios_is_defined_field_field_ref(inputField)) {
                     throw std::runtime_error(
@@ -1049,13 +1055,43 @@ ModelArray::Type Xios::getFieldType(const std::string& fieldId) { return fieldTy
 /*!
  * Set the field type associated with a field with a given ID
  *
- * @param the field ID
- * @param ModelArray::Type used for the corresponding field
+ * @param fieldId the field ID
+ * @param fieldType ModelArray::Type used for the corresponding field
+ * @param ioType the enum for the I/O type
  */
-void Xios::setFieldType(const std::string& fieldId, const ModelArray::Type& fieldType)
+void Xios::setFieldType(
+    const std::string& fieldId, const ModelArray::Type& fieldType, const int ioType)
 {
     fieldTypes[fieldId] = fieldType;
-    setFieldGridRef(fieldId, gridIds[fieldType]);
+    if (ioType == INPUT_RESTART) {
+        setFieldGridRef(fieldId + "_input", gridIds[fieldType]);
+    } else if (ioType == FORCING) {
+        setFieldGridRef(fieldId + "_forcing", gridIds[fieldType]);
+    } else {
+        setFieldGridRef(fieldId, gridIds[fieldType]);
+    }
+}
+
+/*!
+ * Set the field type associated with a field to be written as a restart
+ *
+ * @param fieldId the field ID
+ * @param fieldType ModelArray::Type used for the corresponding field
+ */
+void Xios::setPrognosticFieldType(const std::string& fieldId, const ModelArray::Type& fieldType)
+{
+    setFieldType(fieldId, fieldType, OUTPUT_RESTART);
+}
+
+/*!
+ * Set the field type associated with a field to be written as a diagnostic
+ *
+ * @param fieldId the field ID
+ * @param fieldType ModelArray::Type used for the corresponding field
+ */
+void Xios::setDiagnosticFieldType(const std::string& fieldId, const ModelArray::Type& fieldType)
+{
+    setFieldType(fieldId, fieldType, DIAGNOSTIC);
 }
 
 /*!
@@ -1090,10 +1126,13 @@ void Xios::setupFields()
 
         // Determine field types
         std::set<std::string> configFieldIds;
+        int ioType;
         if (filename == metadata.initialFileName) {
             configFieldIds = configGetInputRestartFieldNames();
+            ioType = INPUT_RESTART;
         } else {
             configFieldIds = configGetForcingFieldNames();
+            ioType = FORCING;
         }
         try {
             auto& modelMPI = ModelMPI::getInstance();
@@ -1118,7 +1157,7 @@ void Xios::setupFields()
                 if (!dimensionKeys.count(dimKey)) {
                     continue;
                 }
-                setFieldType(fieldId, dimensionKeys.at(dimKey));
+                setFieldType(fieldId, dimensionKeys.at(dimKey), ioType);
             }
             ncFile.close();
         } catch (const netCDF::exceptions::NcException& nce) {

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -171,17 +171,19 @@ void Xios::close_context_definition()
                     setFieldGridRef(fieldId, getFieldGridRef(inputFieldId));
                 }
 
-                // Link the input field to the base field if their types align
                 const ModelArray::Type& baseType = getFieldType(fieldId);
                 if (ioType == FORCING && baseType != ModelArray::Type::H) {
                     throw std::runtime_error("Xios: Forcing fields must be treated as HFields");
                 }
                 const ModelArray::Type& inputType = getFieldType(inputFieldId);
                 if (inputType == baseType) {
+                    // Link the input field to the base field if their types align
                     cxios_set_field_field_ref(
                         getField(inputFieldId), fieldId.c_str(), fieldId.length());
+                } else if (baseType == ModelArray::Type::DG && inputType == ModelArray::Type::H) {
+                    // Record fields read in as HField but treated as DGField
+                    inputFieldsToConvert.insert(fieldId);
                 } else {
-                    // TODO: Support having a HField for reading and a DGField for writing
                     throw std::runtime_error(
                         "Xios: Inconsistent field types for reading and writing field '" + fieldId
                         + "'");
@@ -1596,14 +1598,39 @@ void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
 void Xios::read(const std::string& fieldId, ModelArray& modelarray)
 {
     if (!getFieldReadAccess(fieldId)) {
-        throw std::runtime_error("Xios::read: field " + fieldId
-            + " is not configured for reading, but is being read from file.");
+        throw std::runtime_error("Xios::read: field '" + fieldId
+            + "'' is not configured for reading, but is being read from file.");
     };
     if (modelarray.nDimensions() != 2) {
         throw std::invalid_argument("Only ModelArrays of dimension 2 are supported");
     }
     auto& dims = modelarray.dimensions();
     const ModelArray::Type& type = modelarray.getType();
+    const ModelArray::Type& expectedType = getFieldType(fieldId);
+
+    // Account for fields to be read in as HField but converted to DGField
+    if (inputFieldsToConvert.count(fieldId)) {
+        if (type != ModelArray::Type::H) {
+            throw std::runtime_error(
+                "Xios::read: field '" + fieldId + "' was expected to be read as a HField");
+        }
+        if (expectedType != ModelArray::Type::DG) {
+            throw std::runtime_error(
+                "Xios::read: field '" + fieldId + "' was expected to be converted to a DGField");
+        }
+        ModelArray inputarray;
+        cxios_read_data_k82(
+            fieldId.c_str(), fieldId.length(), inputarray.getData(), dims[0], dims[1]);
+        // FIXME: Conversion with overloaded '=' operator is known to be problematic
+        modelarray = inputarray;
+        return;
+    }
+
+    // Other field types should not need converting
+    if (type != expectedType) {
+        throw std::runtime_error(
+            "Xios::read: field '" + fieldId + "' does not have the expected type");
+    }
     if ((type == ModelArray::Type::H) || (type == ModelArray::Type::CG)) {
         cxios_read_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1]);

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -151,14 +151,33 @@ void Xios::close_context_definition()
 {
     if (isEnabled && contextStatus == DEFINITION_OPEN) {
 
-        // Ensure that base fields have operation type 'instant' if not already defined
-        std::set<std::string> fieldIds = configGetInputRestartFieldNames();
-        std::set<std::string> forcingFieldIds = configGetForcingFieldNames();
-        fieldIds.insert(forcingFieldIds.begin(), forcingFieldIds.end());
-        for (const std::string& fieldId : fieldIds) {
-            xios::CField* field = getField(fieldId);
-            if (!cxios_is_defined_field_operation(field)) {
-                cxios_set_field_operation(field, "instant", strlen("instant"));
+        // Special handling of input fields
+        for (int ioType : { INPUT_RESTART, FORCING }) {
+            const std::set<std::string> fieldIds = (ioType == INPUT_RESTART)
+                ? configGetInputRestartFieldNames()
+                : configGetForcingFieldNames();
+            for (const std::string& fieldId : fieldIds) {
+
+                // Ensure that base fields have operation type 'instant' if not already defined
+                xios::CField* field = getField(fieldId);
+                if (!cxios_is_defined_field_operation(field)) {
+                    cxios_set_field_operation(field, "instant", strlen("instant"));
+                }
+
+                // Link the input field back to the base field with a field reference
+                const std::string inputFieldId
+                    = (ioType == INPUT_RESTART) ? fieldId + "_input" : fieldId + "_forcing";
+                xios::CField* inputField = getField(inputFieldId);
+                if (cxios_is_defined_field_field_ref(inputField)) {
+                    throw std::runtime_error(
+                        "Xios: Field reference already exists for input field '" + inputFieldId
+                        + "'");
+                }
+                cxios_set_field_field_ref(inputField, fieldId.c_str(), fieldId.length());
+                if (!cxios_is_defined_field_field_ref(inputField)) {
+                    throw std::runtime_error(
+                        "Xios: Failed to set reference for input field '" + inputFieldId + "'");
+                }
             }
         }
 
@@ -906,17 +925,6 @@ std::string Xios::createInputField(const std::string& fieldId, const int ioType)
     cxios_set_field_name(inputField, fieldId.c_str(), fieldId.length());
     if (!cxios_is_defined_field_name(inputField)) {
         throw std::runtime_error("Xios: Failed to set name for input field '" + inputFieldId + "'");
-    }
-
-    // Link the input field back to the base field with a field reference
-    if (cxios_is_defined_field_field_ref(inputField)) {
-        throw std::runtime_error(
-            "Xios: Field reference already exists for input field '" + inputFieldId + "'");
-    }
-    cxios_set_field_field_ref(inputField, fieldId.c_str(), fieldId.length());
-    if (!cxios_is_defined_field_field_ref(inputField)) {
-        throw std::runtime_error(
-            "Xios: Failed to set reference for input field '" + inputFieldId + "'");
     }
 
     return inputFieldId;

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1583,6 +1583,15 @@ void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
     auto& dims = modelarray.dimensions();
     const ModelArray::Type& type = modelarray.getType();
     domainWritten[domainIds[type]] = true;
+
+    // Check the field type
+    const ModelArray::Type& expectedType = getFieldType(fieldId);
+    if (expectedType != type) {
+        throw std::runtime_error(
+            "Xios::read: field '" + fieldId + "' does not have the expected type");
+    }
+
+    // Write out according to field type
     if ((type == ModelArray::Type::H) || (type == ModelArray::Type::CG)) {
         cxios_write_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1], -1);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -195,10 +195,11 @@ private:
     std::string forcingFilename;
     std::string forcingFileId;
     enum {
-        OUTPUT_RESTART,
-        INPUT_RESTART,
-        DIAGNOSTIC,
-        FORCING,
+        NOT_READ, // Either unused or generically written but not read
+        OUTPUT_RESTART, // Written as restart
+        INPUT_RESTART, // Read as restart
+        DIAGNOSTIC, // Written as diagnostic
+        FORCING, // Read as forcing
     };
     const std::map<int, std::string&> fileMap = {
         { OUTPUT_RESTART, outputFileId },

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -167,7 +167,7 @@ private:
     std::set<std::string> configGetInputRestartFieldNames();
     std::set<std::string> configGetDiagnosticFieldNames();
     void createField(const std::string& fieldId, const std::string& fileId);
-    std::string createInheritedField(const std::string& fieldId, const int ioType);
+    std::string createInputField(const std::string& fieldId, const int ioType);
     void setFieldOperation(const std::string& fieldId, const int ioType);
     void setFieldReadAccess(const std::string& fieldId, const bool& readAccess);
     void setFieldGridRef(const std::string& fieldId, const std::string& gridRef);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -74,7 +74,8 @@ public:
 
     /* Field */
     std::set<std::string> configGetForcingFieldNames();
-    void setFieldType(const std::string& fieldId, const ModelArray::Type& type);
+    void setPrognosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
+    void setDiagnosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
 
     enum {
         ENABLED_KEY,
@@ -178,6 +179,7 @@ private:
     ModelArray::Type getFieldType(const std::string& fieldId);
     std::map<std::string, ModelArray::Type> fieldTypes;
     void setupFields();
+    void setFieldType(const std::string& fieldId, const ModelArray::Type& type, const int ioType);
 
     /* File */
     xios::CFileGroup* getFileGroup();

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -180,6 +180,7 @@ private:
     std::map<std::string, ModelArray::Type> fieldTypes;
     void setupFields();
     void setFieldType(const std::string& fieldId, const ModelArray::Type& type, const int ioType);
+    std::set<std::string> inputFieldsToConvert;
 
     /* File */
     xios::CFileGroup* getFileGroup();

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -132,7 +132,6 @@ bool cxios_is_defined_field_operation(xios::CField* field_hdl);
 bool cxios_is_defined_field_grid_ref(xios::CField* field_hdl);
 bool cxios_is_defined_field_read_access(xios::CField* field_hdl);
 bool cxios_is_defined_field_freq_offset(xios::CField* field_hdl);
-bool cxios_is_defined_field_field_ref(xios::CField* field_hdl);
 
 // file group methods
 void cxios_filegroup_handle_create(xios::CFileGroup** _ret, const char* _id, int _id_len);

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -77,7 +77,7 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     grid.setIO(pio);
 
     // Set field type for diagnostics
-    xiosHandler.setFieldType(hsnowName, ModelArray::Type::H);
+    xiosHandler.setDiagnosticFieldType(hsnowName, ModelArray::Type::H);
 
     // Create some fake data to test writing methods
     HField mask(ModelArray::Type::H);

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -74,16 +74,16 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
 
     // Set field types for restarts
-    xiosHandler.setFieldType(longitudeName, ModelArray::Type::H);
-    xiosHandler.setFieldType(latitudeName, ModelArray::Type::H);
-    xiosHandler.setFieldType(maskName, ModelArray::Type::H);
-    xiosHandler.setFieldType(ciceName, ModelArray::Type::DG);
-    xiosHandler.setFieldType(hiceName, ModelArray::Type::DG);
-    xiosHandler.setFieldType(damageName, ModelArray::Type::DG);
-    xiosHandler.setFieldType(hsnowName, ModelArray::Type::DG);
-    xiosHandler.setFieldType(gridAzimuthName, ModelArray::Type::VERTEX);
-    xiosHandler.setFieldType(ticeName, ModelArray::Type::DGSTRESS);
-    xiosHandler.setFieldType(uName, ModelArray::Type::CG);
+    xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
+    xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
+    xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
+    xiosHandler.setPrognosticFieldType(ciceName, ModelArray::Type::DG);
+    xiosHandler.setPrognosticFieldType(hiceName, ModelArray::Type::DG);
+    xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::DG);
+    xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::Type::DG);
+    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::VERTEX);
+    xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
+    xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);
 
     // Create some fake data to test writing methods
     HField longitude(ModelArray::Type::H);

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -13,7 +13,7 @@ API calls to reduce user requirements.
 
 .. _XIOS: https://forge.ipsl.fr/ioserver
 
-The integration of XIOS into nextSIM-DG's is built around a static ``Xios``
+The integration of XIOS into nextSIM-DG is built around a static ``Xios``
 handler class, which provides a C++ API for the various XIOS functions. When the
 handler is instantiated, the configuration sections (see section below) are
 parsed. Based on the values that are parsed, the handler object will
@@ -47,7 +47,7 @@ to generate an XML file:
 where ``DGCOMP`` is the integer number of DG components (e.g., 6),
 ``DGSTRESSCOMP`` is the integer number of DG stress components (e.g., 8), and
 ``OUTPUT_FILE_NAME`` is the output file name, including its path, e.g.,
-``build/core/test/iodef.xml``.
+``build/core/test/iodef.xml`` or ``run/iodef.xml``.
 
 NextSIM-DG configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,28 +94,21 @@ building without XIOS. That is, the ``model`` section should include
   restart_file = my_restart_file.nc
   restart_period = P0-0T02:00:00
 
-In the cases of forcing and diagnostics files, the file names are configured
-differently, via the ``filename`` entry in the ``XiosForcing`` and/or
-``XiosDiagnostic`` sections, respectively. For example,
+Information related to fields to be read from and written to files are
+configured via the ``XiosInput``, ``XiosOutput``, ``XiosForcing``, and
+``XiosDiagnostic`` sections, where the first two refer to restarts. Note that
+all of these sections are optional.
+
+For restart files, the filename is determined from the ``restart_file`` entry in
+the ``model`` section mentioned above. In the cases of forcing and diagnostics
+files, the file names are configured differently, via the ``filename`` entry in
+the ``XiosForcing`` and/or ``XiosDiagnostic`` sections, respectively. For
+example,
 
 .. code-block::
 
    [XiosForcing]
    filename = my_forcing_file.nc
-
-The fields to be read from and written to files are configured via the
-``XiosInput``, ``XiosOutput``, and ``XiosForcing`` sections, where the first two
-refer to restarts. For example, we could specify that two fields labelled
-``field_A`` and ``field_B`` are to be written into restart files as follows:
-
-.. code-block::
-
-  [XiosOutput]
-  field_names = field_A,field_B
-
-The ``field_names`` entry may contain a single field name or a comma-separated
-list. Note that all of the ``XiosOutput``, ``XiosInput``, ``XiosDiagnostic``,
-and ``XiosForcing`` sections are optional.
 
 Restart and diagnostic file names may include format strings such as
 ``restart%Y-%m-%dT%H:%M:%SZ.nc`` or ``diagnostic%Y-%m-%dT%H:%M:%SZ.nc`` (in
@@ -127,8 +120,21 @@ provided format string. Restart files contain the state at the beginning of the
 time window, whereas diagnostics files are averaged over the timesteps in the
 window.
 
+In addition to specifying file names, we need to specify which fields are to be
+read or written using each I/O type. For example, we could specify that two
+fields labelled ``field_A`` and ``field_B`` are to be written into restart files
+as follows:
+
+.. code-block::
+
+  [XiosOutput]
+  field_names = field_A,field_B
+
+The ``field_names`` entry may contain a single field name or a comma-separated
+list.
+
 As elsewhere in the model, the configuration values above are all parsed by
-calling the ``Model.configure`` member function. Note that this function will
+calling the ``Model.configure()`` member function. Note that this function will
 automatically initialize the model state based on the ``input_file`` entry and
 any ``field_names`` listed in the ``[XiosInput]`` configuration section. You
 will need to ensure that variables defining the grid are read here, i.e.,
@@ -147,23 +153,21 @@ following:
 
 1. Set configuration options as for other parts of the model. (See section above
    for options.)
-2. Get the ``ModelMetadata`` singleton instance by calling the static
-   ``ModelMetadata::getInstance`` member function, passing the MPI partition
-   metadata file as an argument.
-3. Configure the ``Model`` by constructing it and calling its ``configure``
+2. Configure the ``Model`` by constructing it and calling its ``configure``
    member function.
-4. Construct a ``ParametricGrid`` and a new ``ParaGridIO`` pointer.
-5. Associate the ``ParaGridIO`` pointer with the ``ParametricGrid`` instance
+3. Construct a ``ParametricGrid`` and a new ``ParaGridIO`` pointer.
+4. Associate the ``ParaGridIO`` pointer with the ``ParametricGrid`` instance
    using the latter's ``setIO`` member function.
-6. Get the ``Xios`` handler singleton using ``Xios::getInstance``.
-7. For each field to be written to file with XIOS, call the ``setFieldType``
-   member function of ``Xios``, providing the field name as the first argument
+5. Get the ``Xios`` handler singleton using ``Xios::getInstance``.
+6. For each field to be written to file with XIOS, call the
+   ``setPrognosticFieldType`` or ``setDiagnosticFieldType`` member function of
+   ``Xios`` as appropriate, providing the field name as the first argument
    and the ``ModelArray::Type::<TYPE>`` enum as the second argument (replacing
-   ``<TYPE>>`` as appropriate).
-8. Call the ``close_context_definition`` member function of ``Xios``. This is
-   not required if files were read with ``StructureFactory::stateFromFile``
-   because that function automatically closes the context definition before
-   reading.
+   ``<TYPE>>`` with the desired type).
+
+There is no need to explicitly close the XIOS context definition because this
+happens automatically upon reading or writing. As such, all XIOS configuration
+must take place before any files are read from or written to.
 
 XIOS concepts
 -------------
@@ -212,8 +216,9 @@ An instance of the Field type is based on a Grid and is associated with a
 ``ModelArray::Type``. Fields are created automatically upon configuring the
 ``Model``. For fields that are read from file, the field type is determined
 automatically during the file read. For fields that are written, it's required
-to call the ``setFieldType`` member function of the ``Xios`` singleton,
-providing the field name and ``ModelArray::Type``.
+to call the ``setPrognosticFieldType`` or ``setDiagnosticFieldType`` member
+function of the ``Xios`` singleton, providing the field name and
+``ModelArray::Type``.
 
 XIOS File concept
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# XIOS: allow a field to be read and written with different types

Fixes #1034
Supersedes #1037

### Task List
- [x] Defined the tests that specify a complete and functioning change (*It may help to create a [design specification & test specification](../../../wiki/Specification-Template)*)
- [x] Implemented the source code change that satisfies the tests
- [x] Documented the feature by providing worked example
- [x] Updated the README or other documentation
- [x] Completed the pre-Request checklist below

---
# Change Description

For any fields that are configured to be read, their type is determined upon the initial call to `ModelMetadata::setDimensionsFromFile`. For any fields to be written out, their type is configured through a call to `setFieldType`. This breaks down if a field is configured differently in the two cases, but this can and does occur in nextSIM-DG.

This PR modifies the "base" and "inherited" field relationship. The latter is renamed "input" for clarity. In cases where the two have the same `ModelArray::Type`, they are configured to share the same data using an XIOS field reference. If the input type is `HField` and the base type is `DGField` then this is recorded so that we know to do the conversion upon reading that field. In other cases, an error is thrown.

Other changes:
* Set the grid reference for a field if it never gets set.
* Throw an error if a field configured to be read as a forcing is not of `HField` type.
* Throw an error if `getFieldType` is called but the field type hasn't been set.
* Privatise `setFieldType` and instead provide public API variants `setPrognosticFieldType` and `setDiagnosticFieldType` that call it. (This only needs to be usable for fields being written out.)

---
# Test Description

In this version, the tests have not yet been modified such that a conversion would actually take place. This is because the field type needs to be set inside the call to `Model::configure()`. I'll do that in a follow-up PR while addressing #1026.

---
# Documentation Impact

The XIOS docs page has been updated accordingly.

---
### Pre-Request Checklist

- [x] The requirements of this pull request are fully captured in an issue or design specification and are linked and summarised in the description of this PR
- [x] No new warnings are generated
- [x] The documentation has been updated (or an issue has been created to track the corresponding change)
- [x] Methods and Tests are commented such that they can be understood without having to obtain additional context
- [x] This PR/Issue is labelled as a bug/feature/enhancement/breaking change
- [x] This change conforms to the conventions described in the README