### PR TITLE
XIOS: Avoid repeated getting of I/O field names configs

### DIFF
--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -54,7 +54,7 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
 
     // Get all variables in the file and load them into a new ModelState
     ModelState state;
-    for (const std::string& fieldId : xiosHandler.configGetInputRestartFieldNames()) {
+    for (const std::string& fieldId : xiosHandler.inputRestartFieldNames) {
         const ModelArray::Type& type = xiosHandler.getFieldType(fieldId);
         if (type == ModelArray::Type::H) {
             HField field(ModelArray::Type::H);
@@ -83,10 +83,9 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
     }
 
     // Assume that all fields in the supplied ModelState are necessary, and so read them from file.
-    const std::set<std::string> inputFieldIds = xiosHandler.configGetInputRestartFieldNames();
     for (auto& [fieldId, modelarray] : state.data) {
         const std::string inputFieldId = fieldId + "_input";
-        if (inputFieldIds.count(fieldId) == 0) {
+        if (xiosHandler.inputRestartFieldNames.count(fieldId) == 0) {
             throw std::runtime_error(
                 "ParaGridIO::getModelState: field " + fieldId + " is not configured as a restart.");
         }
@@ -119,9 +118,8 @@ ModelState ParaGridIO::readForcingTimeStatic(
 
     // Get all forcings and load them into a new ModelState
     ModelState state;
-    const std::set<std::string> forcingFieldIds = xiosHandler.configGetForcingFieldNames();
     for (const std::string& fieldId : forcings) {
-        if (forcingFieldIds.count(fieldId) == 0) {
+        if (xiosHandler.forcingFieldNames.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::readForcingTimeStatic: field " + fieldId
                 + " is not configured as a forcing.");
         }
@@ -162,9 +160,8 @@ void ParaGridIO::dumpModelState(const ModelState& state, const std::string& file
     }
 
     // Assume that all fields in the supplied ModelState are necessary, and so write them to file.
-    const std::set<std::string> outputFieldIds = xiosHandler.configGetOutputRestartFieldNames();
     for (const auto& [fieldId, modelarray] : state.data) {
-        if (outputFieldIds.count(fieldId) == 0) {
+        if (xiosHandler.outputRestartFieldNames.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::dumpModelState: field " + fieldId
                 + " is not configured as a restart.");
         }
@@ -185,9 +182,8 @@ void ParaGridIO::writeDiagnosticTime(const ModelState& state, const std::string&
     }
 
     // Assume that all fields in the supplied ModelState are necessary, and so write them to file.
-    const std::set<std::string> diagnosticFieldIds = xiosHandler.configGetDiagnosticFieldNames();
     for (const auto& [fieldId, modelarray] : state.data) {
-        if (diagnosticFieldIds.count(fieldId) == 0) {
+        if (xiosHandler.diagnosticFieldNames.count(fieldId) == 0) {
             throw std::runtime_error("ParaGridIO::writeDiagnosticTime: field " + fieldId
                 + " is not configured as a diagnostic.");
         }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -52,13 +52,17 @@ static const std::string xInputPfx = "XiosInput";
 static const std::string xDiagnosticPfx = "XiosDiagnostic";
 static const std::string xForcingPfx = "XiosForcing";
 static const std::map<int, std::string> keyMap = { { Xios::ENABLED_KEY, "xios.enable" },
+    // TODO: Avoid having to parse restart fields (#1056)
     { Xios::OUTPUT_FIELD_NAMES_KEY, xOutputPfx + ".field_names" },
+    // TODO: Avoid having to parse input fields (#1056)
     { Xios::INPUT_FIELD_NAMES_KEY, xInputPfx + ".field_names" },
     { Xios::DIAGNOSTIC_PERIOD_KEY, xDiagnosticPfx + ".period" },
     { Xios::DIAGNOSTIC_FILE_KEY, xDiagnosticPfx + ".filename" },
+    // TODO: Avoid having to parse diagnostic fields for XIOS specifically (#981)
     { Xios::DIAGNOSTIC_FIELD_NAMES_KEY, xDiagnosticPfx + ".field_names" },
     { Xios::FORCING_PERIOD_KEY, xForcingPfx + ".period" },
     { Xios::FORCING_FILE_KEY, xForcingPfx + ".filename" },
+    // TODO: Avoid having to parse forcing fields (#1045)
     { Xios::FORCING_FIELD_NAMES_KEY, xForcingPfx + ".field_names" } };
 
 Xios::HelpMap& Xios::getHelpText(HelpMap& map, bool getAll)
@@ -261,12 +265,16 @@ std::set<std::string> str2set(const std::string& asStr, const char& delim = ',')
  */
 void Xios::parseConfig()
 {
+    // TODO: Avoid having to parse input fields (#1056)
     inputRestartFieldNames
         = str2set(Configured::getConfiguration(keyMap.at(INPUT_FIELD_NAMES_KEY), std::string()));
+    // TODO: Avoid having to parse restart fields (#1056)
     outputRestartFieldNames
         = str2set(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()));
+    // TODO: Avoid having to parse forcing fields (#1045)
     forcingFieldNames
         = str2set(Configured::getConfiguration(keyMap.at(FORCING_FIELD_NAMES_KEY), std::string()));
+    // TODO: Avoid having to parse diagnostic fields for XIOS specifically (#981)
     diagnosticFieldNames = str2set(
         Configured::getConfiguration(keyMap.at(DIAGNOSTIC_FIELD_NAMES_KEY), std::string()));
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -153,9 +153,8 @@ void Xios::close_context_definition()
 
         // Special handling of input fields
         for (int ioType : { INPUT_RESTART, FORCING }) {
-            const std::set<std::string> fieldIds = (ioType == INPUT_RESTART)
-                ? configGetInputRestartFieldNames()
-                : configGetForcingFieldNames();
+            const std::set<std::string> fieldIds
+                = (ioType == INPUT_RESTART) ? inputRestartFieldNames : forcingFieldNames;
             for (const std::string& fieldId : fieldIds) {
                 const std::string inputFieldId
                     = (ioType == INPUT_RESTART) ? fieldId + "_input" : fieldId + "_forcing";
@@ -229,17 +228,53 @@ void Xios::finalize()
  * Overrides `Configure` method from `Configured`
  *
  * Configure the XIOS server if XIOS is enabled in the settings.
- *
  */
 void Xios::configure()
 {
     if (isEnabled) {
+        parseConfig();
         setupClient();
         setupContext();
         setupCalendar();
         setupFiles();
         setupFields();
     }
+}
+
+// Split a string into a set by some delimiter.
+std::set<std::string> str2set(const std::string& asStr, const char& delim = ',')
+{
+    std::set<std::string> asSet;
+    if (asStr.length() > 0) {
+        const char delim = ',';
+        std::istringstream iss(asStr);
+        std::string item;
+        while (std::getline(iss, item, delim)) {
+            asSet.insert(item);
+        }
+    }
+    return asSet;
+}
+
+/*!
+ * Parse the config and stores the field names for each I/O type.
+ */
+void Xios::parseConfig()
+{
+    inputRestartFieldNames
+        = str2set(Configured::getConfiguration(keyMap.at(INPUT_FIELD_NAMES_KEY), std::string()));
+    outputRestartFieldNames
+        = str2set(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()));
+    forcingFieldNames
+        = str2set(Configured::getConfiguration(keyMap.at(FORCING_FIELD_NAMES_KEY), std::string()));
+    diagnosticFieldNames = str2set(
+        Configured::getConfiguration(keyMap.at(DIAGNOSTIC_FIELD_NAMES_KEY), std::string()));
+
+    // Combine all field names into a single set for easier checking later on
+    fieldNames = inputRestartFieldNames;
+    fieldNames.insert(outputRestartFieldNames.begin(), outputRestartFieldNames.end());
+    fieldNames.insert(forcingFieldNames.begin(), forcingFieldNames.end());
+    fieldNames.insert(diagnosticFieldNames.begin(), diagnosticFieldNames.end());
 }
 
 //! Initialize the XIOS context with ID contextId
@@ -751,46 +786,6 @@ xios::CField* Xios::getField(const std::string& fieldId)
     return field;
 }
 
-// Split a string into a set by some delimiter.
-std::set<std::string> str2set(const std::string& asStr, const char& delim = ',')
-{
-    std::set<std::string> asSet;
-    if (asStr.length() > 0) {
-        const char delim = ',';
-        std::istringstream iss(asStr);
-        std::string item;
-        while (std::getline(iss, item, delim)) {
-            asSet.insert(item);
-        }
-    }
-    return asSet;
-}
-
-// Extract the field_names entry from the XiosInput section of the config.
-std::set<std::string> Xios::configGetInputRestartFieldNames()
-{
-    return str2set(Configured::getConfiguration(keyMap.at(INPUT_FIELD_NAMES_KEY), std::string()));
-}
-
-// Extract the field_names entry from the XiosForcing section of the config.
-std::set<std::string> Xios::configGetForcingFieldNames()
-{
-    return str2set(Configured::getConfiguration(keyMap.at(FORCING_FIELD_NAMES_KEY), std::string()));
-}
-
-// Extract the field_names entry from the XiosOutput section of the config.
-std::set<std::string> Xios::configGetOutputRestartFieldNames()
-{
-    return str2set(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()));
-}
-
-// Extract the field_names entry from the XiosDiagnostic section of the config.
-std::set<std::string> Xios::configGetDiagnosticFieldNames()
-{
-    return str2set(
-        Configured::getConfiguration(keyMap.at(DIAGNOSTIC_FIELD_NAMES_KEY), std::string()));
-}
-
 /*!
  * Create a field with some ID
  *
@@ -805,16 +800,16 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
     std::set<std::string> fieldNames;
     std::string ioName;
     if (ioType == INPUT_RESTART) {
-        fieldNames = configGetInputRestartFieldNames();
+        fieldNames = inputRestartFieldNames;
         ioName = "input restart";
     } else if (ioType == OUTPUT_RESTART) {
-        fieldNames = configGetOutputRestartFieldNames();
+        fieldNames = outputRestartFieldNames;
         ioName = "output restart";
     } else if (ioType == FORCING) {
-        fieldNames = configGetForcingFieldNames();
+        fieldNames = forcingFieldNames;
         ioName = "forcing";
     } else if (ioType == DIAGNOSTIC) {
-        fieldNames = configGetDiagnosticFieldNames();
+        fieldNames = diagnosticFieldNames;
         ioName = "diagnostic";
     } else {
         throw std::runtime_error("Xios: Unknown I/O type for field '" + fieldId + "'");
@@ -1144,10 +1139,10 @@ void Xios::setupFields()
         std::set<std::string> configFieldIds;
         int ioType;
         if (filename == metadata.initialFileName) {
-            configFieldIds = configGetInputRestartFieldNames();
+            configFieldIds = inputRestartFieldNames;
             ioType = INPUT_RESTART;
         } else {
-            configFieldIds = configGetForcingFieldNames();
+            configFieldIds = forcingFieldNames;
             ioType = FORCING;
         }
         try {
@@ -1313,13 +1308,13 @@ void Xios::createFile(const std::string& fileId)
     // Get the fieldIds
     std::set<std::string> fieldIds;
     if (ioType == INPUT_RESTART) {
-        fieldIds = configGetInputRestartFieldNames();
+        fieldIds = inputRestartFieldNames;
     } else if (ioType == OUTPUT_RESTART) {
-        fieldIds = configGetOutputRestartFieldNames();
+        fieldIds = outputRestartFieldNames;
     } else if (ioType == FORCING) {
-        fieldIds = configGetForcingFieldNames();
+        fieldIds = forcingFieldNames;
     } else if (ioType == DIAGNOSTIC) {
-        fieldIds = configGetDiagnosticFieldNames();
+        fieldIds = diagnosticFieldNames;
     }
 
     // Determine the file output frequency

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -73,7 +73,7 @@ public:
     size_t getAxisSize(const std::string& axisId);
 
     /* Field */
-    std::set<std::string> configGetForcingFieldNames();
+    std::set<std::string> forcingFieldNames;
     void setPrognosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
     void setDiagnosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
 
@@ -100,6 +100,9 @@ private:
     int mpi_rank { 0 };
     int mpi_size { 0 };
     int cStrLen { 20 }; // Length of C-strings passed to XIOS
+
+    /* Configuration */
+    void parseConfig();
 
     /* Client */
     const std::string clientId = "client";
@@ -164,9 +167,10 @@ private:
     /* Field */
     xios::CFieldGroup* getFieldGroup();
     xios::CField* getField(const std::string& fieldId);
-    std::set<std::string> configGetOutputRestartFieldNames();
-    std::set<std::string> configGetInputRestartFieldNames();
-    std::set<std::string> configGetDiagnosticFieldNames();
+    std::set<std::string> outputRestartFieldNames;
+    std::set<std::string> inputRestartFieldNames;
+    std::set<std::string> diagnosticFieldNames;
+    std::set<std::string> fieldNames;
     void createField(const std::string& fieldId, const std::string& fileId);
     std::string createInputField(const std::string& fieldId, const int ioType);
     void setFieldOperation(const std::string& fieldId, const int ioType);

--- a/core/test/XiosReadForcing_test.cpp
+++ b/core/test/XiosReadForcing_test.cpp
@@ -88,14 +88,13 @@ MPI_TEST_CASE("TestXiosReadForcing", 2)
     // Simulate 4 iterations (timesteps), reading forcing data at each
     ModelMetadata& metadata = ModelMetadata::getInstance();
     const Duration& timestep = metadata.stepLength();
-    // TODO: Avoid making configGetForcingFieldNames public?
-    auto forcingFieldNames = xiosHandler.configGetForcingFieldNames();
     for (int ts = 0; ts <= 4; ts++) {
 
         // Read forcings from file and check they take the expected values
+        // TODO: Avoid making forcingFieldNames public?
         const TimePoint& time = xiosHandler.getCurrentDate();
         const ModelState forcings
-            = pio->readForcingTimeStatic(forcingFieldNames, time, forcingFilename);
+            = pio->readForcingTimeStatic(xiosHandler.forcingFieldNames, time, forcingFilename);
         for (const auto& [fieldName, modelarray] : forcings.data) {
             REQUIRE(fieldName == hsnowName);
             for (size_t j = 0; j < ny; ++j) {


### PR DESCRIPTION
# XIOS: Avoid repeated getting of I/O field names configs

Fixes #1049
Refinement of #1043