### PR TITLE
XIOS pre-requisites for June '23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,9 @@ __pycache__/
 
 # File types
 *.DS_Store
+*.err
 *.log
+*.out
 *.nc
 *.sif
 *.smesh

--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -188,15 +188,25 @@ Model::HelpMap& Model::getHelpRecursive(HelpMap& map, bool getAll)
 
 void Model::run()
 {
+#ifdef USE_XIOS
+    Xios& xiosHandler = Xios::getInstance();
+#endif
+
     try {
         iterator.run();
     } catch (const std::exception& e) {
         writeRestartFile();
+#ifdef USE_XIOS
+        xiosHandler.context_finalize();
+#endif
         Finalizer::finalize();
         throw;
     }
 
     writeRestartFile();
+#ifdef USE_XIOS
+    xiosHandler.context_finalize();
+#endif
     Finalizer::finalize();
 }
 

--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -87,8 +87,9 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
     for (auto& [fieldId, modelarray] : state.data) {
         const std::string inputFieldId = fieldId + "_input";
         if (inputFieldIds.count(fieldId) == 0) {
-            throw std::runtime_error(
+            Logged::warning(
                 "ParaGridIO::getModelState: field " + fieldId + " is not configured as a restart.");
+            continue;
         }
         xiosHandler.read(inputFieldId, modelarray);
     }
@@ -165,8 +166,9 @@ void ParaGridIO::dumpModelState(const ModelState& state, const std::string& file
     const std::set<std::string> outputFieldIds = xiosHandler.configGetOutputRestartFieldNames();
     for (const auto& [fieldId, modelarray] : state.data) {
         if (outputFieldIds.count(fieldId) == 0) {
-            throw std::runtime_error("ParaGridIO::dumpModelState: field " + fieldId
+            Logged::warning("ParaGridIO::dumpModelState: field " + fieldId
                 + " is not configured as a restart.");
+            continue;
         }
         xiosHandler.write(fieldId, modelarray);
     }

--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -157,7 +157,8 @@ void ParaGridIO::dumpModelState(const ModelState& state, const std::string& file
     xiosHandler.close_context_definition();
 
     ModelMetadata& metadata = ModelMetadata::getInstance();
-    if (metadata.finalFileName != filePath) {
+
+    if (filePath.find(xiosHandler.outputFileId) == std::string::npos) {
         throw std::runtime_error("ParaGridIO::dumpModelState: file path '" + filePath
             + "' is inconsistent with model.restart_file '" + metadata.finalFileName + "'");
     }
@@ -180,7 +181,7 @@ void ParaGridIO::writeDiagnosticTime(const ModelState& state, const std::string&
     Xios& xiosHandler = Xios::getInstance();
     xiosHandler.close_context_definition();
 
-    if (xiosHandler.diagnosticFilename != filePath) {
+    if (filePath.find(xiosHandler.diagnosticFileId) == std::string::npos) {
         throw std::runtime_error("ParaGridIO::writeDiagnosticTime: file path '" + filePath
             + "' is inconsistent with XiosDiagnostic.filename '" + xiosHandler.diagnosticFilename
             + "'");

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1062,8 +1062,7 @@ Duration Xios::getFieldFreqOffset(const std::string& fieldId)
 ModelArray::Type Xios::getFieldType(const std::string& fieldId)
 {
     if (fieldTypes.count(fieldId) == 0) {
-        throw std::runtime_error(
-            "Xios::getFieldType: Undefined field type for field '" + fieldId + "'");
+        return ModelArray::Type::H;
     }
     return fieldTypes[fieldId];
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1499,10 +1499,13 @@ void Xios::postprocessOutputFiles()
 
     // If a single domain was written then modify x and y dimensions and variables in the output
     // files
-    if (sum == 1 && mpi_rank == 0) {
+    if (sum == 1) {
 
         // Consider both restart files and diagnostic files
         for (std::string fileId : { outputFileId, diagnosticFileId }) {
+            if (fileId.empty()) {
+                continue;
+            }
             bool exists;
             cxios_file_valid_id(&exists, fileId.c_str(), fileId.length());
             if (!exists) {
@@ -1546,22 +1549,25 @@ void Xios::postprocessOutputFiles()
                     continue;
                 }
 
-                try {
-                    // Open the netCDF file for both reading and writing
-                    netCDF::NcFile ncFile(filename, netCDF::NcFile::write);
+                // Only allow one MPI rank to modify the file
+                if (mpi_rank == 0) {
+                    try {
+                        // Open the netCDF file for both reading and writing
+                        netCDF::NcFile ncFile(filename, netCDF::NcFile::write);
 
-                    // Rename the x and y dimensions with x_dim and y_dim, respectively
-                    ncFile.getDim("x").rename("x_dim");
-                    ncFile.getDim("y").rename("y_dim");
+                        // Rename the x and y dimensions with x_dim and y_dim, respectively
+                        ncFile.getDim("x").rename("x_dim");
+                        ncFile.getDim("y").rename("y_dim");
 
-                    // Rename the x and y variables with x_dim and y_dim, respectively
-                    ncFile.getVar("x").rename("x_dim");
-                    ncFile.getVar("y").rename("y_dim");
+                        // Rename the x and y variables with x_dim and y_dim, respectively
+                        ncFile.getVar("x").rename("x_dim");
+                        ncFile.getVar("y").rename("y_dim");
 
-                    // Ensure changes are flushed to disk before closing
-                    ncFile.sync();
-                } catch (const netCDF::exceptions::NcException& e) {
-                    std::cerr << "Error processing NetCDF file: " << e.what() << std::endl;
+                        // Ensure changes are flushed to disk before closing
+                        ncFile.sync();
+                    } catch (const netCDF::exceptions::NcException& e) {
+                        std::cerr << "Error processing NetCDF file: " << e.what() << std::endl;
+                    }
                 }
             }
         }

--- a/run/iodef.xml
+++ b/run/iodef.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<simulation>
+
+  <!-- Context for XIOS concepts used in nextSIM-DG -->
+  <context id="nextSIM-DG">
+
+    <!-- Gregorian calendar beginning with the Unix epoch -->
+    <calendar type="Gregorian" time_origin="1970-01-01" />
+
+    <!-- Axes defining extrusions for certain fields based on degrees of freedom per node -->
+    <axis_definition>
+      <axis id="DGAxis" n_glo="3" name="dg_comp" dim_name="dg_comp"/>
+      <axis id="DGSAxis" n_glo="3" name="dgstress_comp" dim_name="dgstress_comp"/>
+      <axis id="VertexAxis" n_glo="2" name="ncoords" dim_name="ncoords"/>
+    </axis_definition>
+
+    <grid_definition>
+      <grid id="HGrid" name="HGrid"/>
+      <grid id="DGGrid" name="DGGrid">
+        <axis axis_ref="DGAxis"/>
+      </grid>
+      <grid id="DGSGrid" name="DGSGrid">
+        <axis axis_ref="DGSAxis"/>
+      </grid>
+      <grid id="VertexGrid" name="VertexGrid">
+        <axis axis_ref="VertexAxis"/>
+      </grid>
+      <grid id="CGGrid" name="CGGrid"/>
+    </grid_definition>
+
+  </context>
+
+  <!-- Context for handling XIOS errors and logs -->
+  <context id="xios">
+    <variable_definition>
+      <variable_group id="parameters">
+        <variable id="print_file" type="bool">true</variable>
+      </variable_group>
+    </variable_definition>
+  </context>
+
+</simulation>


### PR DESCRIPTION
# XIOS pre-requisites for June '23

Towards #982
Refinement of #1046

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

This PR provides various fixes to get the June '23 config working with XIOS. Fixes required:
* Filename pattern handling in file writing.
* XIOS finalizer needs to be called at the end of `Model::run()`.
* Convert configuration errors to warnings to allow fields to be in the `ModelState` but not get read/written. (I was having a problem with `tsurf`, which gets added by physics even with a minimal module configuration.)
* Add an `iodef.xml` file in the `run` directory.
* Skip empty filenames during post-processing of files.

---
# Test Description

Add an `iodef.xml` file in the `run` directory using `DG1`.

---
# Documentation Impact

n/a