### PR TITLE
Read forcings only when necessary

### DIFF
--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -388,8 +388,25 @@ ModelState& ModelMetadata::affixCoordinates(ModelState& state) const
     return state;
 }
 
+// Helper function for checking that the model start and timestep align with midnight and the hour.
+void checkStartStep(const std::string start_str, double step)
+{
+    if (start_str != "T00:00:00Z") {
+        throw std::runtime_error("ModelMetadata::setTimes: model.start must be at midnight.");
+    }
+    if (step < 3600) {
+        if (std::fmod(3600, step) != 0.) {
+            throw std::runtime_error(
+                "ModelMetadata::setTimes: model.time_step must be aligned with the hour.");
+        }
+    }
+}
+
 void ModelMetadata::setTimes(const TimePoint& start, const TimePoint& stop, const Duration& step)
 {
+#ifdef USE_XIOS
+    checkStartStep(start.format(TimePoint::hmsFormat), step.seconds());
+#endif
     this->start = start;
     this->stop = stop;
     this->step = step;
@@ -399,6 +416,9 @@ void ModelMetadata::setTimes(const TimePoint& start, const TimePoint& stop, cons
 
 void ModelMetadata::setTimes(const TimePoint& start, const Duration& runLen, const Duration& step)
 {
+#ifdef USE_XIOS
+    checkStartStep(start.format(TimePoint::hmsFormat), step.seconds());
+#endif
     this->start = start;
     this->stop = start + runLen;
     this->step = step;

--- a/core/test/XiosAxis_test.cpp
+++ b/core/test/XiosAxis_test.cpp
@@ -30,8 +30,8 @@ MPI_TEST_CASE("TestXiosAxis", 3)
 {
     std::stringstream config;
     config << "[model]" << std::endl;
-    config << "start = 2023-03-17T17:11:00Z" << std::endl;
-    config << "stop = 2023-03-17T18:11:00Z" << std::endl;
+    config << "start = 2023-03-17T00:00:00Z" << std::endl;
+    config << "stop = 2023-03-17T00:00:00Z" << std::endl;
     config << "time_step = P0-0T01:00:00" << std::endl;
     config << "partition_file = xios_test_partition_metadata_3.nc" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));

--- a/core/test/XiosCalendar_test.cpp
+++ b/core/test/XiosCalendar_test.cpp
@@ -31,8 +31,8 @@ MPI_TEST_CASE("TestXiosCalendar", 1)
 {
     std::stringstream config;
     config << "[model]" << std::endl;
-    config << "start = 2023-03-17T17:11:00Z" << std::endl;
-    config << "stop = 2023-03-17T18:11:00Z" << std::endl;
+    config << "start = 2023-03-17T00:00:00Z" << std::endl;
+    config << "stop = 2023-03-17T00:00:00Z" << std::endl;
     config << "time_step = P0-0T01:00:00" << std::endl;
     config << "partition_file = xios_test_partition_metadata_1.nc" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
@@ -53,11 +53,11 @@ MPI_TEST_CASE("TestXiosCalendar", 1)
 
     // --- Tests for calendar API
     // Calendar start
-    REQUIRE(xiosHandler.getCalendarStart().format() == "2023-03-17T17:11:00Z"); // Set in config
-    TimePoint start("2023-03-17T20:11:00Z");
+    REQUIRE(xiosHandler.getCalendarStart().format() == "2023-03-17T00:00:00Z"); // Set in config
+    TimePoint start("2023-03-18T00:00:00Z");
     xiosHandler.setCalendarStart(start);
     REQUIRE(start == xiosHandler.getCalendarStart());
-    REQUIRE(start.format() == "2023-03-17T20:11:00Z");
+    REQUIRE(start.format() == "2023-03-18T00:00:00Z");
     // Timestep
     ModelMetadata& metadata = ModelMetadata::getInstance();
     REQUIRE(metadata.stepLength().seconds() == 3600.0); // Read from config
@@ -67,12 +67,12 @@ MPI_TEST_CASE("TestXiosCalendar", 1)
 
     // --- Tests for getCurrentDate method
     REQUIRE(xiosHandler.getCalendarStep() == 0);
-    REQUIRE(xiosHandler.getCurrentDate().format() == "2023-03-17T20:11:00Z");
+    REQUIRE(xiosHandler.getCurrentDate().format() == "2023-03-18T00:00:00Z");
 
     // -- Tests that the timestep is set up correctly
     xiosHandler.setCalendarStep(1);
     REQUIRE(xiosHandler.getCalendarStep() == 1);
-    REQUIRE(xiosHandler.getCurrentDate().format() == "2023-03-17T21:11:00Z");
+    REQUIRE(xiosHandler.getCurrentDate().format() == "2023-03-18T01:00:00Z");
 
     xiosHandler.context_finalize();
     Finalizer::finalize();

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -18,7 +18,7 @@
 
 const std::string testFilesDir = TEST_FILES_DIR;
 const std::string diagnosticFilename
-    = testFilesDir + "/diagnostic_2023-03-17T17:11:00Z-2023-03-17T20:10:59Z.nc";
+    = testFilesDir + "/diagnostic_2023-03-17T00:00:00Z-2023-03-17T02:59:59Z.nc";
 
 static const int DGCOMP = 6;
 static const int DGSTRESSCOMP = 8;
@@ -37,8 +37,8 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 3)
 {
     std::stringstream config;
     config << "[model]" << std::endl;
-    config << "start = 2023-03-17T17:11:00Z" << std::endl;
-    config << "stop = 2023-03-17T23:11:00Z" << std::endl;
+    config << "start = 2023-03-17T00:00:00Z" << std::endl;
+    config << "stop = 2023-03-17T00:00:00Z" << std::endl;
     config << "time_step = P0-0T01:30:00" << std::endl;
     config << "init_file = " << diagnosticFilename << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
@@ -91,8 +91,8 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 3)
     int rank;
     MPI_Comm_rank(test_comm, &rank);
     if (rank == 0) {
-        std::filesystem::remove("diagnostic_2023-03-17T17:11:00Z-2023-03-17T20:10:59Z.nc");
-        std::filesystem::remove("diagnostic_2023-03-17T20:11:00Z-2023-03-17T23:10:59Z.nc");
+        std::filesystem::remove("diagnostic_2023-03-17T00:00:00Z-2023-03-17T02:59:59Z.nc");
+        std::filesystem::remove("diagnostic_2023-03-17T03:00:00Z-2023-03-17T05:59:59Z.nc");
     }
 
     xiosHandler.context_finalize();

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -18,7 +18,7 @@
 
 const std::string testFilesDir = TEST_FILES_DIR;
 const std::string restartFilename
-    = testFilesDir + "/restart_2023-03-17T17:11:00Z-2023-03-17T20:10:59Z.nc";
+    = testFilesDir + "/restart_2023-03-17T00:00:00Z-2023-03-17T02:59:59Z.nc";
 
 static const int DGCOMP = 6;
 static const int DGSTRESSCOMP = 8;
@@ -35,8 +35,8 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
 {
     std::stringstream config;
     config << "[model]" << std::endl;
-    config << "start = 2023-03-17T17:11:00Z" << std::endl;
-    config << "stop = 2023-03-17T23:11:00Z" << std::endl;
+    config << "start = 2023-03-17T00:00:00Z" << std::endl;
+    config << "stop = 2023-03-17T00:00:00Z" << std::endl;
     config << "time_step = P0-0T01:30:00" << std::endl;
     config << "init_file = " << restartFilename << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
@@ -76,7 +76,7 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     //       StructureFactory::stateFromFile()
     int rank;
     MPI_Comm_rank(test_comm, &rank);
-    float ts = 2; // Corresponds to 2023-03-17T20:10:59Z
+    float ts = 2; // Corresponds to 2023-03-17T02:59:59Z
     ModelState modelstate = StructureFactory::stateFromFile(restartFilename);
     REQUIRE(modelstate.data.count(maskName) > 0);
     REQUIRE(modelstate.data.count(longitudeName) > 0);
@@ -185,8 +185,8 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
 
     // Remove the restart files
     if (rank == 0) {
-        std::filesystem::remove("restart_2023-03-17T17:11:00Z-2023-03-17T20:10:59Z.nc");
-        std::filesystem::remove("restart_2023-03-17T20:11:00Z-2023-03-17T23:10:59Z.nc");
+        std::filesystem::remove("restart_2023-03-17T00:00:00Z-2023-03-17T02:59:59Z.nc");
+        std::filesystem::remove("restart_2023-03-17T03:00:00Z-2023-03-17T05:59:59Z.nc");
     }
 
     xiosHandler.context_finalize();

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -36,8 +36,8 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
 {
     std::stringstream config;
     config << "[model]" << std::endl;
-    config << "start = 2023-03-17T17:11:00Z" << std::endl;
-    config << "stop = 2023-03-17T23:11:00Z" << std::endl;
+    config << "start = 2023-03-17T00:00:00Z" << std::endl;
+    config << "stop = 2023-03-17T00:00:00Z" << std::endl;
     config << "time_step = P0-0T01:30:00" << std::endl;
     config << "init_file = " << inputFilename << std::endl;
     config << "restart_file = " << outputFilename << std::endl;
@@ -98,11 +98,11 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     }
 
     // Check the files have indeed been created then remove them
-    REQUIRE(std::filesystem::exists("readwrite_2023-03-17T17:11:00Z-2023-03-17T20:10:59Z.nc"));
-    REQUIRE(std::filesystem::exists("readwrite_2023-03-17T20:11:00Z-2023-03-17T23:10:59Z.nc"));
+    REQUIRE(std::filesystem::exists("readwrite_2023-03-17T00:00:00Z-2023-03-17T02:59:59Z.nc"));
+    REQUIRE(std::filesystem::exists("readwrite_2023-03-17T03:00:00Z-2023-03-17T05:59:59Z.nc"));
     if (rank == 0) {
-        std::filesystem::remove("readwrite_2023-03-17T17:11:00Z-2023-03-17T20:10:59Z.nc");
-        std::filesystem::remove("readwrite_2023-03-17T20:11:00Z-2023-03-17T23:10:59Z.nc");
+        std::filesystem::remove("readwrite_2023-03-17T00:00:00Z-2023-03-17T02:59:59Z.nc");
+        std::filesystem::remove("readwrite_2023-03-17T03:00:00Z-2023-03-17T05:59:59Z.nc");
     }
 
     xiosHandler.context_finalize();

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -36,8 +36,8 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
 {
     std::stringstream config;
     config << "[model]" << std::endl;
-    config << "start = 2023-03-17T17:11:00Z" << std::endl;
-    config << "stop = 2023-03-17T23:11:00Z" << std::endl;
+    config << "start = 2023-03-17T00:00:00Z" << std::endl;
+    config << "stop = 2023-03-17T06:00:00Z" << std::endl;
     config << "time_step = P0-0T01:30:00" << std::endl;
     config << "init_file = " << inputFilename << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
@@ -130,8 +130,8 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
 
     // Check the files have indeed been created
     // NOTE: Don't remove them because their contents are checked in XiosReadDiagnostic_test
-    REQUIRE(std::filesystem::exists("diagnostic_2023-03-17T17:11:00Z-2023-03-17T20:10:59Z.nc"));
-    REQUIRE(std::filesystem::exists("diagnostic_2023-03-17T20:11:00Z-2023-03-17T23:10:59Z.nc"));
+    REQUIRE(std::filesystem::exists("diagnostic_2023-03-17T00:00:00Z-2023-03-17T02:59:59Z.nc"));
+    REQUIRE(std::filesystem::exists("diagnostic_2023-03-17T03:00:00Z-2023-03-17T05:59:59Z.nc"));
 
     xiosHandler.context_finalize();
     Finalizer::finalize();

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -36,8 +36,8 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
 {
     std::stringstream config;
     config << "[model]" << std::endl;
-    config << "start = 2023-03-17T17:11:00Z" << std::endl;
-    config << "stop = 2023-03-17T23:11:00Z" << std::endl;
+    config << "start = 2023-03-17T00:00:00Z" << std::endl;
+    config << "stop = 2023-03-17T00:00:00Z" << std::endl;
     config << "time_step = P0-0T01:30:00" << std::endl;
     config << "init_file = " << inputFilename << std::endl;
     config << "restart_file = " << outputFilename << std::endl;
@@ -253,8 +253,8 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
 
     // Check the files have indeed been created
     // NOTE: Don't remove them because their contents are checked in XiosReadRestart_test
-    REQUIRE(std::filesystem::exists("restart_2023-03-17T17:11:00Z-2023-03-17T20:10:59Z.nc"));
-    REQUIRE(std::filesystem::exists("restart_2023-03-17T20:11:00Z-2023-03-17T23:10:59Z.nc"));
+    REQUIRE(std::filesystem::exists("restart_2023-03-17T00:00:00Z-2023-03-17T02:59:59Z.nc"));
+    REQUIRE(std::filesystem::exists("restart_2023-03-17T03:00:00Z-2023-03-17T05:59:59Z.nc"));
 
     xiosHandler.context_finalize();
     Finalizer::finalize();

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -83,6 +83,15 @@ used to configure the calendar used by XIOS. For example,
   stop = 1970-01-01T01:00:00Z
   time_step = P0-0T01:00:00
 
+.. note::
+
+  The XIOS I/O implementation makes two assumptions:
+
+  1. The simulation starts at midnight.
+  2. The timestep aligns with the hour.
+
+  If these conditions aren't met then an error will be thrown.
+
 The filename and period for restart files is configured in the same way as when
 building without XIOS. That is, the ``model`` section should include
 ``init_file``, ``restart_file`` and ``restart_period`` entries:

--- a/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/ERA5Atmosphere.cpp
@@ -73,15 +73,18 @@ void ERA5Atmosphere::update(const TimestepTime& tst)
     std::set<std::string> forcings
         = { "tair", "dew2m", "pair", "sw_in", "lw_in", "wind_speed", "u", "v" };
 
-    ModelState state = ParaGridIO::readForcingTimeStatic(forcings, tst.start, filePath);
-    tairAccessor.getHostRW() = state.data.at("tair");
-    tdewAccessor.getHostRW() = state.data.at("dew2m");
-    pairAccessor.getHostRW() = state.data.at("pair");
-    sw_inAccessor.getHostRW() = state.data.at("sw_in");
-    lw_inAccessor.getHostRW() = state.data.at("lw_in");
-    windAccessor.getHostRW() = state.data.at("wind_speed");
-    uwindAccessor.getHostRW() = state.data.at("u");
-    vwindAccessor.getHostRW() = state.data.at("v");
+    // Read ERA5 forcings at the top of the hour
+    if (std::fmod((tst.start - TimePoint()).seconds(), 3600.) == 0.) {
+        forcingState = ParaGridIO::readForcingTimeStatic(forcings, tst.start, filePath);
+    }
+    tairAccessor.getHostRW() = forcingState.data.at("tair");
+    tdewAccessor.getHostRW() = forcingState.data.at("dew2m");
+    pairAccessor.getHostRW() = forcingState.data.at("pair");
+    sw_inAccessor.getHostRW() = forcingState.data.at("sw_in");
+    lw_inAccessor.getHostRW() = forcingState.data.at("lw_in");
+    windAccessor.getHostRW() = forcingState.data.at("wind_speed");
+    uwindAccessor.getHostRW() = forcingState.data.at("u");
+    vwindAccessor.getHostRW() = forcingState.data.at("v");
     snowAccessor.getHostRW() = 0; // FIXME get snow data
     rainAccessor.getHostRW() = 0; // FIXME get rain data
 

--- a/physics/src/modules/AtmosphereBoundaryModule/include/ERA5Atmosphere.hpp
+++ b/physics/src/modules/AtmosphereBoundaryModule/include/ERA5Atmosphere.hpp
@@ -44,6 +44,8 @@ private:
     // be static.
     static std::string filePath;
 
+    ModelState forcingState;
+
     ModelArrayAccessor<Protected::T_AIR, RW> tairAccessor;
     ModelArrayAccessor<Protected::DEW_2M, RW> tdewAccessor;
     ModelArrayAccessor<Protected::P_AIR, RW> pairAccessor;

--- a/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
+++ b/physics/src/modules/OceanBoundaryModule/TOPAZOcean.cpp
@@ -66,15 +66,20 @@ static const std::set<std::string> forcings = { sstName, sssName, mldName, uName
 
 void TOPAZOcean::updateBefore(const TimestepTime& tst)
 {
-    ModelState state = ParaGridIO::readForcingTimeStatic(forcings, tst.start, filePath);
-    sstExtAccessor.getHostRW() = state.data.at(sstName);
-    sssExtAccessor.getHostRW() = state.data.at(sssName);
-    mldAccessor.getHostRW() = state.data.at(mldName);
-    uAccessor.getHostRW() = state.data.at(uName);
-    vAccessor.getHostRW() = state.data.at(vName);
+    // Read TOPAZ forcings at midnight
+    if (std::fmod((tst.start - TimePoint()).seconds(), 86400.) == 0.) {
+        forcingState = ParaGridIO::readForcingTimeStatic(forcings, tst.start, filePath);
+    }
+
+    sstExtAccessor.getHostRW() = forcingState.data.at(sstName);
+    sssExtAccessor.getHostRW() = forcingState.data.at(sssName);
+    mldAccessor.getHostRW() = forcingState.data.at(mldName);
+    uAccessor.getHostRW() = forcingState.data.at(uName);
+    vAccessor.getHostRW() = forcingState.data.at(vName);
     HField& ssh = sshAccessor.getHostRW();
-    if (state.data.count(sshName)) {
-        ssh = state.data.at(sshName);
+
+    if (forcingState.data.count(sshName)) {
+        ssh = forcingState.data.at(sshName);
     } else {
         ssh = 0.;
     }

--- a/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
+++ b/physics/src/modules/OceanBoundaryModule/include/TOPAZOcean.hpp
@@ -49,6 +49,8 @@ private:
     // be static.
     static std::string filePath;
 
+    ModelState forcingState;
+
     ModelArrayAccessor<Protected::EXT_SST, RW> sstExtAccessor;
     ModelArrayAccessor<Protected::EXT_SSS, RW> sssExtAccessor;
 


### PR DESCRIPTION
# Read forcings only when necessary

Fixes #1054

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

Currently, if the ERA5 and TOPAZ modules are included then they are read every timestep. This is unnecessary given that ERA5 data are only available once per hour and TOPAZ once per day.

This PR makes it so that ERA5 forcings are only read at the top of the hour and TOPAZ forcings are only read at midnight.

## Caveats

1. Assumes that the simulation begins at midnight.
2. Assumes that timesteps are aligned with the hour.

Are we happy with these assumptions? If so, I can add config checks to ensure that they are satisfied. If not then I will have to modify how the XIOS calendar is handled.

(This change is also required to enable ERA5 and TOPAZ forcings with XIOS.)

---
# Test Description

XIOS tests are updated accordingly.

---
# Documentation Impact

A note on the assumptions has been added to the XIOS doc page.