### PR TITLE
Minimal changes to get snapshot diagnostics working again.

### DIFF
--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -48,7 +48,7 @@ ConfigOutput::ConfigOutput()
     , lastOutput(defaultLastOutput)
     , fieldsForOutput()
     , currentFileName()
-    , snapshots(false)
+    , snapshots(true)
     , resetState(true)
 {
 }
@@ -160,8 +160,7 @@ void ConfigOutput::outputState(const ModelState& diagState)
     }
 
     double averagingFactor = meta.stepLength().seconds() / outputPeriod.seconds();
-    if (resetState)
-        state = { {}, diagState.config };
+    ModelState state = { {}, diagState.config };
     auto storeData = ModelComponent::getStore().getAllData();
     if (outputAllTheFields) {
         // If the internal to external name lookup table is still empty, fill it
@@ -181,27 +180,9 @@ void ConfigOutput::outputState(const ModelState& diagState)
             if (entry.second && entry.second->trueSize()) {
                 std::string key;
                 if (reverseExternalNames.count(entry.first)) {
-                    key = reverseExternalNames.at(entry.first);
+                    state.data[reverseExternalNames.at(entry.first)] = *entry.second;
                 } else {
-                    key = entry.first;
-                }
-                if (snapshots || everyTS) {
-                    state.data[key] = *entry.second;
-                } else {
-                    /* Averaging the DG components doesn't make sense, so we only take the mean
-                     * component. This does require an extra copy, though. The DG components are not
-                     * masked ether, so we apply the mask to the copy. */
-                    ModelArray data;
-                    if (entry.second->getType() == ModelArray::Type::DG) {
-                        data = ModelArray(ModelArray::Type::H);
-                        data.setData(entry.second->component(0));
-                    } else {
-                        data = *entry.second;
-                    }
-                    if (resetState)
-                        state.data[key] = mask(data) * averagingFactor;
-                    else
-                        state.data.at(key) += mask(data) * averagingFactor;
+                    state.data[entry.first] = *entry.second;
                 }
             }
         }
@@ -218,25 +199,7 @@ void ConfigOutput::outputState(const ModelState& diagState)
         for (const auto& fieldExtName : fieldsForOutput) {
             if (externalNames.count(fieldExtName) && storeData.count(externalNames.at(fieldExtName))
                 && storeData.at(externalNames.at(fieldExtName))) {
-                if (snapshots || everyTS) {
-                    state.data[fieldExtName] = *storeData.at(externalNames.at(fieldExtName));
-                } else {
-                    /* Averaging the DG components doesn't make sense, so we only take the mean
-                     * component. This does require an extra copy, though. The DG components are not
-                     * masked ether, so we apply the mask to the copy. */
-                    const std::string& key = externalNames.at(fieldExtName);
-                    ModelArray data;
-                    if (storeData.at(key)->getType() == ModelArray::Type::DG) {
-                        data = ModelArray(ModelArray::Type::H);
-                        data.setData(storeData.at(key)->component(0));
-                    } else {
-                        data = *storeData.at(key);
-                    }
-                    if (resetState)
-                        state.data[fieldExtName] = mask(data) * averagingFactor;
-                    else
-                        state.data.at(fieldExtName) += mask(data) * averagingFactor;
-                }
+                state.data[fieldExtName] = *storeData.at(externalNames.at(fieldExtName));
             }
         }
     }
@@ -255,9 +218,6 @@ void ConfigOutput::outputState(const ModelState& diagState)
         meta.affixCoordinates(state);
         StructureFactory::fileFromState(state, currentFileName, false);
         lastOutput = meta.time();
-        resetState = true;
-    } else {
-        resetState = false;
     }
 }
 

--- a/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
@@ -67,8 +67,6 @@ private:
 
     std::map<std::string, std::string> reverseExternalNames;
 
-    ModelState state;
-
     bool snapshots;
     bool resetState;
 };

--- a/core/test/ConfigOutput_test.cpp
+++ b/core/test/ConfigOutput_test.cpp
@@ -76,28 +76,15 @@ void runMe(const bool snapshot)
     Module::Module<IDiagnosticOutput>::setImplementation("Nextsim::ConfigOutput");
     std::stringstream config;
     config << "[ConfigOutput]" << std::endl;
-    config << "period = P0-0T03:00:00" << std::endl; // Output every three hours
+    config << "period = 3600" << std::endl; // Output every hour
     config << "start = 2020-01-11T00:00:00Z" << std::endl; // start after 10 days
     config << "field_names = " << hiceName << "," << ciceName << "," << tsurfName << ","
            << "top_melt" << std::endl;
     config << "filename = diag%m%d.nc" << std::endl;
     config << "file_period = 86400" << std::endl; // Files every day
-    if (snapshot)
-        config << "snapshots = true" << std::endl;
-    else
-        config << "snapshots = false" << std::endl;
 
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
-    /* We need to clear() the Configurator cache here, because this is called multiple times within
-     * the test suite. */
-    Configurator::clear();
     Configurator::addStream(std::move(pcstream));
-
-    /* We need to set the model time step in the ModelMetadata instance, but are forced to set
-     * starting time and duration as well, even though it's not used. */
-    const Duration timeStep = Duration(3600.);
-    auto& metadata = ModelMetadata::getInstance();
-    metadata.setTimes(TimePoint("2010-01-01"), Duration("P0-24T00:00:00"), timeStep);
 
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
 
@@ -187,7 +174,7 @@ void runMe(const bool snapshot)
             ModelState state = { { { "top_melt", topMelt } }, {} };
 
             ido.outputState(state);
-            meta.incrementTime(timeStep);
+            meta.incrementTime(Duration(3600.));
         }
     }
 
@@ -204,8 +191,7 @@ void runMe(const bool snapshot)
     // // No output should occur before the designated start date
     REQUIRE(!std::filesystem::exists(pfx + "10" + sfx));
 
-    const int day = 14;
-    const std::string specFile = diagFiles[day - 1 - 10]; // We only write files after day 10
+    const std::string specFile = diagFiles[5];
     std::set<std::string> fields = { "hice", "cice", "tsurf", "top_melt" };
 
     // Read the netCDF file directly
@@ -215,7 +201,7 @@ void runMe(const bool snapshot)
     netCDF::NcDim timeDim = ncFile.getDim(timeName);
     // Read the time variable
     netCDF::NcVar timeVar = ncFile.getVar(timeName);
-    REQUIRE(timeDim.getSize() == hr_day / 3);
+    REQUIRE(timeDim.getSize() == hr_day);
 
     std::multimap<std::string, netCDF::NcVar> vars(ncFile.getVars());
     REQUIRE(vars.size() == fields.size() + 1 + 4); // +1 for the time variable + 4 for the coords
@@ -224,23 +210,6 @@ void runMe(const bool snapshot)
     }
     REQUIRE(vars.count("time") == 1);
     REQUIRE(vars.count("hsnow") == 0);
-
-    const netCDF::NcVar& var = ncFile.getVar("cice");
-    std::vector<double> conc(nx * ny * 24 / 3);
-    var.getVar(&conc[0]);
-
-    constexpr int i = 3;
-    constexpr int j = 4;
-    // 100 per day, 1 per hour, 0.1 per variable, 0.01 per grid point
-    const double coordComponent = 0.1 + 0.01 * (j * nx + (i + offsetX));
-    double expectedValue = (100 + 24) * (day - 1) + 101 + coordComponent;
-    if (!snapshot) {
-        // First value in the average is three hours before the output and one day increment after
-        expectedValue += (100 + 24) * (day - 2) + 123 + coordComponent;
-        expectedValue += (100 + 24) * (day - 1) + coordComponent;
-        expectedValue /= 3; // Average over three outputs
-    }
-    REQUIRE(conc[j * nx + i + offsetX] == doctest::Approx(expectedValue));
 
     ncFile.close();
 
@@ -253,12 +222,6 @@ void runMe(const bool snapshot)
 }
 
 TEST_SUITE_BEGIN("ConfigOutput");
-#ifdef USE_MPI
-MPI_TEST_CASE("Test averaged output", 2) { runMe(false, test_comm); }
-#else
-TEST_CASE("Test averaged output") { runMe(false); }
-#endif
-
 #ifdef USE_MPI
 MPI_TEST_CASE("Test snapshot output", 2) { runMe(true, test_comm); }
 #else


### PR DESCRIPTION
# Minimal changes to undo PR #827
Fixes #827 not working

### Task List
- [ ] Linked an issue above that captures the requirements of this PR
- [ ] Defined the tests that specify a complete and functioning change
- [*] Implemented the source code change that satisfies the tests
- [ ] Commented all code so that it can be understood without additional context
- [*] No new warnings are generated or they are mentioned below
- [ ] The documentation has been updated (or an issue has been created to do so)
- [ ] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [ ] This change conforms to the conventions described in the README

---
# Change Description

After PR #827, neither the averaged nor the snapshot diagnostics have been working for me. This PR includes the minimal changes to get snapshot diagnostics (which are now the default) working correctly again.

A subsequent PR will add this functionality back, but (hopefully) working.

---
# Test Description

Ran jun23, and obtained diagnostic files that didn't look like a dump of random areas of model memory.
