### PR TITLE
Issue 827 Average diag

### DIFF
--- a/core/src/include/Time.hpp
+++ b/core/src/include/Time.hpp
@@ -180,7 +180,7 @@ public:
     TimePoint()
         : m_t() {};
     TimePoint(const std::string& str) { this->parse(str); }
-    TimePoint(const TimePoint&, const Duration&);
+    TimePoint(const TimePoint& t, const Duration& d) { m_t = (t + d).m_t; }
 
     //! Calculate the Duration between two TimePoints.
     Duration operator-(const TimePoint& a) const { return Duration(m_t - a.m_t); }

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -47,8 +47,8 @@ ConfigOutput::ConfigOutput()
     , lastOutput(defaultLastOutput)
     , fieldsForOutput()
     , currentFileName()
-    , snapshots(true)
-    , resetState(true)
+    , accumulator()
+    , n_accum(0)
 {
 }
 
@@ -201,6 +201,16 @@ void ConfigOutput::outputState(const ModelState& diagState)
         }
     }
 
+    // Accumulate data. Assumes the same data is received every time.
+    for (auto& entry: state.data) {
+        if (accumulator.count(entry.first) <= 0) {
+            accumulator[entry.first] = entry.second;
+        } else {
+            accumulator.at(entry.first) += entry.second;
+        }
+    }
+    ++n_accum;
+
     /*
      * Produce output either:
      *    • on every timestep after the start time initially stored in lastOutput
@@ -213,8 +223,18 @@ void ConfigOutput::outputState(const ModelState& diagState)
         Logged::info("ConfigOutput: Outputting " + std::to_string(state.data.size()) + " fields to "
             + currentFileName + " at " + meta.time().format() + "\n");
         meta.affixCoordinates(state);
-        StructureFactory::fileFromState(state, currentFileName, false);
+        double div = 1./n_accum;
+        for (auto &entry : accumulator) {
+            entry.second *= div;
+        }
+        n_accum = 0;
+        ModelState outputState = { accumulator, {} };
+
+        StructureFactory::fileFromState(outputState, currentFileName, false);
         lastOutput = meta.time();
+        for (auto &entry : accumulator) {
+            entry.second *= 0.;
+        }
     }
 }
 

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -51,12 +51,14 @@ ConfigOutput::ConfigOutput()
 ConfigurationHelp::HelpMap& ConfigOutput::getHelpText(HelpMap& map, bool getAll)
 {
     map[pfx] = {
-        { periodKey, ConfigType::STRING, {}, "", "", "Time between samples of the output data." },
+        { periodKey, ConfigType::STRING, {}, "", "", "Time between samples of the averaged data."
+                " Also the averaging period over which data is accumulated." },
         { startKey, ConfigType::STRING, {}, "model.start", "",
-            "Date at which to start outputting data." },
+            "Date at which to start averaging data."
+            " The first output will occur " + periodKey + " later." },
         { fieldNamesKey, ConfigType::STRING, {}, "ALL", "",
             "Comma separated, space free list of fields to be output. "
-            "The special value \""
+            " The special value \""
                 + all + "\" will output all available fields." },
         { fileNameKey, ConfigType::STRING, {}, "", "",
             "Filename pattern for the output diagnostic files. Date and time elements can be "
@@ -86,9 +88,6 @@ void ConfigOutput::configure()
         lastOutput = ModelMetadata::getInstance().startTime();
     } else {
         lastOutput.parse(startString);
-        if (!everyTS) {
-            lastOutput -= outputPeriod;
-        }
     }
 
     std::string outputFields
@@ -190,16 +189,17 @@ void ConfigOutput::outputState(const ModelState& diagState)
             }
         }
     }
-
-    // Accumulate data. Assumes the same data is received every time.
-    for (auto& entry: state.data) {
-        if (accumulator.count(entry.first) <= 0) {
-            accumulator[entry.first] = entry.second;
-        } else {
-            accumulator.at(entry.first) += entry.second;
+    // Accumulate data after the output start time. Assumes the same data is received every time.
+    if (meta.time() > lastOutput) {
+        for (auto& entry: state.data) {
+            if (accumulator.count(entry.first) <= 0) {
+                accumulator[entry.first] = entry.second;
+            } else {
+                accumulator.at(entry.first) += entry.second;
+            }
         }
+        ++n_accum;
     }
-    ++n_accum;
 
     /*
      * Produce output either:
@@ -222,9 +222,7 @@ void ConfigOutput::outputState(const ModelState& diagState)
         meta.affixCoordinates(outputState);
         StructureFactory::fileFromState(outputState, currentFileName, false);
         lastOutput = meta.time();
-        for (auto &entry : accumulator) {
-            entry.second *= 0.;
-        }
+        accumulator.clear();
     }
 }
 

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -57,8 +57,6 @@ ConfigurationHelp::HelpMap& ConfigOutput::getHelpText(HelpMap& map, bool getAll)
         { periodKey, ConfigType::STRING, {}, "", "", "Time between samples of the output data." },
         { startKey, ConfigType::STRING, {}, "model.start", "",
             "Date at which to start outputting data." },
-        { snapshotKey, ConfigType::BOOLEAN, { "true", "false" }, "false", "",
-            "Output snapshots. Otherwise, output-period averages are output." },
         { fieldNamesKey, ConfigType::STRING, {}, "ALL", "",
             "Comma separated, space free list of fields to be output. "
             "The special value \""

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -25,9 +25,6 @@ static const std::string fieldNamesKey = pfx + ".field_names";
 static const std::string fileNameKey = pfx + ".filename";
 static const std::string filePeriodKey = pfx + ".file_period";
 
-// Access the model.start key. There's no clean way of getting this from Model, I think.
-static const std::string modelStartKey = "model.start";
-
 static const std::map<int, std::string> keyMap = {
     { ConfigOutput::PERIOD_KEY, periodKey },
     { ConfigOutput::START_KEY, startKey },
@@ -85,10 +82,7 @@ void ConfigOutput::configure()
     }
     std::string startString = Configured::getConfiguration(keyMap.at(START_KEY), std::string(""));
     if (startString.empty()) {
-        startString = Configured::getConfiguration(modelStartKey, std::string(""));
-        if (startString.empty())
-            // If you start the model before 1st January year 0, tough.
-            lastOutput.parse(defaultLastOutput);
+        lastOutput = ModelMetadata::getInstance().startTime();
     } else {
         lastOutput.parse(startString);
         if (!everyTS) {

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -32,7 +32,6 @@ static const std::string modelStartKey = "model.start";
 static const std::map<int, std::string> keyMap = {
     { ConfigOutput::PERIOD_KEY, periodKey },
     { ConfigOutput::START_KEY, startKey },
-    { ConfigOutput::SNAPSHOT_KEY, snapshotKey },
     { ConfigOutput::FIELDNAMES_KEY, fieldNamesKey },
     { ConfigOutput::FILENAME_KEY, fileNameKey },
     { ConfigOutput::FILEPERIOD_KEY, filePeriodKey },
@@ -99,8 +98,6 @@ void ConfigOutput::configure()
             lastOutput -= outputPeriod;
         }
     }
-
-    snapshots = Configured::getConfiguration(keyMap.at(SNAPSHOT_KEY), false);
 
     std::string outputFields
         = Configured::getConfiguration(keyMap.at(FIELDNAMES_KEY), std::string(""));
@@ -219,15 +216,6 @@ void ConfigOutput::outputState(const ModelState& diagState)
         StructureFactory::fileFromState(state, currentFileName, false);
         lastOutput = meta.time();
     }
-}
-
-std::string concatenateFields(const std::set<std::string>& strSet)
-{
-    std::string outStr = "";
-    for (auto& str : strSet) {
-        outStr += str + ",";
-    }
-    return outStr;
 }
 
 } /* namespace Nextsim */

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -146,7 +146,6 @@ void ConfigOutput::outputState(const ModelState& diagState)
     if (currentFileName == "" || (lastFileChange + fileChangePeriod <= time)) {
         std::string newFileName = time.format(m_filePrefix) + ".nc";
         if (newFileName != currentFileName) {
-            // TODO: Close the file currentFileName
             FileCallbackCloser::close(currentFileName);
             currentFileName = newFileName;
         }

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -61,8 +61,9 @@ ConfigurationHelp::HelpMap& ConfigOutput::getHelpText(HelpMap& map, bool getAll)
         { fileNameKey, ConfigType::STRING, {}, "", "",
             "Filename pattern for the output diagnostic files. Date and time elements can be "
             "included as in std::put_time()." },
-        { filePeriodKey, ConfigType::STRING, {}, "", "",
-            "The period with which diagnostic files are created." },
+            { filePeriodKey, ConfigType::STRING, {}, "315360000000", "",
+                "The period with which diagnostic files are created. Defaults to a very long time "
+                "(10000 years)." },
     };
     return map;
 }
@@ -118,7 +119,7 @@ void ConfigOutput::configure()
     std::regex_search(rawFileName, match, ncSuffix);
     m_filePrefix = match.empty() ? rawFileName : match.prefix();
 
-    // The default string is the number of seconds in 10000 years of 365 days
+    // The default string is the number of seconds in 10000 common years (i.e. a very long time)
     std::string newFilePeriodStr
         = Configured::getConfiguration(keyMap.at(FILEPERIOD_KEY), std::string("315360000000"));
     fileChangePeriod = Duration(newFilePeriodStr);

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -156,7 +156,6 @@ void ConfigOutput::outputState(const ModelState& diagState)
         lastFileChange = time;
     }
 
-    double averagingFactor = meta.stepLength().seconds() / outputPeriod.seconds();
     ModelState state = { {}, diagState.config };
     auto storeData = ModelComponent::getStore().getAllData();
     if (outputAllTheFields) {

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -222,14 +222,14 @@ void ConfigOutput::outputState(const ModelState& diagState)
         && (everyTS || std::fmod(timeSinceOutput.seconds(), outputPeriod.seconds()) == 0.)) {
         Logged::info("ConfigOutput: Outputting " + std::to_string(state.data.size()) + " fields to "
             + currentFileName + " at " + meta.time().format() + "\n");
-        meta.affixCoordinates(state);
         double div = 1./n_accum;
         for (auto &entry : accumulator) {
             entry.second *= div;
         }
         n_accum = 0;
         ModelState outputState = { accumulator, {} };
-
+        // Merge in fields that are not already in the accumulator (coordinates, mainly).
+        meta.affixCoordinates(outputState);
         StructureFactory::fileFromState(outputState, currentFileName, false);
         lastOutput = meta.time();
         for (auto &entry : accumulator) {

--- a/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/ConfigOutput.cpp
@@ -20,7 +20,6 @@ static const std::regex ncSuffix(".nc$");
 
 static const std::string pfx = "ConfigOutput";
 static const std::string periodKey = pfx + ".period";
-static const std::string snapshotKey = pfx + ".snapshots";
 static const std::string startKey = pfx + ".start";
 static const std::string fieldNamesKey = pfx + ".field_names";
 static const std::string fileNameKey = pfx + ".filename";

--- a/core/src/modules/DiagnosticOutputModule/SnapshotOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/SnapshotOutput.cpp
@@ -26,9 +26,6 @@ static const std::string fieldNamesKey = pfx + ".field_names";
 static const std::string fileNameKey = pfx + ".filename";
 static const std::string filePeriodKey = pfx + ".file_period";
 
-// Access the model.start key. There's no clean way of getting this from Model, I think.
-static const std::string modelStartKey = "model.start";
-
 static const std::map<int, std::string> keyMap = {
     { SnapshotOutput::PERIOD_KEY, periodKey },
     { SnapshotOutput::START_KEY, startKey },
@@ -85,10 +82,7 @@ void SnapshotOutput::configure()
     }
     std::string startString = Configured::getConfiguration(keyMap.at(START_KEY), std::string(""));
     if (startString.empty()) {
-        startString = Configured::getConfiguration(modelStartKey, std::string(""));
-        if (startString.empty())
-            // If you start the model before 1st January year 0, tough.
-            lastOutput.parse(defaultLastOutput);
+        lastOutput = ModelMetadata::getInstance().startTime();
     } else {
         lastOutput.parse(startString);
         if (!everyTS) {

--- a/core/src/modules/DiagnosticOutputModule/SnapshotOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/SnapshotOutput.cpp
@@ -1,0 +1,218 @@
+/*!
+ * @author  Tim Spain <timothy.spain@nersc.no>
+ */
+
+#include "include/SnapshotOutput.hpp"
+#include "include/FileCallbackCloser.hpp"
+#include "include/Logged.hpp"
+#include "include/StructureFactory.hpp"
+
+#include <cmath>
+#include <regex>
+#include <sstream>
+
+namespace Nextsim {
+
+const std::string SnapshotOutput::all = "ALL";
+const std::string SnapshotOutput::defaultLastOutput = "0000-01-01T00:00:00Z";
+
+static const std::regex ncSuffix(".nc$");
+
+static const std::string pfx = "SnapshotOutput";
+static const std::string periodKey = pfx + ".period";
+static const std::string snapshotKey = pfx + ".snapshots";
+static const std::string startKey = pfx + ".start";
+static const std::string fieldNamesKey = pfx + ".field_names";
+static const std::string fileNameKey = pfx + ".filename";
+static const std::string filePeriodKey = pfx + ".file_period";
+
+// Access the model.start key. There's no clean way of getting this from Model, I think.
+static const std::string modelStartKey = "model.start";
+
+static const std::map<int, std::string> keyMap = {
+    { SnapshotOutput::PERIOD_KEY, periodKey },
+    { SnapshotOutput::START_KEY, startKey },
+    { SnapshotOutput::SNAPSHOT_KEY, snapshotKey },
+    { SnapshotOutput::FIELDNAMES_KEY, fieldNamesKey },
+    { SnapshotOutput::FILENAME_KEY, fileNameKey },
+    { SnapshotOutput::FILEPERIOD_KEY, filePeriodKey },
+};
+
+SnapshotOutput::SnapshotOutput()
+    : IDiagnosticOutput()
+    , m_filePrefix()
+    , outputPeriod()
+    , firstOutput(true)
+    , everyTS(false)
+    , outputAllTheFields(false)
+    , lastOutput(defaultLastOutput)
+    , fieldsForOutput()
+    , currentFileName()
+{
+}
+
+ConfigurationHelp::HelpMap& SnapshotOutput::getHelpText(HelpMap& map, bool getAll)
+{
+    map[pfx] = {
+        { periodKey, ConfigType::STRING, {}, "", "", "Time between samples of the output data." },
+        { startKey, ConfigType::STRING, {}, "model.start", "",
+            "Date at which to start outputting data." },
+        { fieldNamesKey, ConfigType::STRING, {}, "ALL", "",
+            "Comma separated, space free list of fields to be output. "
+            "The special value \""
+                + all + "\" will output all available fields." },
+        { fileNameKey, ConfigType::STRING, {}, "", "",
+            "Filename pattern for the output diagnostic files. Date and time elements can be "
+            "included as in std::put_time()." },
+        { filePeriodKey, ConfigType::STRING, {}, "", "",
+            "The period with which diagnostic files are created." },
+    };
+    return map;
+}
+
+ConfigurationHelp::HelpMap& SnapshotOutput::getHelpRecursive(HelpMap& map, bool getAll)
+{
+    getHelpText(map, getAll);
+    return map;
+}
+void SnapshotOutput::configure()
+{
+    std::string periodString = Configured::getConfiguration(keyMap.at(PERIOD_KEY), std::string(""));
+    if (periodString.empty()) {
+        everyTS = true;
+    } else {
+        outputPeriod.parse(periodString);
+    }
+    std::string startString = Configured::getConfiguration(keyMap.at(START_KEY), std::string(""));
+    if (startString.empty()) {
+        startString = Configured::getConfiguration(modelStartKey, std::string(""));
+        if (startString.empty())
+            // If you start the model before 1st January year 0, tough.
+            lastOutput.parse(defaultLastOutput);
+    } else {
+        lastOutput.parse(startString);
+        if (!everyTS) {
+            lastOutput -= outputPeriod;
+        }
+    }
+
+    std::string outputFields
+        = Configured::getConfiguration(keyMap.at(FIELDNAMES_KEY), std::string(""));
+    if (outputFields == all || outputFields.empty()) { // Output *all* the fields?
+        outputAllTheFields = true; // Output all the fields!
+    } else {
+        std::istringstream fieldStream;
+        fieldStream.str(outputFields);
+        for (std::string line; std::getline(fieldStream, line, ',');) {
+            fieldsForOutput.insert(line);
+        }
+        // Sort through the list of fields and create lists of Shared- or ProtectedArrays that
+        // correspond to the fields.
+        for (const std::string& fieldName : fieldsForOutput) {
+            if (externalNames.count(fieldName)) {
+                internalFieldsForOutput.insert(externalNames.at(fieldName));
+            } else {
+                Logged::warning(
+                    "SnapshotOutput: No field with the name \"" + fieldName + "\" was found.");
+            }
+        }
+    }
+
+    std::string rawFileName = Configured::getConfiguration(fileNameKey, m_filePrefix);
+    // Strip any ".nc" suffix from the end of the configured value.
+    std::smatch match;
+    std::regex_search(rawFileName, match, ncSuffix);
+    m_filePrefix = match.empty() ? rawFileName : match.prefix();
+
+    // The default string is the number of seconds in 10000 years of 365 days
+    std::string newFilePeriodStr
+        = Configured::getConfiguration(keyMap.at(FILEPERIOD_KEY), std::string("315360000000"));
+    fileChangePeriod = Duration(newFilePeriodStr);
+    lastFileChange = lastOutput;
+}
+
+void SnapshotOutput::setModelStart(const TimePoint& modelStart)
+{
+    // Set the lastOutput time to the model start if the default value has not yet been replaced.
+    if (lastOutput == TimePoint(defaultLastOutput)) {
+        lastOutput = modelStart;
+    }
+}
+
+void SnapshotOutput::outputState(const ModelState& diagState)
+{
+    auto& meta = ModelMetadata::getInstance();
+    const TimePoint& time = meta.time();
+    if (currentFileName == "" || (lastFileChange + fileChangePeriod <= time)) {
+        std::string newFileName = time.format(m_filePrefix) + ".nc";
+        if (newFileName != currentFileName) {
+            // TODO: Close the file currentFileName
+            FileCallbackCloser::close(currentFileName);
+            currentFileName = newFileName;
+        }
+        lastFileChange = time;
+    }
+
+    double averagingFactor = meta.stepLength().seconds() / outputPeriod.seconds();
+    ModelState state = { {}, diagState.config };
+    auto storeData = ModelComponent::getStore().getAllData();
+    if (outputAllTheFields) {
+        // If the internal to external name lookup table is still empty, fill it
+        if (reverseExternalNames.empty()) {
+            for (auto entry : externalNames) {
+                // Add the reverse lookup between external and internal names, if one has not been
+                // added
+                if (!reverseExternalNames.count(entry.second)) {
+                    reverseExternalNames[entry.second] = entry.first;
+                }
+            }
+        }
+
+        // Output every entry in storeData, as either its external name if
+        // defined, or as its internal name.
+        for (auto entry : storeData) {
+            if (entry.second && entry.second->trueSize()) {
+                std::string key;
+                if (reverseExternalNames.count(entry.first)) {
+                    state.data[reverseExternalNames.at(entry.first)] = *entry.second;
+                } else {
+                    state.data[entry.first] = *entry.second;
+                }
+            }
+        }
+    } else {
+        // Filter the passed state by the field names for output
+        for (auto& entry : diagState.data) {
+            if (fieldsForOutput.count(entry.first) > 0) {
+                state.data[entry.first] = entry.second;
+            }
+        }
+
+        // Get data from the data store for any named fields that have an external name that
+        // matches.
+        for (const auto& fieldExtName : fieldsForOutput) {
+            if (externalNames.count(fieldExtName) && storeData.count(externalNames.at(fieldExtName))
+                && storeData.at(externalNames.at(fieldExtName))) {
+                state.data[fieldExtName] = *storeData.at(externalNames.at(fieldExtName));
+            }
+        }
+    }
+
+    /*
+     * Produce output either:
+     *    • on every timestep after the start time initially stored in lastOutput
+     *    • whenever the current time is an integer number of time periods from the
+     *      last output time.
+     */
+    Duration timeSinceOutput = meta.time() - lastOutput;
+    if (timeSinceOutput.seconds() > 0
+        && (everyTS || std::fmod(timeSinceOutput.seconds(), outputPeriod.seconds()) == 0.)) {
+        Logged::info("SnapshotOutput: Outputting " + std::to_string(state.data.size()) + " fields to "
+            + currentFileName + " at " + meta.time().format() + "\n");
+        meta.affixCoordinates(state);
+        StructureFactory::fileFromState(state, currentFileName, false);
+        lastOutput = meta.time();
+    }
+}
+
+} /* namespace Nextsim */

--- a/core/src/modules/DiagnosticOutputModule/SnapshotOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/SnapshotOutput.cpp
@@ -61,8 +61,9 @@ ConfigurationHelp::HelpMap& SnapshotOutput::getHelpText(HelpMap& map, bool getAl
         { fileNameKey, ConfigType::STRING, {}, "", "",
             "Filename pattern for the output diagnostic files. Date and time elements can be "
             "included as in std::put_time()." },
-        { filePeriodKey, ConfigType::STRING, {}, "", "",
-            "The period with which diagnostic files are created." },
+        { filePeriodKey, ConfigType::STRING, {}, "315360000000", "",
+            "The period with which diagnostic files are created. Defaults to a very long time "
+            "(10000 years)." },
     };
     return map;
 }
@@ -118,7 +119,7 @@ void SnapshotOutput::configure()
     std::regex_search(rawFileName, match, ncSuffix);
     m_filePrefix = match.empty() ? rawFileName : match.prefix();
 
-    // The default string is the number of seconds in 10000 years of 365 days
+    // The default string is the number of seconds in 10000 common years (i.e. a very long time)
     std::string newFilePeriodStr
         = Configured::getConfiguration(keyMap.at(FILEPERIOD_KEY), std::string("315360000000"));
     fileChangePeriod = Duration(newFilePeriodStr);

--- a/core/src/modules/DiagnosticOutputModule/SnapshotOutput.cpp
+++ b/core/src/modules/DiagnosticOutputModule/SnapshotOutput.cpp
@@ -146,7 +146,6 @@ void SnapshotOutput::outputState(const ModelState& diagState)
     if (currentFileName == "" || (lastFileChange + fileChangePeriod <= time)) {
         std::string newFileName = time.format(m_filePrefix) + ".nc";
         if (newFileName != currentFileName) {
-            // TODO: Close the file currentFileName
             FileCallbackCloser::close(currentFileName);
             currentFileName = newFileName;
         }

--- a/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
@@ -9,7 +9,6 @@
 #include "include/IDiagnosticOutput.hpp"
 
 #include "include/Configured.hpp"
-#include "include/ModelComponent.hpp"
 #include "include/Time.hpp"
 
 #include <set>

--- a/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
@@ -66,8 +66,8 @@ private:
 
     std::map<std::string, std::string> reverseExternalNames;
 
-    bool snapshots;
-    bool resetState;
+    ModelState::DataMap accumulator;
+    size_t n_accum;
 };
 
 } /* namespace Nextsim */

--- a/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/ConfigOutput.hpp
@@ -28,7 +28,6 @@ public:
     enum {
         PERIOD_KEY,
         START_KEY,
-        SNAPSHOT_KEY,
         FIELDNAMES_KEY,
         FILENAME_KEY,
         FILEPERIOD_KEY,

--- a/core/src/modules/DiagnosticOutputModule/include/SnapshotOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/SnapshotOutput.hpp
@@ -1,0 +1,73 @@
+/*!
+ *
+ * @author  Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef SNAPSHOTOUTPUT_HPP
+#define SNAPSHOTOUTPUT_HPP
+
+#include "include/IDiagnosticOutput.hpp"
+
+#include "include/Configured.hpp"
+#include "include/ModelComponent.hpp"
+#include "include/Time.hpp"
+
+#include <set>
+
+namespace Nextsim {
+
+/*!
+ * An implementation of the diagnostic output that allows some configuration of
+ * the file output period and frequency, as well as the fields the files contain.
+ */
+class SnapshotOutput : public IDiagnosticOutput, public Configured<SnapshotOutput> {
+public:
+    SnapshotOutput();
+    virtual ~SnapshotOutput() = default;
+
+    enum {
+        PERIOD_KEY,
+        START_KEY,
+        SNAPSHOT_KEY,
+        FIELDNAMES_KEY,
+        FILENAME_KEY,
+        FILEPERIOD_KEY,
+    };
+
+    // IDiagnosticOutput overrides
+    void setFilenamePrefix(const std::string& filePrefix) override { m_filePrefix = filePrefix; }
+    void setModelStart(const TimePoint& modelStart) override;
+    void outputState(const ModelState& state) override;
+
+    // ModelComponent overrides
+    inline std::string getName() const override { return "SnapshotOutput"; };
+    inline void setData(const ModelState::DataMap&) override {};
+
+    // Configured overrides
+    static HelpMap& getHelpRecursive(HelpMap& map, bool getAll);
+    static HelpMap& getHelpText(HelpMap& map, bool getAll);
+    void configure() override;
+
+private:
+    std::string m_filePrefix;
+    Duration outputPeriod;
+    bool firstOutput;
+    bool everyTS;
+    bool outputAllTheFields;
+    TimePoint lastOutput;
+    std::set<std::string> fieldsForOutput;
+    std::string currentFileName;
+    std::set<std::string> internalFieldsForOutput;
+
+    TimePoint lastFileChange;
+    Duration fileChangePeriod;
+
+    static const std::string all;
+    static const std::string defaultLastOutput;
+
+    std::map<std::string, std::string> reverseExternalNames;
+};
+
+} /* namespace Nextsim */
+
+#endif /* SNAPSHOTOUTPUT_HPP */

--- a/core/src/modules/DiagnosticOutputModule/include/SnapshotOutput.hpp
+++ b/core/src/modules/DiagnosticOutputModule/include/SnapshotOutput.hpp
@@ -1,5 +1,4 @@
 /*!
- *
  * @author  Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/src/modules/DiagnosticOutputModule/module.cfg
+++ b/core/src/modules/DiagnosticOutputModule/module.cfg
@@ -19,10 +19,10 @@ has_help = no
 
 [Nextsim::ConfigOutput]
 file_prefix = ConfigOutput
-description = Blocking output with configuration.
+description = Blocking output with configuration, outputs averaged fields.
 has_help = true
 
 [Nextsim::SnapshotOutput]
 file_prefix = SnapshotOutput
-description = Blocking output with configuration.
+description = Blocking output with configuration, outputs snapshotted fields.
 has_help = true

--- a/core/src/modules/DiagnosticOutputModule/module.cfg
+++ b/core/src/modules/DiagnosticOutputModule/module.cfg
@@ -21,3 +21,8 @@ has_help = no
 file_prefix = ConfigOutput
 description = Blocking output with configuration.
 has_help = true
+
+[Nextsim::SnapshotOutput]
+file_prefix = SnapshotOutput
+description = Blocking output with configuration.
+has_help = true

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -467,6 +467,14 @@ else()
     target_include_directories(testConfigOutput PRIVATE ${MODEL_INCLUDE_DIR})
     target_link_libraries(testConfigOutput PRIVATE nextsimlib doctest::doctest)
 
+    add_executable(testSnapshotOutput "SnapshotOutput_test.cpp")
+    target_compile_definitions(
+        testSnapshotOutput
+        PRIVATE TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\"
+    )
+    target_include_directories(testSnapshotOutput PRIVATE ${MODEL_INCLUDE_DIR})
+    target_link_libraries(testSnapshotOutput PRIVATE nextsimlib doctest::doctest)
+
     add_executable(testIterator "Iterator_test.cpp")
     target_link_libraries(testIterator PRIVATE nextsimlib doctest::doctest)
 

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -574,6 +574,7 @@ else()
         testRectGrid
         testParaGrid
         testConfigOutput
+        testSnapshotOutput
         testIterator
         testCommandLineParser
         testConfigurator

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -479,6 +479,10 @@ else()
         mock_includes/ConfigOutputAve
         testmodelarraydetails
     )
+    target_include_directories(testConfigOutputAve AFTER PRIVATE
+        mock_includes/ConfigOutputAve
+        testmodelarraydetails
+    )
     target_link_libraries(testConfigOutputAve PRIVATE doctest::doctest Eigen3::Eigen)
 
     add_executable(testSnapshotOutput "SnapshotOutput_test.cpp")

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -475,7 +475,7 @@ else()
         "../src/Time.cpp"
         "testmodelarraydetails/ModelArrayDetails.cpp"
     )
-    target_include_directories(testConfigOutputAve BEFORE PRIVATE 
+    target_include_directories(testConfigOutputAve BEFORE PRIVATE
         mock_includes/ConfigOutputAve
         testmodelarraydetails
     )

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -467,6 +467,17 @@ else()
     target_include_directories(testConfigOutput PRIVATE ${MODEL_INCLUDE_DIR})
     target_link_libraries(testConfigOutput PRIVATE nextsimlib doctest::doctest)
 
+    add_executable(testConfigOutputAve
+        "ConfigOutputAve_test.cpp"
+        "../src/modules/DiagnosticOutputModule/ConfigOutput.cpp"
+        "../src/ModelArray.cpp"
+        "../src/ModelArraySlice.cpp"
+        "../src/Time.cpp"
+        "testmodelarraydetails/ModelArrayDetails.cpp"
+        )
+    target_include_directories(testConfigOutputAve BEFORE PRIVATE mock_includes/ConfigOutputAve testmodelarraydetails)
+    target_link_libraries(testConfigOutputAve PRIVATE doctest::doctest Eigen3::Eigen)
+
     add_executable(testSnapshotOutput "SnapshotOutput_test.cpp")
     target_compile_definitions(
         testSnapshotOutput

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -474,8 +474,11 @@ else()
         "../src/ModelArraySlice.cpp"
         "../src/Time.cpp"
         "testmodelarraydetails/ModelArrayDetails.cpp"
-        )
-    target_include_directories(testConfigOutputAve BEFORE PRIVATE mock_includes/ConfigOutputAve testmodelarraydetails)
+    )
+    target_include_directories(testConfigOutputAve BEFORE PRIVATE 
+        mock_includes/ConfigOutputAve
+        testmodelarraydetails
+    )
     target_link_libraries(testConfigOutputAve PRIVATE doctest::doctest Eigen3::Eigen)
 
     add_executable(testSnapshotOutput "SnapshotOutput_test.cpp")

--- a/core/test/ConfigOutputAve_test.cpp
+++ b/core/test/ConfigOutputAve_test.cpp
@@ -33,14 +33,21 @@ const auto ny = 1;
 
 TEST_SUITE_BEGIN("ConfigOutput");
 TEST_CASE("Test single output") {
+    Nextsim::ModelArray::setDimensions(Nextsim::ModelArray::Type::TWOD, {nx, ny});
     Nextsim::TwoDField cice(Nextsim::ModelArray::Type::TWOD);
     cice.resize();
-    cice = 1.0;
     Nextsim::ModelState state;
-    state.data["cice"] = cice;
     Nextsim::ConfigOutput co;
+    co.configure();
+    auto t = Nextsim::TimePoint("2000-01-01T01:00:00Z");
+    ModelMetadata::getInstance().time() = t;
+    std::string cice_name = "cice";
+    double cice_val = 1.;
+    cice = cice_val;
+    state.data[cice_name] = cice;
     co.outputState(state);
     auto oState = StructureFactory::getState();
-    std::cout << oState.data.size() << std::endl;
+    REQUIRE(oState.data.size() == 1);
+    REQUIRE(oState.data[cice_name][0] == cice_val);
 }
 TEST_SUITE_END();

--- a/core/test/ConfigOutputAve_test.cpp
+++ b/core/test/ConfigOutputAve_test.cpp
@@ -37,6 +37,7 @@ TEST_CASE("Test single output") {
     Nextsim::ConfigOutput co;
     co.configure();
     auto t = Nextsim::TimePoint("2000-01-01T01:00:00Z");
+    // Set the time in the mock ModelMetadata class
     ModelMetadata::getInstance().time() = t;
     const std::string cice_name = "cice";
     double cice_val = 1.;
@@ -60,6 +61,7 @@ TEST_CASE("Averaging output") {
     const size_t nt = 4;
     for (auto i = 1; i <= nt; ++i) {
         auto t = Nextsim::TimePoint(std::string("2000-01-01T0")+std::to_string((i*15)/60)+":"+std::to_string((i*15) % 60)+":00Z");
+        // Set the step time in the mock ModelMetadata class
         ModelMetadata::getInstance().time() = t;
         double cice_val = i;
         cice = cice_val;

--- a/core/test/ConfigOutputAve_test.cpp
+++ b/core/test/ConfigOutputAve_test.cpp
@@ -36,9 +36,9 @@ TEST_CASE("Test single output") {
     Nextsim::ModelState state;
     Nextsim::ConfigOutput co;
     co.configure();
-    auto t = Nextsim::TimePoint("2000-01-01T01:00:00Z");
     // Set the time in the mock ModelMetadata class
-    ModelMetadata::getInstance().time() = t;
+    ModelMetadata::getInstance().startTime() = Nextsim::TimePoint("2000-01-01T00:00:00Z");
+    ModelMetadata::getInstance().time() = Nextsim::TimePoint("2000-01-01T01:00:00Z");
     const std::string cice_name = "cice";
     double cice_val = 1.;
     cice = cice_val;
@@ -56,6 +56,7 @@ TEST_CASE("Averaging output") {
     Nextsim::ModelState state;
     Nextsim::ConfigOutput co;
     co.configure();
+    ModelMetadata::getInstance().startTime() = Nextsim::TimePoint("2000-01-01T00:00:00Z");
     const std::string cice_name = "cice";
     double accum = 0.;
     const size_t nt = 4;

--- a/core/test/ConfigOutputAve_test.cpp
+++ b/core/test/ConfigOutputAve_test.cpp
@@ -32,6 +32,8 @@ TEST_SUITE_BEGIN("ConfigOutput");
 TEST_CASE("Test single output") {
     Nextsim::ModelArray::setDimensions(Nextsim::ModelArray::Type::TWOD, {nx, ny});
     Nextsim::TwoDField cice(Nextsim::ModelArray::Type::TWOD);
+    // Clear the mock StructureFactory class
+    StructureFactory::getState().data.clear();
     cice.resize();
     Nextsim::ModelState state;
     Nextsim::ConfigOutput co;
@@ -52,6 +54,7 @@ TEST_CASE("Test single output") {
 TEST_CASE("Averaging output") {
     Nextsim::ModelArray::setDimensions(Nextsim::ModelArray::Type::TWOD, {nx, ny});
     Nextsim::TwoDField cice(Nextsim::ModelArray::Type::TWOD);
+    StructureFactory::getState().data.clear();
     cice.resize();
     Nextsim::ModelState state;
     Nextsim::ConfigOutput co;
@@ -75,5 +78,53 @@ TEST_CASE("Averaging output") {
     auto oState = StructureFactory::getState();
     REQUIRE(oState.data.size() == 1);
     REQUIRE(oState.data[cice_name][0] == accum);
+}
+
+TEST_CASE("Model start before output start") {
+    Nextsim::ModelArray::setDimensions(Nextsim::ModelArray::Type::TWOD, {nx, ny});
+    Nextsim::TwoDField cice(Nextsim::ModelArray::Type::TWOD);
+    StructureFactory::getState().data.clear();
+    cice.resize();
+    Nextsim::ModelState state;
+    Nextsim::ConfigOutput co;
+    co.configure();
+    ModelMetadata::getInstance().startTime() = Nextsim::TimePoint("1999-12-31T00:00:00Z");
+    const std::string cice_name = "cice";
+    auto oState = StructureFactory::getState();
+    REQUIRE(oState.data.size() == 0);
+    // Initial steps
+    size_t nt = 96;
+    for (auto i = 1; i <= nt; ++i) {
+        std::string day_str = (i < 96) ? "1999-12-31" : "2000-01-01";
+        auto t = Nextsim::TimePoint(std::string(day_str+"T0")+std::to_string((i*15)/60)+":"+std::to_string((i*15) % 60)+":00Z");
+        // Set the step time in the mock ModelMetadata class
+        ModelMetadata::getInstance().time() = t;
+        double cice_val = i;
+        cice = cice_val;
+        state.data[cice_name] = cice;
+        co.outputState(state);
+    }
+    oState = StructureFactory::getState();
+    REQUIRE(oState.data.size() == 0);
+
+    double accum = 0.;
+    size_t nt_off = 96; // Number of steps in the previous day
+    nt = 4;
+    for (auto i = 1; i <= nt; ++i) {
+        auto t = Nextsim::TimePoint(std::string("2000-01-01T0")+std::to_string((i*15)/60)+":"+std::to_string((i*15) % 60)+":00Z");
+        // Set the step time in the mock ModelMetadata class
+        ModelMetadata::getInstance().time() = t;
+        double cice_val = i + nt_off;
+        cice = cice_val;
+        accum += cice_val;
+        state.data[cice_name] = cice;
+        co.outputState(state);
+
+    }
+    accum /= nt;
+    oState = StructureFactory::getState();
+    REQUIRE(oState.data.size() == 1);
+    REQUIRE(oState.data[cice_name][0] == accum);
+
 }
 TEST_SUITE_END();

--- a/core/test/ConfigOutputAve_test.cpp
+++ b/core/test/ConfigOutputAve_test.cpp
@@ -1,0 +1,46 @@
+/*!
+ * @file ConfigOutputAve_test.cpp
+ *
+ * @date Mar 12, 2026
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <string>
+#include <iostream>
+
+/**********************************************************************
+ *
+ * Mock classes
+ *
+ *********************************************************************/
+#include "include/StructureFactory.hpp"
+
+#include "modules/DiagnosticOutputModule/include/ConfigOutput.hpp"
+
+const std::map<std::string, std::string> IDiagnosticOutput::externalNames = {
+};
+
+/**********************************************************************
+ *
+ * Test code
+ *
+ *********************************************************************/
+const auto nx = 1;
+const auto ny = 1;
+
+TEST_SUITE_BEGIN("ConfigOutput");
+TEST_CASE("Test single output") {
+    Nextsim::TwoDField cice(Nextsim::ModelArray::Type::TWOD);
+    cice.resize();
+    cice = 1.0;
+    Nextsim::ModelState state;
+    state.data["cice"] = cice;
+    Nextsim::ConfigOutput co;
+    co.outputState(state);
+    auto oState = StructureFactory::getState();
+    std::cout << oState.data.size() << std::endl;
+}
+TEST_SUITE_END();

--- a/core/test/ConfigOutputAve_test.cpp
+++ b/core/test/ConfigOutputAve_test.cpp
@@ -1,7 +1,4 @@
 /*!
- * @file ConfigOutputAve_test.cpp
- *
- * @date Mar 12, 2026
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/test/ConfigOutputAve_test.cpp
+++ b/core/test/ConfigOutputAve_test.cpp
@@ -41,7 +41,7 @@ TEST_CASE("Test single output") {
     co.configure();
     auto t = Nextsim::TimePoint("2000-01-01T01:00:00Z");
     ModelMetadata::getInstance().time() = t;
-    std::string cice_name = "cice";
+    const std::string cice_name = "cice";
     double cice_val = 1.;
     cice = cice_val;
     state.data[cice_name] = cice;
@@ -49,5 +49,31 @@ TEST_CASE("Test single output") {
     auto oState = StructureFactory::getState();
     REQUIRE(oState.data.size() == 1);
     REQUIRE(oState.data[cice_name][0] == cice_val);
+}
+
+TEST_CASE("Averaging output") {
+    Nextsim::ModelArray::setDimensions(Nextsim::ModelArray::Type::TWOD, {nx, ny});
+    Nextsim::TwoDField cice(Nextsim::ModelArray::Type::TWOD);
+    cice.resize();
+    Nextsim::ModelState state;
+    Nextsim::ConfigOutput co;
+    co.configure();
+    const std::string cice_name = "cice";
+    double accum = 0.;
+    const size_t nt = 4;
+    for (auto i = 1; i <= nt; ++i) {
+        auto t = Nextsim::TimePoint(std::string("2000-01-01T0")+std::to_string((i*15)/60)+":"+std::to_string((i*15) % 60)+":00Z");
+        ModelMetadata::getInstance().time() = t;
+        double cice_val = i;
+        cice = cice_val;
+        accum += cice_val;
+        state.data[cice_name] = cice;
+        co.outputState(state);
+
+    }
+    accum /= nt;
+    auto oState = StructureFactory::getState();
+    REQUIRE(oState.data.size() == 1);
+    REQUIRE(oState.data[cice_name][0] == accum);
 }
 TEST_SUITE_END();

--- a/core/test/ConfigOutput_test.cpp
+++ b/core/test/ConfigOutput_test.cpp
@@ -41,11 +41,11 @@ const std::string partition_filename = test_files_dir + "/paragrid_test_partitio
 
 namespace Nextsim {
 
+void runMe(const bool snapshot
 #ifdef USE_MPI
-void runMe(const bool snapshot, MPI_Comm myMPIComm)
-#else
-void runMe(const bool snapshot)
+, MPI_Comm myMPIComm
 #endif
+)
 {
     size_t nx = 10;
     size_t ny = 9;

--- a/core/test/SnapshotOutput_test.cpp
+++ b/core/test/SnapshotOutput_test.cpp
@@ -1,0 +1,232 @@
+/*!
+ * @author  Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifdef USE_MPI
+#include <doctest/extensions/doctest_mpi.h>
+#undef INFO
+#else
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+#endif
+
+#include "DiagnosticOutputModule/include/ConfigOutput.hpp"
+
+#include "include/FileCallbackCloser.hpp"
+#include "include/Finalizer.hpp"
+#include "include/IStructure.hpp"
+#include "include/ModelArray.hpp"
+#include "include/ModelArrayRef.hpp"
+#include "include/ModelComponent.hpp"
+#include "include/ModelMetadata.hpp"
+#include "include/ModelState.hpp"
+#include "include/NextsimModule.hpp"
+#include "include/gridNames.hpp"
+#ifdef USE_MPI
+#include "ModelMPI.hpp"
+#include "include/Halo.hpp"
+#endif
+
+#include <ncDim.h>
+#include <ncFile.h>
+#include <ncVar.h>
+
+#include <filesystem>
+#include <sstream>
+
+const std::string test_files_dir = TEST_FILES_DIR;
+#ifdef USE_MPI
+const std::string partition_filename = test_files_dir + "/paragrid_test_partition_metadata_2.nc";
+#endif
+
+namespace Nextsim {
+
+#ifdef USE_MPI
+void runMe(const bool snapshot, MPI_Comm myMPIComm)
+#else
+void runMe(const bool snapshot)
+#endif
+{
+    size_t nx = 10;
+    size_t ny = 9;
+
+#ifdef USE_MPI
+    auto& modelMPI = ModelMPI::getInstance(myMPIComm);
+    auto& meta = ModelMetadata::getInstance(partition_filename);
+
+    const auto localNX = meta.getLocalExtentX() + 2 * Halo::haloWidth;
+    const auto offsetX = meta.getLocalCornerX();
+    const auto localNY = meta.getLocalExtentY() + 2 * Halo::haloWidth;
+    const auto offsetY = meta.getLocalCornerY();
+
+    ModelArray::setDimension(ModelArray::Dimension::X, nx, localNX, offsetX);
+    ModelArray::setDimension(ModelArray::Dimension::XVERTEX, nx + 1, localNX + 1, offsetX);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny, localNY, offsetY);
+    ModelArray::setDimension(ModelArray::Dimension::YVERTEX, ny + 1, localNY + 1, offsetY);
+#else
+    auto& meta = ModelMetadata::getInstance();
+    ModelArray::setDimension(ModelArray::Dimension::X, nx);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny);
+
+    auto offsetX = 0;
+    auto localNX = nx;
+    auto localNY = ny;
+#endif
+
+    Module::Module<IDiagnosticOutput>::setImplementation("Nextsim::ConfigOutput");
+    std::stringstream config;
+    config << "[ConfigOutput]" << std::endl;
+    config << "period = 3600" << std::endl; // Output every hour
+    config << "start = 2020-01-11T00:00:00Z" << std::endl; // start after 10 days
+    config << "field_names = " << hiceName << "," << ciceName << "," << tsurfName << ","
+           << "top_melt" << std::endl;
+    config << "filename = diag%m%d.nc" << std::endl;
+    config << "file_period = 86400" << std::endl; // Files every day
+
+    std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
+    Configurator::addStream(std::move(pcstream));
+
+    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
+
+    HField hice(ModelArray::Type::H);
+    HField cice(ModelArray::Type::H);
+    HField hsnow(ModelArray::Type::H);
+    HField tsurf(ModelArray::Type::H);
+
+    // An internal diagnostic field, not made available through the data store
+    HField topMelt(ModelArray::Type::H);
+
+    hice.resize();
+    cice.resize();
+    hsnow.resize();
+    tsurf.resize();
+    topMelt.resize();
+
+    hice = 0.;
+    cice = 0.;
+    hsnow = 0.;
+    tsurf = 0.;
+    topMelt = 0.;
+
+    ModelComponent::getStore().registerArray(Shared::H_ICE_DG, &hice);
+    ModelComponent::getStore().registerArray(Shared::C_ICE_DG, &cice);
+    ModelComponent::getStore().registerArray(Shared::H_SNOW_DG, &hsnow);
+    ModelComponent::getStore().registerArray(Protected::T_SURF, &tsurf);
+
+    // Set up the coordinates, but use arrays filled with zeros
+    HField latlonData(ModelArray::Type::H);
+    latlonData = 0.;
+    VertexField coordsData(ModelArray::Type::VERTEX);
+    coordsData = 0.;
+    ModelState modelCoordinates = { {
+                                        { longitudeName, latlonData },
+                                        { latitudeName, latlonData },
+                                        { gridAzimuthName, latlonData },
+                                        { coordsName, coordsData },
+                                    },
+        {} };
+    meta.extractCoordinates(modelCoordinates);
+    meta.setTime(TimePoint("2020-01-01T00:00:00Z"));
+
+    auto& ido = Module::getImplementation<IDiagnosticOutput>();
+    tryConfigure(ido);
+
+#ifdef USE_MPI
+    // offset indices by 1 (haloWidth) so only the "inner" data is initialized
+    for (size_t j = 0; j < localNY - 2 * Halo::haloWidth; ++j) {
+        for (size_t i = 0; i < localNX - 2 * Halo::haloWidth; ++i) {
+            hice(i + 1, j + 1) = 0 + 0.01 * (j * nx + (i + offsetX));
+            cice(i + 1, j + 1) = 0.1 + 0.01 * (j * nx + (i + offsetX));
+            hsnow(i + 1, j + 1) = 0.2 + 0.01 * (j * nx + (i + offsetX));
+            tsurf(i + 1, j + 1) = 0.4 + 0.01 * (j * nx + (i + offsetX));
+            topMelt(i + 1, j + 1) = 0.6 + 0.01 * (j * nx + (i + offsetX));
+        }
+    }
+#else
+    for (size_t j = 0; j < localNY; ++j) {
+        for (size_t i = 0; i < localNX; ++i) {
+            hice(i, j) = 0 + 0.01 * (j * nx + (i + offsetX));
+            cice(i, j) = 0.1 + 0.01 * (j * nx + (i + offsetX));
+            hsnow(i, j) = 0.2 + 0.01 * (j * nx + (i + offsetX));
+            tsurf(i, j) = 0.4 + 0.01 * (j * nx + (i + offsetX));
+            topMelt(i, j) = 0.6 + 0.01 * (j * nx + (i + offsetX));
+        }
+    }
+#endif
+    std::vector<std::string> diagFiles;
+    const std::string pfx = "diag01";
+    const std::string sfx = ".nc";
+    const size_t hr_day = 24;
+    for (size_t day = 1; day <= 20; ++day) {
+        if (day > 10) {
+            diagFiles.push_back(pfx + std::to_string(day) + sfx);
+        }
+        double dayIncr = 100.;
+        hice += dayIncr;
+        cice += dayIncr;
+        hsnow += dayIncr;
+        tsurf += dayIncr;
+        for (size_t hour = 0; hour < hr_day; ++hour) {
+            double hourIncr = 1;
+            hice += hourIncr;
+            cice += hourIncr;
+            hsnow += hourIncr;
+            ModelState state = { { { "top_melt", topMelt } }, {} };
+
+            ido.outputState(state);
+            meta.incrementTime(Duration(3600.));
+        }
+    }
+
+    // Close and finalize the files
+    for (const std::string& file : diagFiles) {
+        FileCallbackCloser::close(file);
+    }
+
+    // Now test that there are 10 files, correctly named, and check that one of
+    // them (diag0116.nc) contains what it should.
+    for (const std::string& file : diagFiles) {
+        REQUIRE(std::filesystem::exists(file));
+    }
+    // // No output should occur before the designated start date
+    REQUIRE(!std::filesystem::exists(pfx + "10" + sfx));
+
+    const std::string specFile = diagFiles[5];
+    std::set<std::string> fields = { "hice", "cice", "tsurf", "top_melt" };
+
+    // Read the netCDF file directly
+    netCDF::NcFile ncFile(specFile, netCDF::NcFile::read);
+
+    // Read the time axis
+    netCDF::NcDim timeDim = ncFile.getDim(timeName);
+    // Read the time variable
+    netCDF::NcVar timeVar = ncFile.getVar(timeName);
+    REQUIRE(timeDim.getSize() == hr_day);
+
+    std::multimap<std::string, netCDF::NcVar> vars(ncFile.getVars());
+    REQUIRE(vars.size() == fields.size() + 1 + 4); // +1 for the time variable + 4 for the coords
+    for (const auto& field : fields) {
+        REQUIRE(vars.count(field) == 1);
+    }
+    REQUIRE(vars.count("time") == 1);
+    REQUIRE(vars.count("hsnow") == 0);
+
+    ncFile.close();
+
+    // Clean the testing files
+    for (const auto& fileName : diagFiles) {
+        std::filesystem::remove(fileName);
+    }
+
+    Finalizer::finalize();
+}
+
+TEST_SUITE_BEGIN("ConfigOutput");
+#ifdef USE_MPI
+MPI_TEST_CASE("Test snapshot output", 2) { runMe(true, test_comm); }
+#else
+TEST_CASE("Test snapshot output") { runMe(true); }
+#endif
+
+TEST_SUITE_END();
+}

--- a/core/test/mock_includes/ConfigOutputAve/include/Configured.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/Configured.hpp
@@ -1,0 +1,24 @@
+/*!
+ * @file Configured.hpp
+ *
+ * @date Mar 13, 2026
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef MOCK_INCLUDES_CONFIGURED_HPP
+#define MOCK_INCLUDES_CONFIGURED_HPP
+
+#include "include/ConfigMap.hpp"
+
+template <typename C>
+class Configured {
+public:
+    virtual ~Configured() = default;
+    virtual void configure() = 0;
+    template <typename T>
+    static inline T getConfiguration(const std::string& name, const T& defaultValue) {
+        return T();
+    }
+};
+
+#endif /* MOCK_INCLUDES_CONFIGURED_HPP */

--- a/core/test/mock_includes/ConfigOutputAve/include/Configured.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/Configured.hpp
@@ -1,7 +1,4 @@
 /*!
- * @file Configured.hpp
- *
- * @date Mar 13, 2026
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/test/mock_includes/ConfigOutputAve/include/Configured.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/Configured.hpp
@@ -15,9 +15,21 @@ class Configured {
 public:
     virtual ~Configured() = default;
     virtual void configure() = 0;
-    template <typename T>
-    static inline T getConfiguration(const std::string& name, const T& defaultValue) {
-        return T();
+    static std::string getConfiguration(const std::string& name, const std::string& defaultValue) {
+        const std::string pfx = "ConfigOutput";
+        if (name == pfx+".period") {
+            return std::string("3600");
+        } else if (name == pfx+".start") {
+            return std::string("2000-01-01T00:00:00Z");
+        } else if (name == pfx+".field_names") {
+            return std::string("cice");
+        } else if (name == pfx+".filename") {
+            return "";
+        } else if (name == pfx+".file_period") {
+            return std::string("10000000000");
+        } else {
+            return std::string();
+        }
     }
 };
 

--- a/core/test/mock_includes/ConfigOutputAve/include/FileCallbackCloser.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/FileCallbackCloser.hpp
@@ -1,7 +1,4 @@
 /*!
- * @file FileCallbackCloser.hpp
- *
- * @date Mar 13, 2026
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/test/mock_includes/ConfigOutputAve/include/FileCallbackCloser.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/FileCallbackCloser.hpp
@@ -1,0 +1,18 @@
+/*!
+ * @file FileCallbackCloser.hpp
+ *
+ * @date Mar 13, 2026
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef MOCK_INCLUDES_FILECALLBACKCLOSER_HPP
+#define MOCK_INCLUDES_FILECALLBACKCLOSER_HPP
+
+#include <string>
+
+class FileCallbackCloser {
+public:
+    static void close(const std::string& s) { };
+};
+
+#endif /* MOCK_INCLUDES_FILECALLBACKCLOSER_HPP */

--- a/core/test/mock_includes/ConfigOutputAve/include/IDiagnosticOutput.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/IDiagnosticOutput.hpp
@@ -1,0 +1,67 @@
+/*!
+ * @file IDiagnosticOutput.hpp
+ *
+ * @date Mar 13, 2026
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef MOCK_INCLUDES_IDIAGNOSTICOUTPUT_HPP
+#define MOCK_INCLUDES_IDIAGNOSTICOUTPUT_HPP
+
+#include <map>
+
+#include "include/ConfigurationHelp.hpp"
+#include "include/ModelState.hpp"
+#include "include/Time.hpp"
+
+class IDiagnosticOutput {
+public:
+    virtual ~IDiagnosticOutput() = default;
+
+    virtual void setFilenamePrefix(const std::string& filePrefix) = 0;
+    virtual void outputState(const Nextsim::ModelState& state) = 0;
+    virtual void setData(const Nextsim::ModelState::DataMap& state) { }
+    virtual void setModelStart(const Nextsim::TimePoint& ModelStart) { }
+
+    // functions usually declared in ModelComponent
+    virtual std::string getName() const = 0;
+    const static std::map<std::string, std::string> externalNames;
+};
+typedef Nextsim::ConfigurationHelp::HelpMap HelpMap;
+typedef Nextsim::ConfigurationHelp::ConfigType ConfigType;
+
+class ModelMetadata {
+public:
+    Nextsim::TimePoint& time()
+    {
+        static Nextsim::TimePoint m_time;
+        return m_time;
+    };
+    void affixCoordinates(Nextsim::ModelState& ms) { };
+    static ModelMetadata& getInstance()
+    {
+        static ModelMetadata meta;
+        return meta;
+    };
+};
+
+class ModelComponent {
+    class Store {
+    public:
+        using StoreMap = std::map<std::string, Nextsim::ModelArray*>;
+        StoreMap data;
+        StoreMap getAllData() { return data; }
+    };
+public:
+    static Store& getStore()
+    {
+        static Store store;
+        return store;
+    }
+    void setData(const std::string& name, Nextsim::ModelArray* p_data)
+    {
+        getStore().data[name] = p_data;
+    }
+};
+
+#endif /* MOCK_INCLUDES_IDIAGNOSTICOUTPUT_HPP */

--- a/core/test/mock_includes/ConfigOutputAve/include/IDiagnosticOutput.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/IDiagnosticOutput.hpp
@@ -1,7 +1,4 @@
 /*!
- * @file IDiagnosticOutput.hpp
- *
- * @date Mar 13, 2026
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/test/mock_includes/ConfigOutputAve/include/IDiagnosticOutput.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/IDiagnosticOutput.hpp
@@ -34,6 +34,11 @@ public:
         static Nextsim::TimePoint m_time;
         return m_time;
     };
+    Nextsim::TimePoint& startTime()
+    {
+        static Nextsim::TimePoint m_start;
+        return m_start;
+    }
     void affixCoordinates(Nextsim::ModelState& ms) { };
     static ModelMetadata& getInstance()
     {

--- a/core/test/mock_includes/ConfigOutputAve/include/Logged.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/Logged.hpp
@@ -1,0 +1,20 @@
+/*!
+ * @file Logged.hpp
+ *
+ * @date Mar 13, 2026
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef MOCK_INCLUDES_LOGGED_HPP
+#define MOCK_INCLUDES_LOGGED_HPP
+
+#include <string>
+
+class Logged {
+public:
+    static void info(const std::string& s) { }
+    static void warning(const std::string& s) { }
+
+};
+
+#endif /* MOCK_INCLUDES_LOGGED_HPP */

--- a/core/test/mock_includes/ConfigOutputAve/include/Logged.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/Logged.hpp
@@ -1,7 +1,4 @@
 /*!
- * @file Logged.hpp
- *
- * @date Mar 13, 2026
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/test/mock_includes/ConfigOutputAve/include/ModelMetadata.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/ModelMetadata.hpp
@@ -1,0 +1,13 @@
+/*!
+ * @file ModelMetadata.hpp
+ *
+ * @date Mar 12, 2026
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef MOCK_INCLUDES_MODELMETADATA_HPP
+#define MOCK_INCLUDES_MODELMETADATA_HPP
+
+class ModelMetadata;
+
+#endif /* MOCK_INCLUDES_MODELMETADATA_HPP */

--- a/core/test/mock_includes/ConfigOutputAve/include/ModelMetadata.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/ModelMetadata.hpp
@@ -1,7 +1,4 @@
 /*!
- * @file ModelMetadata.hpp
- *
- * @date Mar 12, 2026
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/core/test/mock_includes/ConfigOutputAve/include/StructureFactory.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/StructureFactory.hpp
@@ -1,0 +1,26 @@
+/*!
+ * @file StructureFactory.hpp
+ *
+ * @date Mar 11, 2026
+ * @author Tim Spain <timothy.spain@nersc.no>
+ */
+
+#ifndef MOCK_INCLUDES_STRUCTUREFACTORY_HPP
+#define MOCK_INCLUDES_STRUCTUREFACTORY_HPP
+
+#include "include/ModelState.hpp"
+#include "include/StructureFactory.hpp"
+class StructureFactory {
+public:
+    static Nextsim::ModelState& getState()
+    {
+        static Nextsim::ModelState storedState;
+        return storedState;
+    }
+    static void fileFromState(const Nextsim::ModelState& state, const std::string& filePath, bool isRestart)
+    {
+        getState() = state;
+    }
+};
+
+#endif /* MOCK_INCLUDES_STRUCTUREFACTORY_HPP */

--- a/core/test/mock_includes/ConfigOutputAve/include/StructureFactory.hpp
+++ b/core/test/mock_includes/ConfigOutputAve/include/StructureFactory.hpp
@@ -1,7 +1,4 @@
 /*!
- * @file StructureFactory.hpp
- *
- * @date Mar 11, 2026
  * @author Tim Spain <timothy.spain@nersc.no>
  */
 

--- a/run/config_june23.cfg
+++ b/run/config_june23.cfg
@@ -6,13 +6,13 @@ time_step = P0-0T00:15:00
 
 
 [Modules]
-DiagnosticOutputModule = Nextsim::ConfigOutput
+DiagnosticOutputModule = Nextsim::SnapshotOutput
 DynamicsModule = Nextsim::BBMDynamics
 IceThermodynamicsModule = Nextsim::ThermoWinton
 AtmosphereBoundaryModule = Nextsim::ERA5Atmosphere
 OceanBoundaryModule = Nextsim::TOPAZOcean
 
-[ConfigOutput]
+[SnapshotOutput]
 period = P0-1T0:00:00
 start = 2010-01-01T00:00:00Z
 field_names = hsnow,hice,tsurf,tinterior,tbottom,cice

--- a/run/config_june23.cfg
+++ b/run/config_june23.cfg
@@ -6,13 +6,13 @@ time_step = P0-0T00:15:00
 
 
 [Modules]
-DiagnosticOutputModule = Nextsim::SnapshotOutput
+DiagnosticOutputModule = Nextsim::ConfigOutput
 DynamicsModule = Nextsim::BBMDynamics
 IceThermodynamicsModule = Nextsim::ThermoWinton
 AtmosphereBoundaryModule = Nextsim::ERA5Atmosphere
 OceanBoundaryModule = Nextsim::TOPAZOcean
 
-[SnapshotOutput]
+[ConfigOutput]
 period = P0-1T0:00:00
 start = 2010-01-01T00:00:00Z
 field_names = hsnow,hice,tsurf,tinterior,tbottom,cice

--- a/test/ThermoIntegration_test.py
+++ b/test/ThermoIntegration_test.py
@@ -55,13 +55,13 @@ stop = 2011-01-01T00:00:00Z
 time_step = P0-1T00:00:00
 
 [Modules]
-DiagnosticOutputModule = Nextsim::ConfigOutput
+DiagnosticOutputModule = Nextsim::SnapshotOutput
 IceAlbedoModule = Nextsim::MU71Albedo
 AtmosphereBoundaryModule = Nextsim::MU71Atmosphere
 OceanBoundaryModule = Nextsim::FluxConfiguredOcean
 IceThermodynamicsModule = Nextsim::ThermoWinton
 
-[ConfigOutput]
+[SnapshotOutput]
 start = 2010-01-01T00:00:00Z
 field_names = hsnow,hice,tsurf,tinterior,tbottom
 


### PR DESCRIPTION
# Average diagnostic fields

Fixes #(827

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

Adds a new implementation to the diagnostic output module, `SnapshotOutput`, which behaves as `ConfigOutput` used, providing instantaneous snapshots of the model state at the specified times. Changes the behaviour of `ConfigOutput` to now average the values of the provided fields between the specified times. It is currently not possible to configure some fields to be output as an average while others are instantaneous samples.
 
---
# Test Description

Added a test, `ConfigOutputAve_test`, which is a stripped-down unit test that just tests the averaging functionality of the updated class.

As part of this, some infrastructure for creating mocks of parts of nextSIM-DG has been added.
 
---
# Documentation Impact

The online documentation includes differentiating description of the two classes.
