### PR TITLE
XIOS: read all inputs

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1133,12 +1133,16 @@ void Xios::setupFields()
 {
     ModelMetadata& metadata = ModelMetadata::getInstance();
 
+    // Set dimensions based on those found in input file
+    if (!metadata.initialFileName.empty()) {
+        metadata.setDimensionsFromFile(metadata.initialFileName);
+    }
+
     for (const std::string& filename :
         { metadata.initialFileName, era5ForcingFilename, topazForcingFilename }) {
         if (filename.empty()) {
-            break;
+            continue;
         }
-        metadata.setDimensionsFromFile(filename);
 
         // Create map for field types
         const std::map<std::string, ModelArray::Type> dimensionKeys = {

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -829,7 +829,6 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         setFieldReadAccess(fieldId, false);
         fileAddField(fileId, fieldId);
     } else {
-        // TODO: Allow unused fields in input files (#1060)
         throw std::runtime_error("Xios: Unknown I/O type for field '" + fieldId + "'");
     }
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1169,9 +1169,10 @@ void Xios::setupFields()
                 for (netCDF::NcDim& dim : varDims) {
                     const std::string name = dim.getName();
                     // Skip the time_counter dim as it's handled differently
-                    if (name != "time_counter") {
-                        dimKey += dim.getName();
+                    if (name == "time_counter" || name == "time") {
+                        continue;
                     }
+                    dimKey += name;
                 }
 
                 // Skip invalid dimension keys, otherwise add to the corresponding config section

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -51,8 +51,6 @@ static const std::string xDiagnosticPfx = "XiosDiagnostic";
 static const std::map<int, std::string> keyMap = { { Xios::ENABLED_KEY, "xios.enable" },
     // TODO: Avoid having to parse restart fields (#1056)
     { Xios::OUTPUT_FIELD_NAMES_KEY, "XiosOutput.field_names" },
-    // TODO: Avoid having to parse input fields (#1056)
-    { Xios::INPUT_FIELD_NAMES_KEY, "XiosInput.field_names" },
     { Xios::DIAGNOSTIC_PERIOD_KEY, xDiagnosticPfx + ".period" },
     { Xios::DIAGNOSTIC_FILE_KEY, xDiagnosticPfx + ".filename" },
     // TODO: Avoid having to parse diagnostic fields for XIOS specifically (#981)
@@ -72,10 +70,6 @@ Xios::HelpMap& Xios::getHelpText(HelpMap& map, bool getAll)
     map["XiosOutput"] = {
         { keyMap.at(OUTPUT_FIELD_NAMES_KEY), ConfigType::STRING, {}, "", "",
             "Comma-separated list of field names to be written to the output file." },
-    };
-    map["XiosInput"] = {
-        { keyMap.at(INPUT_FIELD_NAMES_KEY), ConfigType::STRING, {}, "", "",
-            "Comma-separated list of field names to be read from the input file." },
     };
     map["XiosDiagnostic"] = {
         { keyMap.at(DIAGNOSTIC_PERIOD_KEY), ConfigType::STRING, {}, "0", "",
@@ -242,7 +236,6 @@ void Xios::configure()
         setupContext();
         setupCalendar();
         setupFiles();
-        setupFields();
     }
 }
 
@@ -266,22 +259,12 @@ std::set<std::string> str2set(const std::string& asStr, const char& delim = ',')
  */
 void Xios::parseConfig()
 {
-    // TODO: Avoid having to parse input fields (#1056)
-    inputRestartFieldNames
-        = str2set(Configured::getConfiguration(keyMap.at(INPUT_FIELD_NAMES_KEY), std::string()));
     // TODO: Avoid having to parse restart fields (#1056)
     outputRestartFieldNames
         = str2set(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()));
     // TODO: Avoid having to parse diagnostic fields for XIOS specifically (#981)
     diagnosticFieldNames = str2set(
         Configured::getConfiguration(keyMap.at(DIAGNOSTIC_FIELD_NAMES_KEY), std::string()));
-
-    // Combine all field names into a single set for easier checking later on
-    fieldNames = inputRestartFieldNames;
-    fieldNames.insert(outputRestartFieldNames.begin(), outputRestartFieldNames.end());
-    fieldNames.insert(era5ForcingFieldNames.begin(), era5ForcingFieldNames.end());
-    fieldNames.insert(topazForcingFieldNames.begin(), topazForcingFieldNames.end());
-    fieldNames.insert(diagnosticFieldNames.begin(), diagnosticFieldNames.end());
 }
 
 //! Initialize the XIOS context with ID contextId
@@ -823,6 +806,10 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         if (!cxios_is_defined_field_name(baseField)) {
             throw std::runtime_error("Xios: Failed to set name for field '" + fieldId + "'");
         }
+
+        // Set grid reference
+        ModelArray::Type& fieldType = fieldTypes[fieldId];
+        setFieldGridRef(fieldId, gridIds[fieldType]);
     }
 
     int ioType = getFileIOType(fileId);
@@ -952,6 +939,10 @@ std::string Xios::createInputField(const std::string& fieldId, const int ioType)
         throw std::runtime_error("Xios: Failed to set name for input field '" + inputFieldId + "'");
     }
 
+    // Set grid reference
+    ModelArray::Type& fieldType = fieldTypes[inputFieldId];
+    setFieldGridRef(inputFieldId, gridIds[fieldType]);
+
     return inputFieldId;
 }
 
@@ -1008,23 +999,6 @@ void Xios::setFieldFreqOffset(const std::string& fieldId, const Duration& freqOf
         throw std::runtime_error(
             "Xios: Failed to set frequency offset for field '" + fieldId + "'");
     }
-}
-
-/*!
- * Get the grid reference associated with a field with a given ID
- *
- * @param the field ID
- * @return grid reference used for the corresponding field
- */
-std::string Xios::getFieldGridRef(const std::string& fieldId)
-{
-    xios::CField* field = getField(fieldId);
-    if (!cxios_is_defined_field_grid_ref(field)) {
-        throw std::runtime_error("Xios: Undefined grid reference for field '" + fieldId + "'");
-    }
-    char cStr[cStrLen];
-    cxios_get_field_grid_ref(field, cStr, cStrLen);
-    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -1097,7 +1071,6 @@ void Xios::setFieldType(
         Logged::warning("Xios::setFieldType: Overwriting field type for field '" + ioFieldId + "'");
     }
     fieldTypes[ioFieldId] = fieldType;
-    setFieldGridRef(ioFieldId, gridIds[fieldType]);
 }
 
 /*!
@@ -1158,27 +1131,22 @@ void Xios::setupFields()
         };
 
         // Determine field types
-        std::set<std::string> configFieldIds;
         int ioType;
         if (filename == metadata.initialFileName) {
-            configFieldIds = inputRestartFieldNames;
             ioType = INPUT_RESTART;
         } else if (filename == era5ForcingFilename) {
-            configFieldIds = era5ForcingFieldNames;
             ioType = ERA5_FORCING;
         } else {
-            configFieldIds = topazForcingFieldNames;
             ioType = TOPAZ_FORCING;
         }
+
+        std::set<std::string> configFieldIds;
+        auto& modelMPI = ModelMPI::getInstance();
         try {
-            auto& modelMPI = ModelMPI::getInstance();
             netCDF::NcFilePar ncFile(filename, netCDF::NcFile::read, modelMPI.getComm());
 
             for (auto& [fieldId, var] : ncFile.getVars()) {
-                // Only consider fields that appear in the config
-                if (configFieldIds.count(fieldId) == 0) {
-                    continue;
-                }
+
                 // Determine the type from the dimensions
                 std::vector<netCDF::NcDim> varDims = var.getDims();
                 std::string dimKey = "";
@@ -1189,11 +1157,17 @@ void Xios::setupFields()
                         dimKey += dim.getName();
                     }
                 }
-                // Skip invalid dimension keys
+
+                // Skip invalid dimension keys, otherwise add to the corresponding config section
                 if (!dimensionKeys.count(dimKey)) {
                     continue;
                 }
-                setFieldType(fieldId, dimensionKeys.at(dimKey), ioType);
+                configFieldIds.insert(fieldId);
+
+                // Set the input field type and default the base field type correspondingly
+                ModelArray::Type fieldType = dimensionKeys.at(dimKey);
+                setFieldType(fieldId, fieldType, ioType);
+                setFieldType(fieldId, fieldType, NOT_READ);
             }
             ncFile.close();
         } catch (const netCDF::exceptions::NcException& nce) {
@@ -1201,7 +1175,20 @@ void Xios::setupFields()
             ncWhat += ": " + filename;
             throw std::runtime_error(ncWhat);
         }
+        if (filename == metadata.initialFileName) {
+            inputRestartFieldNames = configFieldIds;
+        } else if (filename == era5ForcingFilename) {
+            era5ForcingFieldNames = configFieldIds;
+        } else {
+            topazForcingFieldNames = configFieldIds;
+        }
     }
+
+    // Combine all field names into a single set for easier checking later on
+    fieldNames = inputRestartFieldNames;
+    fieldNames.insert(outputRestartFieldNames.begin(), outputRestartFieldNames.end());
+    fieldNames.insert(era5ForcingFieldNames.begin(), era5ForcingFieldNames.end());
+    fieldNames.insert(diagnosticFieldNames.begin(), diagnosticFieldNames.end());
 }
 
 /*!
@@ -1523,6 +1510,9 @@ void Xios::setupFiles()
                 "Xios::setupFiles: TOPAZ forcing and diagnostic file names must differ.");
         }
     }
+
+    // Setup fields before creating files because createFile creates the associated fields
+    setupFields();
 
     // Create files for any non-empty file IDs
     for (const std::string& fileId :

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -164,11 +164,14 @@ void Xios::close_context_definition()
                 }
 
                 // Check the field types
-                const ModelArray::Type& inputType = getFieldType(inputFieldId);
                 if (fieldTypes.count(inputFieldId) == 0) {
-                    // getFieldType defaults to HField but doesn't set that as field type
-                    setFieldType(fieldId, inputType, ioType);
+                    if (fieldTypes.count(fieldId) > 0) {
+                        setFieldType(fieldId, getFieldType(fieldId), ioType);
+                    } else {
+                        setFieldType(fieldId, ModelArray::Type::H, ioType);
+                    }
                 }
+                const ModelArray::Type& inputType = getFieldType(inputFieldId);
                 if (fieldTypes.count(fieldId) == 0) {
                     // Unused base fields still need a field type
                     setFieldType(fieldId, inputType, NOT_READ);

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -179,6 +179,10 @@ void Xios::close_context_definition()
                     throw std::runtime_error("Xios: Forcing fields must be treated as HFields");
                 }
 
+                // Set grid references
+                setFieldGridRef(fieldId, gridIds[baseType]);
+                setFieldGridRef(inputFieldId, gridIds[inputType]);
+
                 if (inputType == baseType) {
                     // Link the input field to the base field if their types align
                     cxios_set_field_field_ref(
@@ -806,10 +810,6 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         if (!cxios_is_defined_field_name(baseField)) {
             throw std::runtime_error("Xios: Failed to set name for field '" + fieldId + "'");
         }
-
-        // Set grid reference
-        ModelArray::Type& fieldType = fieldTypes[fieldId];
-        setFieldGridRef(fieldId, gridIds[fieldType]);
     }
 
     int ioType = getFileIOType(fileId);
@@ -938,10 +938,6 @@ std::string Xios::createInputField(const std::string& fieldId, const int ioType)
     if (!cxios_is_defined_field_name(inputField)) {
         throw std::runtime_error("Xios: Failed to set name for input field '" + inputFieldId + "'");
     }
-
-    // Set grid reference
-    ModelArray::Type& fieldType = fieldTypes[inputFieldId];
-    setFieldGridRef(inputFieldId, gridIds[fieldType]);
 
     return inputFieldId;
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1148,12 +1148,16 @@ void Xios::setupFields()
 {
     ModelMetadata& metadata = ModelMetadata::getInstance();
 
+    // Set dimensions based on those found in input file
+    if (!metadata.initialFileName.empty()) {
+        metadata.setDimensionsFromFile(metadata.initialFileName);
+    }
+
     for (const std::string& filename :
         { metadata.initialFileName, era5ForcingFilename, topazForcingFilename }) {
         if (filename.empty()) {
-            break;
+            continue;
         }
-        metadata.setDimensionsFromFile(filename);
 
         // Create map for field types
         const std::map<std::string, ModelArray::Type> dimensionKeys = {

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1070,7 +1070,7 @@ Duration Xios::getFieldFreqOffset(const std::string& fieldId)
 ModelArray::Type Xios::getFieldType(const std::string& fieldId)
 {
     if (fieldTypes.count(fieldId) == 0) {
-        return ModelArray::Type::H;
+        throw std::runtime_error("Xios::getFieldType: Field type not set for '" + fieldId + "'");
     }
     return fieldTypes[fieldId];
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1060,11 +1060,6 @@ ModelArray::Type Xios::getFieldType(const std::string& fieldId)
 void Xios::setFieldType(
     const std::string& fieldId, const ModelArray::Type& fieldType, const int ioType)
 {
-    if (fieldNames.count(fieldId) == 0) {
-        Logged::warning("Xios::setFieldType: Cannot set field type for field '" + fieldId
-            + "' because it is not in the config.");
-        return;
-    }
     const std::string ioFieldId = getFieldIOId(fieldId, ioType);
     if (fieldTypes.count(ioFieldId) > 0) {
         Logged::warning("Xios::setFieldType: Overwriting field type for field '" + ioFieldId + "'");

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1046,7 +1046,7 @@ Duration Xios::getFieldFreqOffset(const std::string& fieldId)
 ModelArray::Type Xios::getFieldType(const std::string& fieldId)
 {
     if (fieldTypes.count(fieldId) == 0) {
-        return ModelArray::Type::H;
+        throw std::runtime_error("Xios::getFieldType: Field type not set for '" + fieldId + "'");
     }
     return fieldTypes[fieldId];
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1153,9 +1153,10 @@ void Xios::setupFields()
                 for (netCDF::NcDim& dim : varDims) {
                     const std::string name = dim.getName();
                     // Skip the time_counter dim as it's handled differently
-                    if (name != "time_counter") {
-                        dimKey += dim.getName();
+                    if (name == "time_counter" || name == "time") {
+                        continue;
                     }
+                    dimKey += name;
                 }
 
                 // Skip invalid dimension keys, otherwise add to the corresponding config section

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -179,6 +179,10 @@ void Xios::close_context_definition()
                     throw std::runtime_error("Xios: Forcing fields must be treated as HFields");
                 }
 
+                // Set grid references
+                setFieldGridRef(fieldId, gridIds[baseType]);
+                setFieldGridRef(inputFieldId, gridIds[inputType]);
+
                 if (inputType == baseType) {
                     // Link the input field to the base field if their types align
                     cxios_set_field_field_ref(
@@ -834,10 +838,6 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         if (!cxios_is_defined_field_name(baseField)) {
             throw std::runtime_error("Xios: Failed to set name for field '" + fieldId + "'");
         }
-
-        // Set grid reference
-        ModelArray::Type& fieldType = fieldTypes[fieldId];
-        setFieldGridRef(fieldId, gridIds[fieldType]);
     }
 
     if (ioType == INPUT_RESTART || ioType == ERA5_FORCING || ioType == TOPAZ_FORCING) {
@@ -962,10 +962,6 @@ std::string Xios::createInputField(const std::string& fieldId, const int ioType)
     if (!cxios_is_defined_field_name(inputField)) {
         throw std::runtime_error("Xios: Failed to set name for input field '" + inputFieldId + "'");
     }
-
-    // Set grid reference
-    ModelArray::Type& fieldType = fieldTypes[inputFieldId];
-    setFieldGridRef(inputFieldId, gridIds[fieldType]);
 
     return inputFieldId;
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -51,8 +51,6 @@ static const std::string xDiagnosticPfx = "XiosDiagnostic";
 static const std::map<int, std::string> keyMap = { { Xios::ENABLED_KEY, "xios.enable" },
     // TODO: Avoid having to parse restart fields (#1056)
     { Xios::OUTPUT_FIELD_NAMES_KEY, "XiosOutput.field_names" },
-    // TODO: Avoid having to parse input fields (#1056)
-    { Xios::INPUT_FIELD_NAMES_KEY, "XiosInput.field_names" },
     { Xios::DIAGNOSTIC_PERIOD_KEY, xDiagnosticPfx + ".period" },
     { Xios::DIAGNOSTIC_FILE_KEY, xDiagnosticPfx + ".filename" },
     // TODO: Avoid having to parse diagnostic fields for XIOS specifically (#981)
@@ -72,10 +70,6 @@ Xios::HelpMap& Xios::getHelpText(HelpMap& map, bool getAll)
     map["XiosOutput"] = {
         { keyMap.at(OUTPUT_FIELD_NAMES_KEY), ConfigType::STRING, {}, "", "",
             "Comma-separated list of field names to be written to the output file." },
-    };
-    map["XiosInput"] = {
-        { keyMap.at(INPUT_FIELD_NAMES_KEY), ConfigType::STRING, {}, "", "",
-            "Comma-separated list of field names to be read from the input file." },
     };
     map["XiosDiagnostic"] = {
         { keyMap.at(DIAGNOSTIC_PERIOD_KEY), ConfigType::STRING, {}, "0", "",
@@ -242,7 +236,6 @@ void Xios::configure()
         setupContext();
         setupCalendar();
         setupFiles();
-        setupFields();
     }
 }
 
@@ -266,21 +259,12 @@ std::set<std::string> str2set(const std::string& asStr, const char& delim = ',')
  */
 void Xios::parseConfig()
 {
-    // TODO: Avoid having to parse input fields (#1056)
-    inputRestartFieldNames
-        = str2set(Configured::getConfiguration(keyMap.at(INPUT_FIELD_NAMES_KEY), std::string()));
     // TODO: Avoid having to parse restart fields (#1056)
     outputRestartFieldNames
         = str2set(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()));
     // TODO: Avoid having to parse diagnostic fields for XIOS specifically (#981)
     diagnosticFieldNames = str2set(
         Configured::getConfiguration(keyMap.at(DIAGNOSTIC_FIELD_NAMES_KEY), std::string()));
-
-    // Combine all field names into a single set for easier checking later on
-    fieldNames = inputRestartFieldNames;
-    fieldNames.insert(outputRestartFieldNames.begin(), outputRestartFieldNames.end());
-    fieldNames.insert(era5ForcingFieldNames.begin(), era5ForcingFieldNames.end());
-    fieldNames.insert(diagnosticFieldNames.begin(), diagnosticFieldNames.end());
 }
 
 //! Initialize the XIOS context with ID contextId
@@ -850,6 +834,10 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         if (!cxios_is_defined_field_name(baseField)) {
             throw std::runtime_error("Xios: Failed to set name for field '" + fieldId + "'");
         }
+
+        // Set grid reference
+        ModelArray::Type& fieldType = fieldTypes[fieldId];
+        setFieldGridRef(fieldId, gridIds[fieldType]);
     }
 
     if (ioType == INPUT_RESTART || ioType == ERA5_FORCING || ioType == TOPAZ_FORCING) {
@@ -975,6 +963,10 @@ std::string Xios::createInputField(const std::string& fieldId, const int ioType)
         throw std::runtime_error("Xios: Failed to set name for input field '" + inputFieldId + "'");
     }
 
+    // Set grid reference
+    ModelArray::Type& fieldType = fieldTypes[inputFieldId];
+    setFieldGridRef(inputFieldId, gridIds[fieldType]);
+
     return inputFieldId;
 }
 
@@ -1031,23 +1023,6 @@ void Xios::setFieldFreqOffset(const std::string& fieldId, const Duration& freqOf
         throw std::runtime_error(
             "Xios: Failed to set frequency offset for field '" + fieldId + "'");
     }
-}
-
-/*!
- * Get the grid reference associated with a field with a given ID
- *
- * @param the field ID
- * @return grid reference used for the corresponding field
- */
-std::string Xios::getFieldGridRef(const std::string& fieldId)
-{
-    xios::CField* field = getField(fieldId);
-    if (!cxios_is_defined_field_grid_ref(field)) {
-        throw std::runtime_error("Xios: Undefined grid reference for field '" + fieldId + "'");
-    }
-    char cStr[cStrLen];
-    cxios_get_field_grid_ref(field, cStr, cStrLen);
-    return convertCStrToCppStr(cStr, cStrLen);
 }
 
 /*!
@@ -1112,7 +1087,6 @@ void Xios::setFieldType(
 {
     const std::string ioFieldId = getFieldIOId(fieldId, ioType);
     fieldTypes[ioFieldId] = fieldType;
-    setFieldGridRef(ioFieldId, gridIds[fieldType]);
 }
 
 /*!
@@ -1173,27 +1147,22 @@ void Xios::setupFields()
         };
 
         // Determine field types
-        std::set<std::string> configFieldIds;
         int ioType;
         if (filename == metadata.initialFileName) {
-            configFieldIds = inputRestartFieldNames;
             ioType = INPUT_RESTART;
         } else if (filename == era5ForcingFilename) {
-            configFieldIds = era5ForcingFieldNames;
             ioType = ERA5_FORCING;
         } else {
-            configFieldIds = topazForcingFieldNames;
             ioType = TOPAZ_FORCING;
         }
+
+        std::set<std::string> configFieldIds;
+        auto& modelMPI = ModelMPI::getInstance();
         try {
-            auto& modelMPI = ModelMPI::getInstance();
             netCDF::NcFilePar ncFile(filename, netCDF::NcFile::read, modelMPI.getComm());
 
             for (auto& [fieldId, var] : ncFile.getVars()) {
-                // Only consider fields that appear in the config
-                if (configFieldIds.count(fieldId) == 0) {
-                    continue;
-                }
+
                 // Determine the type from the dimensions
                 std::vector<netCDF::NcDim> varDims = var.getDims();
                 std::string dimKey = "";
@@ -1204,11 +1173,17 @@ void Xios::setupFields()
                         dimKey += dim.getName();
                     }
                 }
-                // Skip invalid dimension keys
+
+                // Skip invalid dimension keys, otherwise add to the corresponding config section
                 if (!dimensionKeys.count(dimKey)) {
                     continue;
                 }
-                setFieldType(fieldId, dimensionKeys.at(dimKey), ioType);
+                configFieldIds.insert(fieldId);
+
+                // Set the input field type and default the base field type correspondingly
+                ModelArray::Type fieldType = dimensionKeys.at(dimKey);
+                setFieldType(fieldId, fieldType, ioType);
+                setFieldType(fieldId, fieldType, NOT_READ);
             }
             ncFile.close();
         } catch (const netCDF::exceptions::NcException& nce) {
@@ -1216,7 +1191,20 @@ void Xios::setupFields()
             ncWhat += ": " + filename;
             throw std::runtime_error(ncWhat);
         }
+        if (filename == metadata.initialFileName) {
+            inputRestartFieldNames = configFieldIds;
+        } else if (filename == era5ForcingFilename) {
+            era5ForcingFieldNames = configFieldIds;
+        } else {
+            topazForcingFieldNames = configFieldIds;
+        }
     }
+
+    // Combine all field names into a single set for easier checking later on
+    fieldNames = inputRestartFieldNames;
+    fieldNames.insert(outputRestartFieldNames.begin(), outputRestartFieldNames.end());
+    fieldNames.insert(era5ForcingFieldNames.begin(), era5ForcingFieldNames.end());
+    fieldNames.insert(diagnosticFieldNames.begin(), diagnosticFieldNames.end());
 }
 
 /*!
@@ -1538,6 +1526,9 @@ void Xios::setupFiles()
                 "Xios::setupFiles: TOPAZ forcing and diagnostic file names must differ.");
         }
     }
+
+    // Setup fields before creating files because createFile creates the associated fields
+    setupFields();
 
     // Create files for any non-empty file IDs
     for (const std::string& fileId :

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -16,7 +16,6 @@
 #include "include/Logged.hpp"
 #include "include/ModelArray.hpp"
 #include "include/Time.hpp"
-#include "include/gridNames.hpp"
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/format.hpp>
 #include <boost/format/group.hpp>
@@ -74,17 +73,14 @@ public:
     size_t getAxisSize(const std::string& axisId);
 
     /* Field */
-    const std::set<std::string> era5ForcingFieldNames
-        = { "tair", "dew2m", "pair", "sw_in", "lw_in", "wind_speed", "u", "v" };
-    const std::set<std::string> topazForcingFieldNames
-        = { sstName, sssName, mldName, uName, vName, sshName };
+    std::set<std::string> era5ForcingFieldNames;
+    std::set<std::string> topazForcingFieldNames;
     void setPrognosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
     void setDiagnosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
 
     enum {
         ENABLED_KEY,
         OUTPUT_FIELD_NAMES_KEY,
-        INPUT_FIELD_NAMES_KEY,
         DIAGNOSTIC_PERIOD_KEY,
         DIAGNOSTIC_FILE_KEY,
         DIAGNOSTIC_FIELD_NAMES_KEY,
@@ -181,7 +177,6 @@ private:
     void setFieldReadAccess(const std::string& fieldId, const bool& readAccess);
     void setFieldGridRef(const std::string& fieldId, const std::string& gridRef);
     void setFieldFreqOffset(const std::string& fieldId, const Duration& freqOffset);
-    std::string getFieldGridRef(const std::string& fieldId);
     bool getFieldReadAccess(const std::string& fieldId);
     Duration getFieldFreqOffset(const std::string& fieldId);
     ModelArray::Type getFieldType(const std::string& fieldId);

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -73,8 +73,6 @@ public:
     size_t getAxisSize(const std::string& axisId);
 
     /* Field */
-    std::set<std::string> era5ForcingFieldNames;
-    std::set<std::string> topazForcingFieldNames;
     void setPrognosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
     void setDiagnosticFieldType(const std::string& fieldId, const ModelArray::Type& type);
 
@@ -169,6 +167,8 @@ private:
     std::set<std::string> outputRestartFieldNames;
     std::set<std::string> inputRestartFieldNames;
     std::set<std::string> diagnosticFieldNames;
+    std::set<std::string> era5ForcingFieldNames;
+    std::set<std::string> topazForcingFieldNames;
     std::set<std::string> fieldNames;
     void createField(const std::string& fieldId, const std::string& fileId);
     std::string getFieldIOId(const std::string& fieldId, const int ioType);

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -76,7 +76,7 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 3)
     //       StructureFactory::stateFromFile()
     for (const auto [fieldName, modelarray] :
         StructureFactory::stateFromFile(diagnosticFilename).data) {
-        REQUIRE(fieldName == hsnowName);
+        REQUIRE(fieldName == sssName);
         for (size_t j = 0; j < ny; ++j) {
             for (size_t i = 0; i < nx; ++i) {
                 REQUIRE(modelarray(i, j) == doctest::Approx(0.15));

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -43,9 +43,6 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 3)
     config << "init_file = " << diagnosticFilename << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "partition_file = xios_test_partition_metadata_3.nc" << std::endl;
-    config << "[XiosInput]" << std::endl;
-    config << "field_names = " << hsnowName << std::endl;
-    config << "period = P0-0T03:00:00" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -145,7 +145,7 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
                     }
                 }
             }
-        } else if (fieldName == uName) {
+        } else if (fieldName == shearName) {
             for (size_t j = 0; j < CGDEGREE * ny + 1; ++j) {
                 for (size_t i = 0; i < CGDEGREE * nx + 1; ++i) {
                     if (rank == 0) {

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -97,6 +97,12 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
                 }
             }
         } else if (fieldName == gridAzimuthName) {
+            for (size_t j = 0; j < ny; ++j) {
+                for (size_t i = 0; i < nx; ++i) {
+                    REQUIRE(modelarray(i, j) == doctest::Approx(0.0));
+                }
+            }
+        } else if (fieldName == coordsName) {
             for (size_t j = 0; j < ny + 1; ++j) {
                 for (size_t i = 0; i < nx + 1; ++i) {
                     float expected_x;
@@ -139,7 +145,7 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
                     }
                 }
             }
-        } else if (fieldName == uName) {
+        } else if (fieldName == shearName) {
             for (size_t j = 0; j < CGDEGREE * ny + 1; ++j) {
                 for (size_t i = 0; i < CGDEGREE * nx + 1; ++i) {
                     if (rank == 0) {

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -41,10 +41,6 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     config << "init_file = " << restartFilename << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
-    config << "[XiosInput]" << std::endl;
-    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
-           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -41,10 +41,6 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     config << "init_file = " << restartFilename << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
-    config << "[XiosInput]" << std::endl;
-    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -43,10 +43,6 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     config << "restart_file = " << outputFilename << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
-    config << "[XiosInput]" << std::endl;
-    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
            << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -43,10 +43,6 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     config << "restart_file = " << outputFilename << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
-    config << "[XiosInput]" << std::endl;
-    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
-           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
            << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -46,7 +46,8 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
            << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
-           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << damageName << "," << hsnowName << "," << ticeName << "," << shearName << ","
+           << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -45,8 +45,9 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << shearName << ","
+           << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -44,7 +44,7 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosDiagnostic]" << std::endl;
     config << "filename = " << diagnosticFilename << std::endl;
-    config << "field_names = " << hsnowName << std::endl;
+    config << "field_names = " << sssName << std::endl;
     config << "period = P0-0T03:00:00" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
@@ -76,27 +76,9 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     ParaGridIO* pio = new ParaGridIO(grid);
     grid.setIO(pio);
 
-    // Set field type for diagnostics
-    xiosHandler.setDiagnosticFieldType(hsnowName, ModelArray::Type::H);
-
     // Create some fake data to test writing methods
-    HField mask(ModelArray::Type::H);
-    mask.resize();
-    for (size_t j = 0; j < ny; ++j) {
-        for (size_t i = 0; i < nx; ++i) {
-            mask(i, j) = j >= 1 ? 1.0 : 0.0;
-        }
-    }
-    VertexField coordinates(ModelArray::Type::VERTEX);
-    coordinates.resize();
-    DGField hice(ModelArray::Type::DG);
-    hice.resize();
-    DGSField tice(ModelArray::Type::DGSTRESS);
-    tice.resize();
-    CGField uice(ModelArray::Type::CG);
-    uice.resize();
-    HField hsnow(ModelArray::Type::H);
-    hsnow.resize();
+    HField sss(ModelArray::Type::H);
+    sss.resize();
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("diagnostic*.nc"));
@@ -114,13 +96,13 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
         // Update diagnostics
         for (size_t j = 0; j < ny; ++j) {
             for (size_t i = 0; i < nx; ++i) {
-                hsnow(i, j) = 0.1 * ts;
+                sss(i, j) = 0.1 * ts;
             }
         }
 
         // Set up ModelStates for diagnostics and write out
         ModelState diagnostics = { {
-                                       { hsnowName, hsnow },
+                                       { sssName, sss },
                                    },
             {} };
         pio->writeDiagnosticTime(diagnostics, diagnosticFilename);

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -44,7 +44,7 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosDiagnostic]" << std::endl;
     config << "filename = " << diagnosticFilename << std::endl;
-    config << "field_names = " << hsnowName << std::endl;
+    config << "field_names = " << sssName << std::endl;
     config << "period = P0-0T03:00:00" << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
@@ -76,12 +76,9 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     ParaGridIO* pio = new ParaGridIO(grid);
     grid.setIO(pio);
 
-    // Set field type for diagnostics
-    xiosHandler.setDiagnosticFieldType(hsnowName, ModelArray::Type::H);
-
     // Create some fake data to test writing methods
-    HField hsnow(ModelArray::Type::H);
-    hsnow.reinitialize();
+    HField sss(ModelArray::Type::H);
+    sss.reinitialize();
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("diagnostic*.nc"));
@@ -99,13 +96,13 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
         // Update diagnostics
         for (size_t j = 0; j < ny; ++j) {
             for (size_t i = 0; i < nx; ++i) {
-                hsnow(i, j) = 0.1 * ts;
+                sss(i, j) = 0.1 * ts;
             }
         }
 
         // Set up ModelStates for diagnostics and write out
         ModelState diagnostics = { {
-                                       { hsnowName, hsnow },
+                                       { sssName, sss },
                                    },
             {} };
         pio->writeDiagnosticTime(diagnostics, diagnosticFilename);

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -45,8 +45,9 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     config << "restart_period = P0-0T03:00:00" << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << gridAzimuthName << "," << ciceName << "," << hiceName << "," << damageName << ","
-           << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
+           << damageName << "," << hsnowName << "," << ticeName << "," << shearName << ","
+           << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -77,13 +78,14 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
+    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
     xiosHandler.setPrognosticFieldType(ciceName, ModelArray::Type::DG);
     xiosHandler.setPrognosticFieldType(hiceName, ModelArray::Type::DG);
     xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::DG);
     xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::Type::DG);
-    xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::VERTEX);
+    xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
-    xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);
+    xiosHandler.setPrognosticFieldType(shearName, ModelArray::Type::CG);
 
     // Create some fake data to test writing methods
     HField longitude(ModelArray::Type::H);
@@ -119,6 +121,9 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
             mask(i, j) = (i == 0 && j == 0 ? 0.0 : 1.0);
         }
     }
+    HField grid_azimuth(ModelArray::Type::H);
+    grid_azimuth.resize();
+    grid_azimuth = 0.0;
     DGField cice(ModelArray::Type::DG);
     cice.resize();
     DGField hice(ModelArray::Type::DG);
@@ -127,12 +132,12 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     damage.resize();
     DGField hsnow(ModelArray::Type::DG);
     hsnow.resize();
-    VertexField grid_azimuth(ModelArray::Type::VERTEX);
-    grid_azimuth.resize();
+    VertexField coords(ModelArray::Type::VERTEX);
+    coords.resize();
     DGSField tice(ModelArray::Type::DGSTRESS);
     tice.resize();
-    CGField uice(ModelArray::Type::CG);
-    uice.resize();
+    CGField shear(ModelArray::Type::CG);
+    shear.resize();
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("restart*.nc"));
@@ -166,11 +171,11 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
         for (size_t j = 0; j < ny + 1; ++j) {
             for (size_t i = 0; i < nx + 1; ++i) {
                 if (rank == 0) {
-                    grid_azimuth.components({ i, j })[0] = 1.0 * ts * i;
-                    grid_azimuth.components({ i, j })[1] = 1.0 * ts * j;
+                    coords.components({ i, j })[0] = 1.0 * ts * i;
+                    coords.components({ i, j })[1] = 1.0 * ts * j;
                 } else {
-                    grid_azimuth.components({ i, j })[0] = 1.0 * ts * (i + 2);
-                    grid_azimuth.components({ i, j })[1] = 1.0 * ts * j;
+                    coords.components({ i, j })[0] = 1.0 * ts * (i + 2);
+                    coords.components({ i, j })[1] = 1.0 * ts * j;
                 }
             }
         }
@@ -221,7 +226,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                 } else {
                     value = (i == 1 && j == 1) ? NAN : 1.0 * ts * ((i + 5) * (j + 1));
                 }
-                uice(i, j) = value;
+                shear(i, j) = value;
             }
         }
 
@@ -230,13 +235,14 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                                     { maskName, mask },
                                     { longitudeName, longitude },
                                     { latitudeName, latitude },
+                                    { gridAzimuthName, grid_azimuth },
                                     { ciceName, cice },
                                     { hiceName, hice },
                                     { damageName, damage },
                                     { hsnowName, hsnow },
-                                    { gridAzimuthName, grid_azimuth },
+                                    { coordsName, coords },
                                     { ticeName, tice },
-                                    { uName, uice },
+                                    { shearName, shear },
                                 },
             {} };
         StructureFactory::fileFromState(restarts, outputFilename, true);

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -94,7 +94,8 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     }
     HField grid_azimuth(ModelArray::Type::H);
     grid_azimuth.reinitialize();
-    grid_azimuth = 0;
+    grid_azimuth = 0.0;
+
     /*
      * Mask definition, where 0 indicates land and 1 indicates ocean:
      *

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -43,14 +43,11 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     config << "restart_file = " << outputFilename << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
-    config << "[XiosInput]" << std::endl;
-    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
-           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
     config << "[XiosOutput]" << std::endl;
     config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
            << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
-           << damageName << "," << hsnowName << "," << ticeName << "," << uName << "," << std::endl;
+           << damageName << "," << hsnowName << "," << ticeName << "," << shearName << ","
+           << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -78,7 +75,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
 
     // Set field types for restarts
     xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
-    xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::CG);
+    xiosHandler.setPrognosticFieldType(shearName, ModelArray::Type::CG);
 
     // Create some fake data to test writing methods
     HField longitude(ModelArray::Type::H);
@@ -98,7 +95,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     HField grid_azimuth(ModelArray::Type::H);
     grid_azimuth.reinitialize();
     grid_azimuth = 0;
-
     /*
      * Mask definition, where 0 indicates land and 1 indicates ocean:
      *
@@ -130,8 +126,8 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     coords.reinitialize();
     DGSField tice(ModelArray::Type::DGSTRESS);
     tice.reinitialize();
-    CGField uice(ModelArray::Type::CG);
-    uice.reinitialize();
+    CGField shear(ModelArray::Type::CG);
+    shear.reinitialize();
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("restart*.nc"));
@@ -220,7 +216,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                 } else {
                     value = (i == 1 && j == 1) ? NAN : 1.0 * ts * ((i + 5) * (j + 1));
                 }
-                uice(i, j) = value;
+                shear(i, j) = value;
             }
         }
 
@@ -236,7 +232,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                                     { hsnowName, hsnow },
                                     { coordsName, coords },
                                     { ticeName, tice },
-                                    { uName, uice },
+                                    { shearName, shear },
                                 },
             {} };
         StructureFactory::fileFromState(restarts, outputFilename, true);

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -54,9 +54,6 @@ variables:
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
-	float grid_azimuth(y_dim, x_dim) ;
-		grid_azimuth:online_operation = "once" ;
-		grid_azimuth:coordinates = "lat lon" ;
 	float sss(y_dim, x_dim) ;
 		sss:online_operation = "once" ;
 		sss:coordinates = "lat lon" ;
@@ -112,10 +109,6 @@ data:
  mask =
   0, 1, 0, 1,
   1, 1, 1, 1 ;
-
- grid_azimuth =
-  0, 0, 0, 0,
-  0, 0, 0, 0 ;
 
  sss =
   _, _, _, _,

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -54,6 +54,9 @@ variables:
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
+	float sss(y_dim, x_dim) ;
+		sss:online_operation = "once" ;
+		sss:coordinates = "lat lon" ;
   // DGField variables
   float cice(y_dim, x_dim, dg_comp) ;
 		cice:online_operation = "once" ;
@@ -106,6 +109,10 @@ data:
  mask =
   0, 1, 0, 1,
   1, 1, 1, 1 ;
+
+ sss =
+  _, _, _, _,
+  _, _, _, _ ;
 
  // DGField variables
 

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -51,6 +51,9 @@ variables:
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
+	float grid_azimuth(y_dim, x_dim) ;
+		grid_azimuth:online_operation = "once" ;
+		grid_azimuth:coordinates = "lat lon" ;
 	float sss(y_dim, x_dim) ;
 		sss:online_operation = "once" ;
 		sss:coordinates = "lat lon" ;
@@ -68,17 +71,17 @@ variables:
 		hsnow:online_operation = "once" ;
 		hsnow:coordinates = "lat lon dg_comp" ;
   // VertexField variables
-	float grid_azimuth(y_vertex, x_vertex, ncoords) ;
-		grid_azimuth:online_operation = "once" ;
-		grid_azimuth:coordinates = "lat lon ncoords" ;
+	float coords(y_vertex, x_vertex, ncoords) ;
+		coords:online_operation = "once" ;
+		coords:coordinates = "lat lon ncoords" ;
   // DGStressField variables
 	float tice(y_dim, x_dim, dgstress_comp) ;
 		tice:online_operation = "once" ;
 		tice:coordinates = "lat lon dgstress_comp" ;
   // CGField variables
-	float u(y_cg, x_cg) ;
-		u:online_operation = "once" ;
-		u:coordinates = "lat lon" ;
+	float shear(y_cg, x_cg) ;
+		shear:online_operation = "once" ;
+		shear:coordinates = "lat lon" ;
 
 // global attributes:
 		:structure_name = "parametric_rectangular" ;
@@ -102,6 +105,10 @@ data:
  mask =
   0, 1, 0, 1,
   1, 1, 1, 1 ;
+
+ grid_azimuth =
+  0, 0, 0, 0,
+  0, 0, 0, 0 ;
 
  sss =
   _, _, _, _,
@@ -151,7 +158,7 @@ data:
 
  // VertexField variables
 
- grid_azimuth =
+ coords =
   0, 0,
   1, 0,
   2, 0,
@@ -182,7 +189,7 @@ data:
 
  // CGField variables
 
- u =
+ shear =
   NaN, NaN, 3, 4, 5, NaN, 7, 8, 9,
   NaN, NaN, 6, 8, 10, NaN, 14, 16, 18,
   3, 6, 9, 12, 15, 18, 21, 24, 27,

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -54,6 +54,9 @@ variables:
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
+	float grid_azimuth(y_dim, x_dim) ;
+		grid_azimuth:online_operation = "once" ;
+		grid_azimuth:coordinates = "lat lon" ;
 	float sss(y_dim, x_dim) ;
 		sss:online_operation = "once" ;
 		sss:coordinates = "lat lon" ;
@@ -79,9 +82,9 @@ variables:
 		tice:online_operation = "once" ;
 		tice:coordinates = "lat lon dgstress_comp" ;
   // CGField variables
-	float u(y_cg, x_cg) ;
-		u:online_operation = "once" ;
-		u:coordinates = "lat lon" ;
+	float shear(y_cg, x_cg) ;
+		shear:online_operation = "once" ;
+		shear:coordinates = "lat lon" ;
 
 // global attributes:
 		:structure_name = "parametric_rectangular" ;
@@ -109,6 +112,10 @@ data:
  mask =
   0, 1, 0, 1,
   1, 1, 1, 1 ;
+
+ grid_azimuth =
+  0, 0, 0, 0,
+  0, 0, 0, 0 ;
 
  sss =
   _, _, _, _,
@@ -189,7 +196,7 @@ data:
 
  // CGField variables
 
- u =
+ shear =
   NaN, NaN, 3, 4, 5, NaN, 7, 8, 9,
   NaN, NaN, 6, 8, 10, NaN, 14, 16, 18,
   3, 6, 9, 12, 15, 18, 21, 24, 27,

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -51,6 +51,9 @@ variables:
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
+	float sss(y_dim, x_dim) ;
+		sss:online_operation = "once" ;
+		sss:coordinates = "lat lon" ;
   // DGField variables
   float cice(y_dim, x_dim, dg_comp) ;
 		cice:online_operation = "once" ;
@@ -99,6 +102,10 @@ data:
  mask =
   0, 1, 0, 1,
   1, 1, 1, 1 ;
+
+ sss =
+  _, _, _, _,
+  _, _, _, _ ;
 
  // DGField variables
 

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -95,8 +95,8 @@ building without XIOS. That is, the ``model`` section should include
   restart_period = P0-0T02:00:00
 
 Information related to fields to be written to files are currently configured
-via the ``XiosOutput``, and ``XiosDiagnostic`` sections, where the first two
-refer to restarts. Note that both of these sections are optional. Moreover, they
+via the ``XiosOutput`` section (for restart files), and ``XiosDiagnostic`` section (for diagnostic files). 
+Note that both of these sections are optional. Moreover, they
 provide an interim solution. Eventually, it will not be necessary to provide
 XIOS-specific configuration information.
 

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -94,10 +94,11 @@ building without XIOS. That is, the ``model`` section should include
   restart_file = my_restart_file.nc
   restart_period = P0-0T02:00:00
 
-Information related to fields to be read from and written to files are
-configured via the ``XiosInput``, ``XiosOutput``, and ``XiosDiagnostic``
-sections, where the first two refer to restarts. Note that all of these sections
-are optional.
+Information related to fields to be written to files are currently configured
+via the ``XiosOutput``, and ``XiosDiagnostic`` sections, where the first two
+refer to restarts. Note that both of these sections are optional. Moreover, they
+provide an interim solution. Eventually, it will not be necessary to provide
+XIOS-specific configuration information.
 
 For restart files, the filename is determined from the ``restart_file`` entry in
 the ``model`` section mentioned above. In the case of diagnostics files, the
@@ -120,9 +121,9 @@ time window, whereas diagnostics files are averaged over the timesteps in the
 window.
 
 In addition to specifying file names, we need to specify which fields are to be
-read or written using each I/O type. For example, we could specify that two
-fields labelled ``field_A`` and ``field_B`` are to be written into restart files
-as follows:
+written using each I/O type. For example, we could specify that two fields
+labelled ``field_A`` and ``field_B`` are to be written into restart files as
+follows:
 
 .. code-block::
 
@@ -130,16 +131,15 @@ as follows:
   field_names = field_A,field_B
 
 The ``field_names`` entry may contain a single field name or a comma-separated
-list.
+list. Note that this is an interim solution. Eventually, it will not be
+necessary to provide field names to configure XIOS.
 
 As elsewhere in the model, the configuration values above are all parsed by
 calling the ``Model.configure()`` member function. Note that this function will
 automatically initialize the model state based on the ``input_file`` entry and
-any ``field_names`` listed in the ``[XiosInput]`` configuration section. You
-will need to ensure that variables defining the grid are read here, i.e.,
-``longitude`` and ``latitude`` and possibly ``coords`` and ``grid_azimuth``. The
-XIOS I/O implementation does not currently support Cartesian grids (based on
-``x_dim`` and ``y_dim``).
+all field variables found in that file, including variables defining the grid
+i.e., ``longitude`` and ``latitude`` and possibly ``coords`` and
+``grid_azimuth``.
 
 Forcing files
 -------------


### PR DESCRIPTION
# XIOS: read all inputs

Towards #1056

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

This PR avoids the need for an `XiosInput` configuration section. Instead, XIOS reads all field variables that it finds in any input files whose names are provided.

---
# Test Description

XIOS tests are updated to account for this change. Some tweaks were required to avoid the same variable name (`u`) being read from both restarts and forcings.

---
# Documentation Impact

The XIOS docs page has been update accordingly.