### PR TITLE
Determine XIOS field types (take 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ if(ENABLE_XIOS)
     target_link_libraries(nextsimlib PUBLIC xios HDF5::HDF5)
     target_include_directories(
         nextsimlib
-        PRIVATE ${xios_INCLUDES} ${xios_EXTERNS}/blitz ${xios_EXTERNS}/boost_extraction/include
+        PUBLIC ${xios_INCLUDES} ${xios_EXTERNS}/blitz ${xios_EXTERNS}/boost_extraction/include
                 ${xios_EXTERNS}/rapidxml/include
     )
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -12,6 +12,17 @@ else()
     set(ParaGridIOImplSource "${CMAKE_CURRENT_SOURCE_DIR}/ParaGridIO.cpp")
 endif()
 
+# Create a stable generated include dir and copy the chosen ModelArrayDetails.hpp
+# This ensures a single canonical header, which can be included as
+# "include/ModelArrayDetails.hpp" from any target.
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/${ModelArrayStructure}/include/ModelArrayDetails.hpp"
+    "${CMAKE_CURRENT_BINARY_DIR}/include/ModelArrayDetails.hpp"
+    COPYONLY
+)
+set(NextsimIncludeDirs "${NextsimIncludeDirs}" "${CMAKE_CURRENT_BINARY_DIR}/include")
+
 set(BaseSources
     "ModelMPI.cpp"
     "Logged.cpp"
@@ -68,5 +79,6 @@ set(NextsimIncludeDirs
     "${ModuleDir}"
     "${CMAKE_CURRENT_SOURCE_DIR}"
     "${CMAKE_CURRENT_SOURCE_DIR}/${ModelArrayStructure}"
+    "${CMAKE_CURRENT_BINARY_DIR}/include"
     PARENT_SCOPE
 )

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -119,14 +119,17 @@ void Model::configure()
 
     configureRestarts();
 
+    // Configure parameters related to the temporal discretisation
+    configureTime();
+
+    // Configure prognostic data
     pData.configure();
 
     auto& metadata = ModelMetadata::getInstance();
     modelStep.init();
     modelStep.setInitFile(metadata.initialFileName);
 
-    configureTime();
-
+    // Read the initial state from file
     ModelState initialState(StructureFactory::stateFromFile(metadata.initialFileName));
 
     // Get the coordinates from the ModelState for persistence

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -839,6 +839,7 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         setFieldReadAccess(fieldId, false);
         fileAddField(fileId, fieldId);
     } else {
+        // TODO: Allow unused fields in input files (#1060)
         throw std::runtime_error("Xios: Unknown I/O type for field '" + fieldId + "'");
     }
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -801,32 +801,6 @@ xios::CField* Xios::getField(const std::string& fieldId)
  */
 void Xios::createField(const std::string& fieldId, const std::string& fileId)
 {
-    int ioType = getFileIOType(fileId);
-
-    // Check that the field is in the expected config section
-    std::string ioName;
-    if (ioType == INPUT_RESTART
-        && inputRestartFieldNames.find(fieldId) == inputRestartFieldNames.end()) {
-        throw std::runtime_error(
-            "Xios: Field '" + fieldId + "' cannot be found in the input restart config section");
-    } else if (ioType == OUTPUT_RESTART
-        && outputRestartFieldNames.find(fieldId) == outputRestartFieldNames.end()) {
-        throw std::runtime_error(
-            "Xios: Field '" + fieldId + "' cannot be found in the output restart config section");
-    } else if (ioType == ERA5_FORCING
-        && era5ForcingFieldNames.find(fieldId) == era5ForcingFieldNames.end()) {
-        throw std::runtime_error(
-            "Xios: Field '" + fieldId + "' cannot be found in the ERA5 forcing config section");
-    } else if (ioType == TOPAZ_FORCING
-        && topazForcingFieldNames.find(fieldId) == topazForcingFieldNames.end()) {
-        throw std::runtime_error(
-            "Xios: Field '" + fieldId + "' cannot be found in the TOPAZ forcing config section");
-    } else if (ioType == DIAGNOSTIC
-        && diagnosticFieldNames.find(fieldId) == diagnosticFieldNames.end()) {
-        throw std::runtime_error(
-            "Xios: Field '" + fieldId + "' cannot be found in the diagnostic config section");
-    }
-
     // Attempt to create the base field (if it doesn't already exist)
     bool exists;
     cxios_field_valid_id(&exists, fieldId.c_str(), fieldId.length());
@@ -851,6 +825,7 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         }
     }
 
+    int ioType = getFileIOType(fileId);
     if (ioType == INPUT_RESTART || ioType == ERA5_FORCING || ioType == TOPAZ_FORCING) {
         // Create an input field and set it's operation type and read access and associate it
         // with the file
@@ -1351,20 +1326,6 @@ void Xios::createFile(const std::string& fileId)
         throw std::runtime_error("Xios: Failed to set parallel access for file '" + fileId + "'");
     }
 
-    // Get the fieldIds
-    std::set<std::string> fieldIds;
-    if (ioType == INPUT_RESTART) {
-        fieldIds = inputRestartFieldNames;
-    } else if (ioType == OUTPUT_RESTART) {
-        fieldIds = outputRestartFieldNames;
-    } else if (ioType == ERA5_FORCING) {
-        fieldIds = era5ForcingFieldNames;
-    } else if (ioType == TOPAZ_FORCING) {
-        fieldIds = topazForcingFieldNames;
-    } else if (ioType == DIAGNOSTIC) {
-        fieldIds = diagnosticFieldNames;
-    }
-
     // Determine the file output frequency
     cxios_duration outputFreq;
     ModelMetadata& metadata = ModelMetadata::getInstance();
@@ -1427,6 +1388,20 @@ void Xios::createFile(const std::string& fileId)
             throw std::runtime_error(
                 "Xios: Failed to set split frequency format for file '" + fileId + "'");
         }
+    }
+
+    // Get the fieldIds
+    std::set<std::string> fieldIds;
+    if (ioType == INPUT_RESTART) {
+        fieldIds = inputRestartFieldNames;
+    } else if (ioType == OUTPUT_RESTART) {
+        fieldIds = outputRestartFieldNames;
+    } else if (ioType == ERA5_FORCING) {
+        fieldIds = era5ForcingFieldNames;
+    } else if (ioType == TOPAZ_FORCING) {
+        fieldIds = topazForcingFieldNames;
+    } else if (ioType == DIAGNOSTIC) {
+        fieldIds = diagnosticFieldNames;
     }
 
     // Loop over field_names entries in the config

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -280,6 +280,7 @@ void Xios::parseConfig()
     fieldNames = inputRestartFieldNames;
     fieldNames.insert(outputRestartFieldNames.begin(), outputRestartFieldNames.end());
     fieldNames.insert(era5ForcingFieldNames.begin(), era5ForcingFieldNames.end());
+    fieldNames.insert(topazForcingFieldNames.begin(), topazForcingFieldNames.end());
     fieldNames.insert(diagnosticFieldNames.begin(), diagnosticFieldNames.end());
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1116,6 +1116,9 @@ void Xios::setFieldType(
         return;
     }
     const std::string ioFieldId = getFieldIOId(fieldId, ioType);
+    if (fieldTypes.count(ioFieldId) > 0) {
+        Logged::warning("Xios::setFieldType: Overwriting field type for field '" + ioFieldId + "'");
+    }
     fieldTypes[ioFieldId] = fieldType;
     setFieldGridRef(ioFieldId, gridIds[fieldType]);
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -803,29 +803,27 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
     int ioType = getFileIOType(fileId);
 
     // Check that the field is in the expected config section
-    std::set<std::string> fieldNames;
     std::string ioName;
-    if (ioType == INPUT_RESTART) {
-        fieldNames = inputRestartFieldNames;
-        ioName = "input restart";
-    } else if (ioType == OUTPUT_RESTART) {
-        fieldNames = outputRestartFieldNames;
-        ioName = "output restart";
-    } else if (ioType == ERA5_FORCING) {
-        fieldNames = era5ForcingFieldNames;
-        ioName = "era5_forcing";
-    } else if (ioType == TOPAZ_FORCING) {
-        fieldNames = topazForcingFieldNames;
-        ioName = "topaz_forcing";
-    } else if (ioType == DIAGNOSTIC) {
-        fieldNames = diagnosticFieldNames;
-        ioName = "diagnostic";
-    } else {
-        throw std::runtime_error("Xios: Unknown I/O type for field '" + fieldId + "'");
-    }
-    if (fieldNames.find(fieldId) == fieldNames.end()) {
+    if (ioType == INPUT_RESTART
+        && inputRestartFieldNames.find(fieldId) == inputRestartFieldNames.end()) {
         throw std::runtime_error(
-            "Xios: Field '" + fieldId + "' cannot be found in the " + ioName + " config section");
+            "Xios: Field '" + fieldId + "' cannot be found in the input restart config section");
+    } else if (ioType == OUTPUT_RESTART
+        && outputRestartFieldNames.find(fieldId) == outputRestartFieldNames.end()) {
+        throw std::runtime_error(
+            "Xios: Field '" + fieldId + "' cannot be found in the output restart config section");
+    } else if (ioType == ERA5_FORCING
+        && era5ForcingFieldNames.find(fieldId) == era5ForcingFieldNames.end()) {
+        throw std::runtime_error(
+            "Xios: Field '" + fieldId + "' cannot be found in the ERA5 forcing config section");
+    } else if (ioType == TOPAZ_FORCING
+        && topazForcingFieldNames.find(fieldId) == topazForcingFieldNames.end()) {
+        throw std::runtime_error(
+            "Xios: Field '" + fieldId + "' cannot be found in the TOPAZ forcing config section");
+    } else if (ioType == DIAGNOSTIC
+        && diagnosticFieldNames.find(fieldId) == diagnosticFieldNames.end()) {
+        throw std::runtime_error(
+            "Xios: Field '" + fieldId + "' cannot be found in the diagnostic config section");
     }
 
     // Attempt to create the base field (if it doesn't already exist)
@@ -859,11 +857,13 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         setFieldOperation(inputFieldId, ioType);
         setFieldReadAccess(inputFieldId, true);
         fileAddField(fileId, inputFieldId);
-    } else {
+    } else if (ioType == OUTPUT_RESTART || ioType == DIAGNOSTIC) {
         // Set the field operation type and read access and associate the field with the file
         setFieldOperation(fieldId, ioType);
         setFieldReadAccess(fieldId, false);
         fileAddField(fileId, fieldId);
+    } else {
+        throw std::runtime_error("Xios: Unknown I/O type for field '" + fieldId + "'");
     }
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1110,6 +1110,11 @@ ModelArray::Type Xios::getFieldType(const std::string& fieldId)
 void Xios::setFieldType(
     const std::string& fieldId, const ModelArray::Type& fieldType, const int ioType)
 {
+    if (fieldNames.count(fieldId) == 0) {
+        Logged::warning("Xios::setFieldType: Cannot set field type for field '" + fieldId
+            + "' because it is not in the config.");
+        return;
+    }
     const std::string ioFieldId = getFieldIOId(fieldId, ioType);
     fieldTypes[ioFieldId] = fieldType;
     setFieldGridRef(ioFieldId, gridIds[fieldType]);

--- a/core/src/discontinuousgalerkin/ModelArrayDetails.cpp
+++ b/core/src/discontinuousgalerkin/ModelArrayDetails.cpp
@@ -139,4 +139,7 @@ const ModelArray::TypeMap ModelArray::definedComp0Map()
         { Type::DGSTRESS, Type::H },
     };
 };
+
+const ModelArray::Type ModelArray::AdvectionType = ModelArray::Type::DG;
+
 }

--- a/core/src/discontinuousgalerkin/include/ModelArrayDetails.hpp
+++ b/core/src/discontinuousgalerkin/include/ModelArrayDetails.hpp
@@ -25,7 +25,7 @@ enum class Type {
 
 enum class Base { Cell, Vertex };
 
-static const Type AdvectionType = Type::DG;
+static const Type AdvectionType;
 
 static ModelArray HField() { return ModelArray(Type::H); }
 static ModelArray VertexField() { return ModelArray(Type::VERTEX); }

--- a/core/src/finitevolume/ModelArrayDetails.cpp
+++ b/core/src/finitevolume/ModelArrayDetails.cpp
@@ -84,4 +84,6 @@ const std::map<ModelArray::Type, ModelArray::Dimension> ModelArray::componentMap
 
 const ModelArray::TypeMap ModelArray::definedComp0Map() { return {}; };
 
+const ModelArray::Type ModelArray::AdvectionType = ModelArray::Type::H;
+
 }

--- a/core/src/finitevolume/include/ModelArrayDetails.hpp
+++ b/core/src/finitevolume/include/ModelArrayDetails.hpp
@@ -20,7 +20,7 @@ enum class Type {
     VERTEX,
 };
 
-static const Type AdvectionType = Type::H;
+static const Type AdvectionType;
 
 static ModelArray HField() { return ModelArray(Type::H); }
 static ModelArray UField() { return ModelArray(Type::U); }

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -53,6 +53,7 @@ public:
 #ifdef USE_XIOS
         // Set XIOS field types
         Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
         xiosHandler.setPrognosticFieldType(hiceName, ModelArray::AdvectionType);
         xiosHandler.setPrognosticFieldType(ciceName, ModelArray::AdvectionType);
         xiosHandler.setPrognosticFieldType(damageName, ModelArray::AdvectionType);

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -7,6 +7,9 @@
 
 #include "include/ModelComponent.hpp"
 #include "include/Time.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#endif
 #include "include/gridNames.hpp"
 
 #include <limits>
@@ -46,6 +49,15 @@ public:
         getStore().registerArray(Protected::SHEAR, &shear, RO);
         getStore().registerArray(Protected::SIGMAI, &sigmaI, RO);
         getStore().registerArray(Protected::SIGMAII, &sigmaII, RO);
+
+#ifdef USE_XIOS
+        // Set XIOS field types
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(hiceName, ModelArray::AdvectionType);
+        xiosHandler.setPrognosticFieldType(ciceName, ModelArray::AdvectionType);
+        xiosHandler.setPrognosticFieldType(damageName, ModelArray::AdvectionType);
+        xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::AdvectionType);
+#endif
     }
     virtual ~IDynamics() = default;
 

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -52,7 +52,7 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 3)
     // Check the input file exists
     if (!std::filesystem::exists(diagnosticFilename)) {
         throw std::runtime_error(
-            "XiosReadDiagnostic_test: Input file not found. Did you run XiosWrite_test?");
+            "XiosReadDiagnostic_test: Input file not found. Did you run XiosWriteDiagnostic_test?");
     }
 
     // Create ModelMPI instance based off the test communicator

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -43,8 +43,8 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -101,6 +101,12 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
                 }
             }
         } else if (fieldName == gridAzimuthName) {
+            for (size_t j = 0; j < ny; ++j) {
+                for (size_t i = 0; i < nx; ++i) {
+                    REQUIRE(modelarray(i, j) == doctest::Approx(0.0));
+                }
+            }
+        } else if (fieldName == coordsName) {
             for (size_t j = 0; j < ny + 1; ++j) {
                 for (size_t i = 0; i < nx + 1; ++i) {
                     float expected_x;

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -51,7 +51,7 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     // Check the input file exists
     if (!std::filesystem::exists(restartFilename)) {
         throw std::runtime_error(
-            "XiosReadRestart_test: Input file not found. Did you run XiosWrite_test?");
+            "XiosReadRestart_test: Input file not found. Did you run XiosWriteRestart_test?");
     }
 
     // Create ModelMPI instance based off the test communicator

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -69,8 +69,6 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     REQUIRE(xiosHandler.getCalendarStep() == 0);
 
     // Set ModelArray dimensions
-    const size_t nx = ModelArray::size(ModelArray::Dimension::X);
-    const size_t ny = ModelArray::size(ModelArray::Dimension::Y);
     REQUIRE(ModelArray::nComponents(ModelArray::Type::DG) == DGCOMP);
     REQUIRE(ModelArray::size(ModelArray::Dimension::DG) == DGCOMP);
 

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -45,12 +45,12 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -80,21 +80,6 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     xiosHandler.setDiagnosticFieldType(hsnowName, ModelArray::Type::H);
 
     // Create some fake data to test writing methods
-    HField mask(ModelArray::Type::H);
-    mask.resize();
-    for (size_t j = 0; j < ny; ++j) {
-        for (size_t i = 0; i < nx; ++i) {
-            mask(i, j) = j >= 1 ? 1.0 : 0.0;
-        }
-    }
-    VertexField coordinates(ModelArray::Type::VERTEX);
-    coordinates.resize();
-    DGField hice(ModelArray::Type::DG);
-    hice.resize();
-    DGSField tice(ModelArray::Type::DGSTRESS);
-    tice.resize();
-    CGField uice(ModelArray::Type::CG);
-    uice.resize();
     HField hsnow(ModelArray::Type::H);
     hsnow.resize();
 

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -77,10 +77,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
 
     // Set field types for restarts
-    xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
-    xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
-    xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
-    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);
 

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -43,6 +43,10 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     config << "restart_file = " << outputFilename << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
+    config << "[XiosInput]" << std::endl;
+    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
+           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
+           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
            << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
@@ -55,8 +59,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
 
     // Create a Model and configure it so that time options are parsed
     Model model;
-    model.configureRestarts();
-    model.configureTime();
+    model.configure();
 
     // Get the Xios singleton instance and check it's initialized
     // NOTE: The singleton is created when Xios::getInstance() is first called. In this test, this

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -80,10 +80,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
-    xiosHandler.setPrognosticFieldType(ciceName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(hiceName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::Type::DG);
     xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::VERTEX);
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -45,12 +45,12 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosInput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -103,6 +103,10 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
             latitude(i, j) = j;
         }
     }
+    HField grid_azimuth(ModelArray::Type::H);
+    grid_azimuth.resize();
+    grid_azimuth = 0;
+
     /*
      * Mask definition, where 0 indicates land and 1 indicates ocean:
      *
@@ -130,8 +134,8 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     damage.resize();
     DGField hsnow(ModelArray::Type::DG);
     hsnow.resize();
-    VertexField grid_azimuth(ModelArray::Type::VERTEX);
-    grid_azimuth.resize();
+    VertexField coords(ModelArray::Type::VERTEX);
+    coords.resize();
     DGSField tice(ModelArray::Type::DGSTRESS);
     tice.resize();
     CGField uice(ModelArray::Type::CG);
@@ -169,11 +173,11 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
         for (size_t j = 0; j < ny + 1; ++j) {
             for (size_t i = 0; i < nx + 1; ++i) {
                 if (rank == 0) {
-                    grid_azimuth.components({ i, j })[0] = 1.0 * ts * i;
-                    grid_azimuth.components({ i, j })[1] = 1.0 * ts * j;
+                    coords.components({ i, j })[0] = 1.0 * ts * i;
+                    coords.components({ i, j })[1] = 1.0 * ts * j;
                 } else {
-                    grid_azimuth.components({ i, j })[0] = 1.0 * ts * (i + 2);
-                    grid_azimuth.components({ i, j })[1] = 1.0 * ts * j;
+                    coords.components({ i, j })[0] = 1.0 * ts * (i + 2);
+                    coords.components({ i, j })[1] = 1.0 * ts * j;
                 }
             }
         }
@@ -233,11 +237,12 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                                     { maskName, mask },
                                     { longitudeName, longitude },
                                     { latitudeName, latitude },
+                                    { gridAzimuthName, grid_azimuth },
                                     { ciceName, cice },
                                     { hiceName, hice },
                                     { damageName, damage },
                                     { hsnowName, hsnow },
-                                    { gridAzimuthName, grid_azimuth },
+                                    { coordsName, coords },
                                     { ticeName, tice },
                                     { uName, uice },
                                 },

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -80,7 +80,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
-    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::VERTEX);
+    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
     xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);
 

--- a/core/test/testmodelarraydetails/ModelArrayDetails.cpp
+++ b/core/test/testmodelarraydetails/ModelArrayDetails.cpp
@@ -98,4 +98,6 @@ const ModelArray::TypeMap ModelArray::definedComp0Map()
         { Type::TWOCOMP, Type::TWOD },
     };
 };
+
+const ModelArray::Type ModelArray::AdvectionType = ModelArray::Type::TWOCOMP;
 }

--- a/core/test/testmodelarraydetails/include/ModelArrayDetails.hpp
+++ b/core/test/testmodelarraydetails/include/ModelArrayDetails.hpp
@@ -16,7 +16,7 @@ enum class Type {
     TWOCOMP,
 };
 
-static const Type AdvectionType = Type::TWOCOMP;
+static const Type AdvectionType;
 
 static ModelArray OneDField() { return ModelArray(Type::ONED); }
 static ModelArray TwoDField() { return ModelArray(Type::TWOD); }

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -48,6 +48,9 @@ variables:
   float latitude(y_dim, x_dim) ;
     latitude:online_operation = "once" ;
     latitude:coordinates = "lat lon" ;
+  float grid_azimuth(y_dim, x_dim) ;
+    grid_azimuth:online_operation = "once" ;
+    grid_azimuth:coordinates = "lat lon" ;
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
@@ -65,9 +68,9 @@ variables:
 		hsnow:online_operation = "once" ;
 		hsnow:coordinates = "lat lon dg_comp" ;
   // VertexField variables
-	float grid_azimuth(y_vertex, x_vertex, ncoords) ;
-		grid_azimuth:online_operation = "once" ;
-		grid_azimuth:coordinates = "lat lon ncoords" ;
+	float coords(y_vertex, x_vertex, ncoords) ;
+		coords:online_operation = "once" ;
+		coords:coordinates = "lat lon ncoords" ;
   // DGStressField variables
 	float tice(y_dim, x_dim, dgstress_comp) ;
 		tice:online_operation = "once" ;
@@ -95,6 +98,10 @@ data:
  latitude =
   0, 0, 0, 0,
   1, 1, 1, 1 ;
+
+ grid_azimuth =
+  0, 0, 0, 0,
+  0, 0, 0, 0 ;
 
  mask =
   0, 1, 0, 1,
@@ -144,7 +151,7 @@ data:
 
  // VertexField variables
 
- grid_azimuth =
+ coords =
   0, 0,
   1, 0,
   2, 0,

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -180,10 +180,15 @@ following:
 4. Associate the ``ParaGridIO`` pointer with the ``ParametricGrid`` instance
    using the latter's ``setIO`` member function.
 5. Get the ``Xios`` handler singleton using ``Xios::getInstance``.
-6. For each field to be written to file with XIOS, call the
-   ``setPrognosticFieldType`` or ``setDiagnosticFieldType`` member function of
-   ``Xios`` as appropriate, providing the field name as the first argument
-   and the ``ModelArray::Type::<TYPE>`` enum as the second argument (replacing
+6. For each field to be written to file with XIOS, the field type needs to be
+   set. By default, ``coords`` is set to ``ModelArray::Type::VERTEX`` and
+   ``hice``, ``cice``, ``damage``, and ``hsnow`` are all determined based on the
+   ``ModelArray::AdvectionType`` set in the grid implementation. All other
+   fields default to ``ModelArray::Type::H``. If you want to customise any other
+   field types then call the ``setPrognosticFieldType`` or
+   ``setDiagnosticFieldType`` member function of ``Xios`` as appropriate,
+   providing the field name as the first argument and the
+   ``ModelArray::Type::<TYPE>`` enum as the second argument (replacing
    ``<TYPE>>`` with the desired type).
 
 There is no need to explicitly close the XIOS context definition because this

--- a/physics/src/modules/include/IColumnPhysics.hpp
+++ b/physics/src/modules/include/IColumnPhysics.hpp
@@ -14,17 +14,29 @@
 #include "include/ModelArrayRef.hpp"
 #include "include/ModelComponent.hpp"
 #include "include/Time.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#include "include/gridNames.hpp"
+#endif
 
 namespace Nextsim {
 
 class IColumnPhysics : public ModelComponent {
 public:
+    IColumnPhysics()
+    {
+#ifdef USE_XIOS
+        // Set XIOS field types
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(tsurfName, ModelArray::AdvectionType);
+#endif
+    }
+
     virtual ~IColumnPhysics() = default;
 
     virtual void update(const TimestepTime&) = 0;
-protected:
-    IColumnPhysics() = default;
 
+protected:
     static void setCMin(double cMin) { IceMinima::cMin = cMin; };
     static void setHMin(double hMin) { IceMinima::hMin = hMin; };
 };


### PR DESCRIPTION
# Determine XIOS field types (take 3)

Fixes #1026 
Refinement of #1043
~~Merges into #1050~~

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

Main changes:
* Modify build system to allow including XIOS outside of `core/src`.
* Modify build system to make `ModelArray::AdvectionType` always available.
* Set core field types to be used by XIOS in the `IDynamics` and `IColumnPhysics` modules.
* Default field type to `ModelArray::Type::H`.

Some warnings are also added to make it clearer what's going on.

---
# Test Description

Some of the field names used in the XIOS tests needed tweaking to avoid conflicts between restarts and forcings.

---
# Documentation Impact

The XIOS docs page has been updated accordingly.