### PR TITLE
Drop `XiosOutput` section

### DIFF
--- a/core/src/Model.cpp
+++ b/core/src/Model.cpp
@@ -59,6 +59,10 @@ Model::~Model() { }
 
 void Model::configureRestarts()
 {
+    // Ensure configureRestarts is only called once
+    if (configuredRestarts) {
+        return;
+    }
     ModelMetadata& metadata = ModelMetadata::getInstance();
 
     // Parse the initial restart file name and the pattern for output restart files
@@ -74,10 +78,16 @@ void Model::configureRestarts()
 
     // Set global dimensions with an initial read of the input file
     metadata.setDimensionsFromFile(metadata.initialFileName);
+
+    configuredRestarts = true;
 }
 
 void Model::configureTime()
 {
+    // Ensure configureTime is only called once
+    if (configuredTime) {
+        return;
+    }
     ModelMetadata& metadata = ModelMetadata::getInstance();
 
 #ifdef USE_XIOS
@@ -106,6 +116,8 @@ void Model::configureTime()
         metadata.setTimes(startTimeStr, Duration(runLengthStr), stepStr);
     }
     iterator.setStartStopStep(metadata.startTime(), metadata.stopTime(), metadata.stepLength());
+
+    configuredTime = true;
 }
 
 void Model::configure()

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -325,6 +325,12 @@ void ModelMetadata::setDimensionsFromFile(const std::string& filename)
             // Determine coordinate system and communicate to XIOS
             const bool isSpherical
                 = (!ncFile.getVar("longitude").isNull() && !ncFile.getVar("latitude").isNull());
+            if (!isSpherical && ncFile.getVar("x").isNull() && ncFile.getVar("y").isNull()) {
+                throw std::runtime_error(
+                    "ModelMetadata: Could not find coordinate system variables 'longitude' and"
+                    " 'latitude' or 'x' and 'y' in input file '"
+                    + filename + "'.");
+            }
             Xios::setSphericalCoordinates(isSpherical);
 #endif
         }

--- a/core/src/ModelMetadata.cpp
+++ b/core/src/ModelMetadata.cpp
@@ -320,6 +320,13 @@ void ModelMetadata::setDimensionsFromFile(const std::string& filename)
 #else
             ModelArray::setDimension(dimType, dim.getSize());
 #endif
+
+#if USE_XIOS
+            // Determine coordinate system and communicate to XIOS
+            const bool isSpherical
+                = (!ncFile.getVar("longitude").isNull() && !ncFile.getVar("latitude").isNull());
+            Xios::setSphericalCoordinates(isSpherical);
+#endif
         }
     } catch (const netCDF::exceptions::NcException& nce) {
         std::string ncWhat(nce.what());

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -134,7 +134,6 @@ Xios::~Xios() { finalize(); }
 void Xios::close_context_definition()
 {
     if (isEnabled && contextStatus == DEFINITION_OPEN) {
-        // TODO: Check moving this here doesn't break anything else
         setupFiles();
 
         // Special handling of input fields

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -284,6 +284,23 @@ void Xios::parseConfig()
     // TODO: Avoid having to parse diagnostic fields for XIOS specifically (#981)
     diagnosticFieldNames = str2set(
         Configured::getConfiguration(keyMap.at(DIAGNOSTIC_FIELD_NAMES_KEY), std::string()));
+
+    // Ensure the coordinate variables are included in diagnostic files
+    if (spherical) {
+        if (diagnosticFieldNames.count(longitudeName) == 0) {
+            diagnosticFieldNames.insert(longitudeName);
+        }
+        if (diagnosticFieldNames.count(latitudeName) == 0) {
+            diagnosticFieldNames.insert(latitudeName);
+        }
+    } else {
+        if (diagnosticFieldNames.count(xName) == 0) {
+            diagnosticFieldNames.insert(xName);
+        }
+        if (diagnosticFieldNames.count(yName) == 0) {
+            diagnosticFieldNames.insert(yName);
+        }
+    }
 }
 
 //! Initialize the XIOS context with ID contextId

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -49,8 +49,6 @@ namespace Nextsim {
 
 static const std::string xDiagnosticPfx = "XiosDiagnostic";
 static const std::map<int, std::string> keyMap = { { Xios::ENABLED_KEY, "xios.enable" },
-    // TODO: Avoid having to parse restart fields (#1056)
-    { Xios::OUTPUT_FIELD_NAMES_KEY, "XiosOutput.field_names" },
     { Xios::DIAGNOSTIC_PERIOD_KEY, xDiagnosticPfx + ".period" },
     { Xios::DIAGNOSTIC_FILE_KEY, xDiagnosticPfx + ".filename" },
     // TODO: Avoid having to parse diagnostic fields for XIOS specifically (#981)
@@ -66,10 +64,6 @@ Xios::HelpMap& Xios::getHelpText(HelpMap& map, bool getAll)
             "to be modifed by the user. Build nextSIM-DG with XIOS support with the CMake argument "
             "-DENABLE_XIOS=ON, passing the path to your XIOS installation with "
             "-Dxios_DIR=/path/to/xios." },
-    };
-    map["XiosOutput"] = {
-        { keyMap.at(OUTPUT_FIELD_NAMES_KEY), ConfigType::STRING, {}, "", "",
-            "Comma-separated list of field names to be written to the output file." },
     };
     map["XiosDiagnostic"] = {
         { keyMap.at(DIAGNOSTIC_PERIOD_KEY), ConfigType::STRING, {}, "0", "",
@@ -266,9 +260,6 @@ std::set<std::string> str2set(const std::string& asStr, const char& delim = ',')
  */
 void Xios::parseConfig()
 {
-    // TODO: Avoid having to parse restart fields (#1056)
-    outputRestartFieldNames
-        = str2set(Configured::getConfiguration(keyMap.at(OUTPUT_FIELD_NAMES_KEY), std::string()));
     // TODO: Avoid having to parse diagnostic fields for XIOS specifically (#981)
     diagnosticFieldNames = str2set(
         Configured::getConfiguration(keyMap.at(DIAGNOSTIC_FIELD_NAMES_KEY), std::string()));
@@ -1075,6 +1066,7 @@ void Xios::setFieldType(
 void Xios::setPrognosticFieldType(const std::string& fieldId, const ModelArray::Type& fieldType)
 {
     setFieldType(fieldId, fieldType, OUTPUT_RESTART);
+    outputRestartFieldNames.insert(fieldId);
 }
 
 /*!

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -134,6 +134,8 @@ Xios::~Xios() { finalize(); }
 void Xios::close_context_definition()
 {
     if (isEnabled && contextStatus == DEFINITION_OPEN) {
+        // TODO: Check moving this here doesn't break anything else
+        setupFiles();
 
         // Special handling of input fields
         for (int ioType : { INPUT_RESTART, ERA5_FORCING, TOPAZ_FORCING }) {
@@ -195,6 +197,27 @@ void Xios::close_context_definition()
             }
         }
 
+        // Special handling of output fields
+        for (int ioType : { OUTPUT_RESTART, DIAGNOSTIC }) {
+            if (fileMap.at(ioType).empty()) {
+                continue;
+            }
+            const std::set<std::string> fieldIds
+                = (ioType == OUTPUT_RESTART) ? outputRestartFieldNames : diagnosticFieldNames;
+            for (const std::string& fieldId : fieldIds) {
+
+                // Ensure that fields have operation type 'instant' if not already defined
+                xios::CField* field = getField(fieldId);
+                if (!cxios_is_defined_field_operation(field)) {
+                    cxios_set_field_operation(field, "instant", strlen("instant"));
+                }
+
+                // Set grid references
+                const ModelArray::Type& type = getFieldType(fieldId);
+                setFieldGridRef(fieldId, gridIds[type]);
+            }
+        }
+
         cxios_context_close_definition();
         contextStatus = DEFINITION_CLOSED;
     }
@@ -236,7 +259,6 @@ void Xios::configure()
         setupClient();
         setupContext();
         setupCalendar();
-        setupFiles();
     }
 }
 

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -813,6 +813,10 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         if (!cxios_is_defined_field_name(baseField)) {
             throw std::runtime_error("Xios: Failed to set name for field '" + fieldId + "'");
         }
+
+        // Set grid reference
+        ModelArray::Type& fieldType = fieldTypes[fieldId];
+        setFieldGridRef(fieldId, gridIds[fieldType]);
     }
 
     int ioType = getFileIOType(fileId);
@@ -940,6 +944,10 @@ std::string Xios::createInputField(const std::string& fieldId, const int ioType)
     if (!cxios_is_defined_field_name(inputField)) {
         throw std::runtime_error("Xios: Failed to set name for input field '" + inputFieldId + "'");
     }
+
+    // Set grid reference
+    ModelArray::Type& fieldType = fieldTypes[inputFieldId];
+    setFieldGridRef(inputFieldId, gridIds[fieldType]);
 
     return inputFieldId;
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -813,10 +813,6 @@ void Xios::createField(const std::string& fieldId, const std::string& fileId)
         if (!cxios_is_defined_field_name(baseField)) {
             throw std::runtime_error("Xios: Failed to set name for field '" + fieldId + "'");
         }
-
-        // Set grid reference
-        ModelArray::Type& fieldType = fieldTypes[fieldId];
-        setFieldGridRef(fieldId, gridIds[fieldType]);
     }
 
     int ioType = getFileIOType(fileId);
@@ -944,10 +940,6 @@ std::string Xios::createInputField(const std::string& fieldId, const int ioType)
     if (!cxios_is_defined_field_name(inputField)) {
         throw std::runtime_error("Xios: Failed to set name for input field '" + inputFieldId + "'");
     }
-
-    // Set grid reference
-    ModelArray::Type& fieldType = fieldTypes[inputFieldId];
-    setFieldGridRef(inputFieldId, gridIds[fieldType]);
 
     return inputFieldId;
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1175,7 +1175,9 @@ void Xios::setupFields()
                 // Set the input field type and default the base field type correspondingly
                 ModelArray::Type fieldType = dimensionKeys.at(dimKey);
                 setFieldType(fieldId, fieldType, ioType);
-                setFieldType(fieldId, fieldType, NOT_READ);
+                if (fieldTypes.count(fieldId) == 0) {
+                    setFieldType(fieldId, fieldType, NOT_READ);
+                }
             }
             ncFile.close();
         } catch (const netCDF::exceptions::NcException& nce) {

--- a/core/src/include/Model.hpp
+++ b/core/src/include/Model.hpp
@@ -65,6 +65,9 @@ private:
     Iterator iterator;
     DevStep modelStep; // Change the model step calculation here
     PrognosticData pData;
+
+    bool configuredRestarts = false; // Guard to avoid repeated configuration
+    bool configuredTime = false; // Guard to avoid repeated configuration
 };
 
 } /* namespace Nextsim */

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -60,6 +60,8 @@ public:
 
     /* Configuration */
     void configure() override;
+    static void setSphericalCoordinates(const bool isSpherical) { spherical = isSpherical; }
+    static bool sphericalCoordinates() { return spherical; }
 
     /* Calendar, date and duration */
     void setCalendarStart(const TimePoint& start);
@@ -99,6 +101,7 @@ private:
 
     /* Configuration */
     void parseConfig();
+    inline static bool spherical = false;
 
     /* Client */
     const std::string clientId = "client";

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -78,7 +78,6 @@ public:
 
     enum {
         ENABLED_KEY,
-        OUTPUT_FIELD_NAMES_KEY,
         DIAGNOSTIC_PERIOD_KEY,
         DIAGNOSTIC_FILE_KEY,
         DIAGNOSTIC_FIELD_NAMES_KEY,

--- a/core/src/modules/StructureModule/include/ParametricGrid.hpp
+++ b/core/src/modules/StructureModule/include/ParametricGrid.hpp
@@ -24,6 +24,21 @@ public:
     ParametricGrid()
         : pio(nullptr)
     {
+#ifdef USE_XIOS
+        // Set XIOS field types for core grid-related fields
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
+        xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
+        const bool spherical = true; // TODO: Determine this
+        if (spherical) {
+            xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
+            xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
+        } else {
+            xiosHandler.setPrognosticFieldType(xName, ModelArray::Type::H);
+            xiosHandler.setPrognosticFieldType(yName, ModelArray::Type::H);
+        }
+        xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
+#endif
     }
     virtual ~ParametricGrid()
     {

--- a/core/src/modules/StructureModule/include/ParametricGrid.hpp
+++ b/core/src/modules/StructureModule/include/ParametricGrid.hpp
@@ -28,15 +28,14 @@ public:
         // Set XIOS field types for core grid-related fields
         Xios& xiosHandler = Xios::getInstance();
         xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
-        xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
-        const bool spherical = true; // TODO: Determine this
-        if (spherical) {
+        if (Xios::sphericalCoordinates()) {
             xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
             xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
         } else {
             xiosHandler.setPrognosticFieldType(xName, ModelArray::Type::H);
             xiosHandler.setPrognosticFieldType(yName, ModelArray::Type::H);
         }
+        xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
         xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
 #endif
     }

--- a/core/src/modules/StructureModule/include/RectangularGrid.hpp
+++ b/core/src/modules/StructureModule/include/RectangularGrid.hpp
@@ -28,6 +28,12 @@ public:
         , nx(0)
         , ny(0)
     {
+#ifdef USE_XIOS
+        // Set XIOS field types for core grid-related fields
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(xName, ModelArray::Type::H);
+        xiosHandler.setPrognosticFieldType(yName, ModelArray::Type::H);
+#endif
     }
 
     RectangularGrid(const GridDimensions& dims)

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -50,7 +50,7 @@ public:
         // Advected fields
         xiosHandler.setPrognosticFieldType(hiceName, ModelArray::AdvectionType);
         xiosHandler.setPrognosticFieldType(ciceName, ModelArray::AdvectionType);
-        xiosHandler.setPrognosticFieldType(damageName, ModelArray::AdvectionType);
+        xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::H);
         xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::AdvectionType);
 #endif
     }

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -46,7 +46,8 @@ public:
 #ifdef USE_XIOS
         // Set XIOS field types
         Xios& xiosHandler = Xios::getInstance();
-        xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
+
+        // Advected fields
         xiosHandler.setPrognosticFieldType(hiceName, ModelArray::AdvectionType);
         xiosHandler.setPrognosticFieldType(ciceName, ModelArray::AdvectionType);
         xiosHandler.setPrognosticFieldType(damageName, ModelArray::AdvectionType);

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -52,6 +52,10 @@ public:
         xiosHandler.setPrognosticFieldType(ciceName, ModelArray::AdvectionType);
         xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::H);
         xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::AdvectionType);
+
+        // FIXME: We need to write out u and v to get a perfect restart
+        // xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::H);
+        // xiosHandler.setPrognosticFieldType(vName, ModelArray::Type::H);
 #endif
     }
     virtual ~IDynamics() = default;

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -53,7 +53,7 @@ public:
         xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::H);
         xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::AdvectionType);
 
-        // FIXME: We need to write out u and v to get a perfect restart
+        // FIXME: We need to write out u and v to get a perfect restart (#1066)
         // xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::H);
         // xiosHandler.setPrognosticFieldType(vName, ModelArray::Type::H);
 #endif

--- a/core/src/modules/include/IStructure.hpp
+++ b/core/src/modules/include/IStructure.hpp
@@ -38,14 +38,6 @@ public:
         Xios& xiosHandler = Xios::getInstance();
         xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
         xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
-        const bool spherical = true; // TODO: determine this
-        if (spherical) {
-            xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
-            xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
-        } else {
-            xiosHandler.setPrognosticFieldType(xName, ModelArray::Type::H);
-            xiosHandler.setPrognosticFieldType(yName, ModelArray::Type::H);
-        }
         xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
 #endif
     }

--- a/core/src/modules/include/IStructure.hpp
+++ b/core/src/modules/include/IStructure.hpp
@@ -8,6 +8,10 @@
 
 #include "include/ModelMetadata.hpp"
 #include "include/ModelState.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#endif
+#include "include/gridNames.hpp"
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <string>
@@ -27,7 +31,24 @@ namespace Nextsim {
  */
 class IStructure {
 public:
-    IStructure() { }
+    IStructure()
+    {
+#ifdef USE_XIOS
+        // Set XIOS field types for core grid-related fields
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(coordsName, ModelArray::Type::VERTEX);
+        xiosHandler.setPrognosticFieldType(gridAzimuthName, ModelArray::Type::H);
+        const bool spherical = true; // TODO: determine this
+        if (spherical) {
+            xiosHandler.setPrognosticFieldType(latitudeName, ModelArray::Type::H);
+            xiosHandler.setPrognosticFieldType(longitudeName, ModelArray::Type::H);
+        } else {
+            xiosHandler.setPrognosticFieldType(xName, ModelArray::Type::H);
+            xiosHandler.setPrognosticFieldType(yName, ModelArray::Type::H);
+        }
+        xiosHandler.setPrognosticFieldType(maskName, ModelArray::Type::H);
+#endif
+    }
     virtual ~IStructure() = default;
 
     /*!

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -67,15 +67,14 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 3)
     Xios& xiosHandler = Xios::getInstance();
     REQUIRE(xiosHandler.getCalendarStep() == 0);
 
-    // Deduce the local lengths of the two dimensions
-    const size_t nx = ModelArray::size(ModelArray::Dimension::X);
-    const size_t ny = ModelArray::size(ModelArray::Dimension::Y);
-
     // Read restarts from file and check they take the expected values
     // NOTE: The ParametricGrid is created and the XIOS context definition is closed in the call to
     //       StructureFactory::stateFromFile()
-    for (const auto [fieldName, modelarray] :
-        StructureFactory::stateFromFile(diagnosticFilename).data) {
+    ModelState modelstate = StructureFactory::stateFromFile(diagnosticFilename);
+    REQUIRE(modelstate.data.count(sssName) > 0);
+    const size_t nx = ModelArray::size(ModelArray::Dimension::X);
+    const size_t ny = ModelArray::size(ModelArray::Dimension::Y);
+    for (const auto [fieldName, modelarray] : modelstate.data) {
         REQUIRE(fieldName == sssName);
         for (size_t j = 0; j < ny; ++j) {
             for (size_t i = 0; i < nx; ++i) {

--- a/core/test/XiosReadDiagnostic_test.cpp
+++ b/core/test/XiosReadDiagnostic_test.cpp
@@ -74,11 +74,15 @@ MPI_TEST_CASE("TestXiosReadDiagnostic", 3)
     REQUIRE(modelstate.data.count(sssName) > 0);
     const size_t nx = ModelArray::size(ModelArray::Dimension::X);
     const size_t ny = ModelArray::size(ModelArray::Dimension::Y);
+    REQUIRE(modelstate.data.count(sssName) > 0);
+    REQUIRE(modelstate.data.count(latitudeName) > 0);
+    REQUIRE(modelstate.data.count(longitudeName) > 0);
     for (const auto [fieldName, modelarray] : modelstate.data) {
-        REQUIRE(fieldName == sssName);
-        for (size_t j = 0; j < ny; ++j) {
-            for (size_t i = 0; i < nx; ++i) {
-                REQUIRE(modelarray(i, j) == doctest::Approx(0.15));
+        if (fieldName == sssName) {
+            for (size_t j = 0; j < ny; ++j) {
+                for (size_t i = 0; i < nx; ++i) {
+                    REQUIRE(modelarray(i, j) == doctest::Approx(0.15));
+                }
             }
         }
     }

--- a/core/test/XiosReadForcing_test.cpp
+++ b/core/test/XiosReadForcing_test.cpp
@@ -98,9 +98,14 @@ MPI_TEST_CASE("TestXiosReadForcing", 2)
     for (int ts = 0; ts <= 4; ts += 2) {
         const TimePoint& time = xiosHandler.getCurrentDate();
 
-        // Read ERA5 forcings from file and check they take the expected values
-        for (const auto& [fieldName, modelarray] :
-            pio->readForcingTimeStatic(era5ForcingFieldNames, time, era5ForcingFilename).data) {
+        // Read ERA5 forcings from file, checking that they contain the expected fields and that
+        // those have the expected values
+        ModelState era5Forcings
+            = pio->readForcingTimeStatic(era5ForcingFieldNames, time, era5ForcingFilename);
+        for (const auto& fieldName : era5ForcingFieldNames) {
+            REQUIRE(era5Forcings.data.count(fieldName) > 0);
+        }
+        for (const auto& [fieldName, modelarray] : era5Forcings.data) {
             for (size_t j = 0; j < ny; ++j) {
                 for (size_t i = 0; i < nx; ++i) {
                     REQUIRE(modelarray(i, j) == doctest::Approx(0.1 * ts));
@@ -108,12 +113,16 @@ MPI_TEST_CASE("TestXiosReadForcing", 2)
             }
         }
 
-        // Read TOPAZ forcings from file and check they take the expected values
+        // Read TOPAZ forcings from file, checking that they contain the expected fields and that
+        // those have the expected values
         // NOTE: Only the first timestep has TOPAZ data
         if (ts == 0) {
-            for (const auto& [fieldName, modelarray] :
-                pio->readForcingTimeStatic(topazForcingFieldNames, time, topazForcingFilename)
-                    .data) {
+            ModelState topazForcings
+                = pio->readForcingTimeStatic(topazForcingFieldNames, time, topazForcingFilename);
+            for (const auto& fieldName : topazForcingFieldNames) {
+                REQUIRE(topazForcings.data.count(fieldName) > 0);
+            }
+            for (const auto& [fieldName, modelarray] : topazForcings.data) {
                 for (size_t j = 0; j < ny; ++j) {
                     for (size_t i = 0; i < nx; ++i) {
                         REQUIRE(modelarray(i, j) == doctest::Approx(ts + 1));

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -70,13 +70,25 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
     REQUIRE(ModelArray::nComponents(ModelArray::Type::DG) == DGCOMP);
     REQUIRE(ModelArray::size(ModelArray::Dimension::DG) == DGCOMP);
 
-    // Read restarts from file and check they take the expected values
+    // Read restarts from file, checking that the expected fields are included and that they take
+    // the expected values
     // NOTE: The ParametricGrid is created and the XIOS context definition is closed in the call to
     //       StructureFactory::stateFromFile()
     int rank;
     MPI_Comm_rank(test_comm, &rank);
     float ts = 2; // Corresponds to 2023-03-17T20:10:59Z
     ModelState modelstate = StructureFactory::stateFromFile(restartFilename);
+    REQUIRE(modelstate.data.count(maskName) > 0);
+    REQUIRE(modelstate.data.count(longitudeName) > 0);
+    REQUIRE(modelstate.data.count(latitudeName) > 0);
+    REQUIRE(modelstate.data.count(gridAzimuthName) > 0);
+    REQUIRE(modelstate.data.count(coordsName) > 0);
+    REQUIRE(modelstate.data.count(ciceName) > 0);
+    REQUIRE(modelstate.data.count(hiceName) > 0);
+    REQUIRE(modelstate.data.count(damageName) > 0);
+    REQUIRE(modelstate.data.count(hsnowName) > 0);
+    REQUIRE(modelstate.data.count(ticeName) > 0);
+    REQUIRE(modelstate.data.count(shearName) > 0);
     ModelArray& mask = modelstate.data.at(maskName);
     for (size_t j = 0; j < ny; ++j) {
         for (size_t i = 0; i < nx; ++i) {

--- a/core/test/XiosReadRestart_test.cpp
+++ b/core/test/XiosReadRestart_test.cpp
@@ -114,6 +114,12 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
                     REQUIRE(modelarray(i, j) == doctest::Approx(0.0));
                 }
             }
+        } else if (fieldName == damageName) {
+            for (size_t j = 0; j < ny; ++j) {
+                for (size_t i = 0; i < nx; ++i) {
+                    REQUIRE(modelarray(i, j) == doctest::Approx(1.0 * ts * (i + nx * j)));
+                }
+            }
         } else if (fieldName == coordsName) {
             for (size_t j = 0; j < ny + 1; ++j) {
                 for (size_t i = 0; i < nx + 1; ++i) {
@@ -128,8 +134,7 @@ MPI_TEST_CASE("TestXiosReadRestart", 2)
                     REQUIRE(modelarray.components({ i, j })[1] == doctest::Approx(expected_y));
                 }
             }
-        } else if (fieldName == ciceName || fieldName == hiceName || fieldName == damageName
-            || fieldName == hsnowName) {
+        } else if (fieldName == ciceName || fieldName == hiceName || fieldName == hsnowName) {
             for (size_t j = 0; j < ny; ++j) {
                 for (size_t i = 0; i < nx; ++i) {
                     for (size_t d = 0; d < DGCOMP; ++d) {

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -43,11 +43,6 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     config << "restart_file = " << outputFilename << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
-    config << "[XiosOutput]" << std::endl;
-    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
-           << damageName << "," << hsnowName << "," << ticeName << "," << shearName << ","
-           << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/core/test/XiosReadWriteRestart_test.cpp
+++ b/core/test/XiosReadWriteRestart_test.cpp
@@ -64,11 +64,22 @@ MPI_TEST_CASE("TestXiosReadWriteRestart", 2)
     REQUIRE(ModelArray::nComponents(ModelArray::Type::DG) == DGCOMP);
     REQUIRE(ModelArray::size(ModelArray::Dimension::DG) == DGCOMP);
 
-    // Read initial state from the test input file
+    // Read initial state from the test input file, checking that the it contains the expected
+    // fields
     // NOTE: XIOS axes, domains, and grids are created by the ParaGridIO constructor, which is
     //       constructed in the call to StructureFactory::stateFromFile(). The XIOS context also
     //       gets closed in this call.
     ModelState modelstate = StructureFactory::stateFromFile(inputFilename);
+    REQUIRE(modelstate.data.count(maskName) > 0);
+    REQUIRE(modelstate.data.count(longitudeName) > 0);
+    REQUIRE(modelstate.data.count(latitudeName) > 0);
+    REQUIRE(modelstate.data.count(gridAzimuthName) > 0);
+    REQUIRE(modelstate.data.count(coordsName) > 0);
+    REQUIRE(modelstate.data.count(ciceName) > 0);
+    REQUIRE(modelstate.data.count(hiceName) > 0);
+    REQUIRE(modelstate.data.count(hsnowName) > 0);
+    REQUIRE(modelstate.data.count(ticeName) > 0);
+    REQUIRE(modelstate.data.count(shearName) > 0);
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("readwrite*.nc"));

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -52,12 +52,12 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     // Create ModelMPI instance based off the test communicator
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
-    // Create a Model and configure it so that time options are parsed
+    // Create a Model
     Model model;
     model.configureRestarts();
     model.configureTime();
 
-    // Get the Xios singleton instance and check it's initialized
+    // Get the Xios singleton instance
     // NOTE: The singleton is created when Xios::getInstance() is first called. In this test, this
     //       happens when the time sets set by ModelMetadata::setTime(). This occurs in the call to
     //       Model::configureTime() above.
@@ -114,8 +114,7 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     }
 
     // Check the files have indeed been created
-    // NOTE: Don't remove them because their contents are checked in
-    // XiosReadxios_test_diagnostic_test
+    // NOTE: Don't remove them because their contents are checked in XiosReadDiagnostic_test
     REQUIRE(std::filesystem::exists("diagnostic_2023-03-17T17:11:00Z-2023-03-17T20:10:59Z.nc"));
     REQUIRE(std::filesystem::exists("diagnostic_2023-03-17T20:11:00Z-2023-03-17T23:10:59Z.nc"));
 

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -79,6 +79,7 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     // Create some fake data to test writing methods
     HField sss(ModelArray::Type::H);
     sss.reinitialize();
+    sss.resize();
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("diagnostic*.nc"));

--- a/core/test/XiosWriteDiagnostic_test.cpp
+++ b/core/test/XiosWriteDiagnostic_test.cpp
@@ -77,9 +77,22 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
     grid.setIO(pio);
 
     // Create some fake data to test writing methods
+    HField longitude(ModelArray::Type::H);
+    longitude.reinitialize();
+    for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+            longitude(i, j) = i;
+        }
+    }
+    HField latitude(ModelArray::Type::H);
+    latitude.reinitialize();
+    for (size_t j = 0; j < ny; ++j) {
+        for (size_t i = 0; i < nx; ++i) {
+            latitude(i, j) = j;
+        }
+    }
     HField sss(ModelArray::Type::H);
     sss.reinitialize();
-    sss.resize();
 
     // Check files with the expected names don't exist yet
     REQUIRE_FALSE(std::filesystem::exists("diagnostic*.nc"));
@@ -103,6 +116,8 @@ MPI_TEST_CASE("TestXiosWriteDiagnostic", 2)
 
         // Set up ModelStates for diagnostics and write out
         ModelState diagnostics = { {
+                                       { longitudeName, longitude },
+                                       { latitudeName, latitude },
                                        { sssName, sss },
                                    },
             {} };

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -49,15 +49,26 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     // Create ModelMPI instance based off the test communicator
     auto& modelMPI = ModelMPI::getInstance(test_comm);
 
-    // Create a Model and configure it so that time options are parsed
+    // Create a Model
     Model model;
-    model.configure();
+    model.configureRestarts();
+    model.configureTime();
 
-    // Get the Xios singleton instance and check it's initialized
+    // Get the Xios singleton instance
     // NOTE: The singleton is created when Xios::getInstance() is first called. In this test, this
     //       happens when the time sets set by ModelMetadata::setTime(). This occurs in the call to
     //       Model::configureTime() above.
     Xios& xiosHandler = Xios::getInstance();
+
+    // Custom XIOS configuration to ensure the unit test covers all discretisation types
+    // NOTE: This needs to happen after Model::configureTime() but before the rest of
+    //       Model::configure() so is placed here. Doing this is a non-standard approach purely for
+    //       testing purposes.
+    xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
+    xiosHandler.setPrognosticFieldType(shearName, ModelArray::Type::CG);
+
+    // Continue configuration
+    model.configure();
 
     // Set ModelArray dimensions
     const size_t nx = ModelArray::size(ModelArray::Dimension::X);
@@ -67,10 +78,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
 
     // The ParametricGrid structure is required by XIOS
     Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
-
-    // Set field types for restarts
-    xiosHandler.setPrognosticFieldType(ticeName, ModelArray::Type::DGSTRESS);
-    xiosHandler.setPrognosticFieldType(shearName, ModelArray::Type::CG);
 
     // Create some fake data to test writing methods
     HField longitude(ModelArray::Type::H);

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -121,7 +121,7 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     cice.reinitialize();
     DGField hice(ModelArray::Type::DG);
     hice.reinitialize();
-    DGField damage(ModelArray::Type::DG);
+    HField damage(ModelArray::Type::H);
     damage.reinitialize();
     DGField hsnow(ModelArray::Type::DG);
     hsnow.reinitialize();
@@ -145,6 +145,13 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     MPI_Comm_rank(test_comm, &rank);
     for (int ts = 0; ts <= 4; ts++) {
 
+        // Update HField restarts
+        for (size_t j = 0; j < ny; ++j) {
+            for (size_t i = 0; i < nx; ++i) {
+                damage(i, j) = 1.0 * ts * (i + nx * j);
+            }
+        }
+
         // Update DGField restarts
         // NOTE: NaN values for mask when i = 0 and j = 0
         for (size_t j = 0; j < ny; ++j) {
@@ -154,7 +161,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
                         = (i == 0 && j == 0) ? NAN : 1.0 * ts * (d + DGCOMP * (i + nx * j));
                     cice.components({ i, j })[d] = value;
                     hice.components({ i, j })[d] = value;
-                    damage.components({ i, j })[d] = value;
                     hsnow.components({ i, j })[d] = value;
                 }
             }

--- a/core/test/XiosWriteRestart_test.cpp
+++ b/core/test/XiosWriteRestart_test.cpp
@@ -43,11 +43,6 @@ MPI_TEST_CASE("TestXiosWriteRestart", 2)
     config << "restart_file = " << outputFilename << std::endl;
     config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
     config << "restart_period = P0-0T03:00:00" << std::endl;
-    config << "[XiosOutput]" << std::endl;
-    config << "field_names = " << maskName << "," << longitudeName << "," << latitudeName << ","
-           << coordsName << "," << gridAzimuthName << "," << ciceName << "," << hiceName << ","
-           << damageName << "," << hsnowName << "," << ticeName << "," << shearName << ","
-           << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -64,9 +64,6 @@ variables:
   float hice(y_dim, x_dim, dg_comp) ;
 		hice:online_operation = "once" ;
 		hice:coordinates = "lat lon dg_comp" ;
-  float damage(y_dim, x_dim, dg_comp) ;
-		damage:online_operation = "once" ;
-		damage:coordinates = "lat lon dg_comp" ;
   float hsnow(y_dim, x_dim, dg_comp) ;
 		hsnow:online_operation = "once" ;
 		hsnow:coordinates = "lat lon dg_comp" ;
@@ -127,16 +124,6 @@ data:
   18, 19, 20, 21, 22, 23 ;
 
  hice =
-  NaN, 1, NaN, 3, NaN, 5,
-  NaN, 7, NaN, 9, NaN, 11,
-  NaN, 1, NaN, 3, NaN, 5,
-  NaN, 7, NaN, 9, NaN, 11,
-  12, 13, 14, 15, 16, 17,
-  18, 19, 20, 21, 22, 23,
-  12, 13, 14, 15, 16, 17,
-  18, 19, 20, 21, 22, 23 ;
-
- damage =
   NaN, 1, NaN, 3, NaN, 5,
   NaN, 7, NaN, 9, NaN, 11,
   NaN, 1, NaN, 3, NaN, 5,

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -54,9 +54,6 @@ variables:
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
-	float grid_azimuth(y_dim, x_dim) ;
-		grid_azimuth:online_operation = "once" ;
-		grid_azimuth:coordinates = "lat lon" ;
 	float sss(y_dim, x_dim) ;
 		sss:online_operation = "once" ;
 		sss:coordinates = "lat lon" ;
@@ -112,10 +109,6 @@ data:
  mask =
   0, 1, 0, 1,
   1, 1, 1, 1 ;
-
- grid_azimuth =
-  0, 0, 0, 0,
-  0, 0, 0, 0 ;
 
  sss =
   _, _, _, _,

--- a/core/test/xios_test_input.cdl
+++ b/core/test/xios_test_input.cdl
@@ -54,6 +54,9 @@ variables:
 	float mask(y_dim, x_dim) ;
 		mask:online_operation = "once" ;
 		mask:coordinates = "lat lon" ;
+	float grid_azimuth(y_dim, x_dim) ;
+		grid_azimuth:online_operation = "once" ;
+		grid_azimuth:coordinates = "lat lon" ;
 	float sss(y_dim, x_dim) ;
 		sss:online_operation = "once" ;
 		sss:coordinates = "lat lon" ;
@@ -109,6 +112,10 @@ data:
  mask =
   0, 1, 0, 1,
   1, 1, 1, 1 ;
+
+ grid_azimuth =
+  0, 0, 0, 0,
+  0, 0, 0, 0 ;
 
  sss =
   _, _, _, _,

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -94,45 +94,13 @@ building without XIOS. That is, the ``model`` section should include
   restart_file = my_restart_file.nc
   restart_period = P0-0T02:00:00
 
-Information related to fields to be written to files are currently configured
-via the ``XiosOutput`` section (for restart files), and ``XiosDiagnostic`` section (for diagnostic files). 
-Note that both of these sections are optional. Moreover, they
-provide an interim solution. Eventually, it will not be necessary to provide
-XIOS-specific configuration information.
-
-For restart files, the filename is determined from the ``restart_file`` entry in
-the ``model`` section mentioned above. In the case of diagnostics files, the
-file names are configured differently, via the ``filename`` entry in the
-``XiosDiagnostic`` section. For example,
-
-.. code-block::
-
-   [XiosDiagnostic]
-   filename = my_diag_file.nc
-
-Restart and diagnostic file names may include format strings such as
-``restart%Y-%m-%dT%H:%M:%SZ.nc`` or ``diagnostic%Y-%m-%dT%H:%M:%SZ.nc`` (in
-fact, these are the defaults). When writing out restarts and diagnostics, a
-separate file is produced for each restart period, with filename of the format
-``<FILENAME>_<START_TIME>-<END_TIME>.nc``, where ``<START_TIME>`` and
+Restart file names may include format strings such as
+``restart%Y-%m-%dT%H:%M:%SZ.nc`` (in fact, this is the default). When writing
+out, a separate file is produced for each restart period, with filename of the
+format ``<FILENAME>_<START_TIME>-<END_TIME>.nc``, where ``<START_TIME>`` and
 ``<END_TIME>`` are the start and end of the associated period, written using the
 provided format string. Restart files contain the state at the beginning of the
-time window, whereas diagnostics files are averaged over the timesteps in the
-window.
-
-In addition to specifying file names, we need to specify which fields are to be
-written using each I/O type. For example, we could specify that two fields
-labelled ``field_A`` and ``field_B`` are to be written into restart files as
-follows:
-
-.. code-block::
-
-  [XiosOutput]
-  field_names = field_A,field_B
-
-The ``field_names`` entry may contain a single field name or a comma-separated
-list. Note that this is an interim solution. Eventually, it will not be
-necessary to provide field names to configure XIOS.
+time window.
 
 As elsewhere in the model, the configuration values above are all parsed by
 calling the ``Model.configure()`` member function. Note that this function will
@@ -140,6 +108,39 @@ automatically initialize the model state based on the ``input_file`` entry and
 all field variables found in that file, including variables defining the grid
 i.e., ``longitude`` and ``latitude`` and possibly ``coords`` and
 ``grid_azimuth``.
+
+Diagnostics files
+-----------------
+
+Information related to diagnostic outputs are currently configured via the
+(optional) ``XiosDiagnostic`` section. This is an interim solution that will
+eventually be unified with the ``ConfigOutput`` section.
+File names are configured via the ``filename`` entry. For example,
+
+.. code-block::
+
+   [XiosDiagnostic]
+   filename = my_diag_file.nc
+
+As with restart files, diagnostic file names may include format strings such as
+``diagnostic%Y-%m-%dT%H:%M:%SZ.nc``. While restart files contain the state at
+the beginning of the time window, diagnostics files are averaged over the
+timesteps in the window.
+
+In addition to specifying file names, we need to specify which fields are to be
+written using each I/O type. For example, we could specify that two fields
+labelled ``field_A`` and ``field_B`` are to be written as diagnostics as
+follows:
+
+.. code-block::
+
+  [XiosDiagnostic]
+  field_names = field_A,field_B
+
+The ``field_names`` entry may contain a single field name or a comma-separated
+list. This is an interim solution that will eventually be unified with the
+``ConfigOutput`` section.
+
 
 Forcing files
 -------------
@@ -175,21 +176,11 @@ following:
 1. Set configuration options as for other parts of the model. (See section above
    for options.)
 2. Configure the ``Model`` by constructing it and calling its ``configure``
-   member function.
-3. Construct a ``ParametricGrid`` and a new ``ParaGridIO`` pointer.
-4. Associate the ``ParaGridIO`` pointer with the ``ParametricGrid`` instance
-   using the latter's ``setIO`` member function.
-5. Get the ``Xios`` handler singleton using ``Xios::getInstance``.
-6. For each field to be written to file with XIOS, the field type needs to be
-   set. By default, ``coords`` is set to ``ModelArray::Type::VERTEX`` and
-   ``hice``, ``cice``, ``damage``, and ``hsnow`` are all determined based on the
-   ``ModelArray::AdvectionType`` set in the grid implementation. All other
-   fields default to ``ModelArray::Type::H``. If you want to customise any other
-   field types then call the ``setPrognosticFieldType`` or
-   ``setDiagnosticFieldType`` member function of ``Xios`` as appropriate,
-   providing the field name as the first argument and the
-   ``ModelArray::Type::<TYPE>`` enum as the second argument (replacing
-   ``<TYPE>>`` with the desired type).
+   member function. NextSIM-DG communicates the field type (i.e.,
+   discretisation) for each field to XIOS during this step, which allows XIOS to
+   set up the correct data structures for each field.
+3. Get the ``Xios`` handler singleton using ``Xios::getInstance()``.
+4. Specify the ``ParametricGrid`` grid type.
 
 There is no need to explicitly close the XIOS context definition because this
 happens automatically upon reading or writing. As such, all XIOS configuration

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -206,7 +206,7 @@ Different domains are used for different field types, depending on the number of
 degrees of freedom (DoFs) they have in the horizontal. The ``HDomain`` has one
 DoF per cell and is used for the ``HField``, ``DGField``, and ``DGSField``
 types. The ``VertexDomain`` has one DoF per vertex and is used for the
-``VertexField`` type. Finally, the ``CGDomain`` has the same (degree-dependant)
+``VertexField`` type. Finally, the ``CGDomain`` has the same (degree-dependent)
 number of DoFs as the continuous Galerkin discretisation and is used by
 ``CGField``.
 
@@ -230,19 +230,22 @@ XIOS Field concept
 ^^^^^^^^^^^^^^^^^^
 
 An instance of the Field type is based on a Grid and is associated with a
-``ModelArray::Type``. Fields are created automatically upon configuring the
-``Model``. For fields that are read from file, the field type is determined
-automatically during the file read. For fields that are written, it's required
-to call the ``setPrognosticFieldType`` or ``setDiagnosticFieldType`` member
-function of the ``Xios`` singleton, providing the field name and
-``ModelArray::Type``.
+``ModelArray::Type``. For fields that are read from file, the field type is
+determined automatically during the file read. For fields that are written, it's
+required to call the ``setPrognosticFieldType`` or ``setDiagnosticFieldType``
+member function of the ``Xios`` singleton, providing the field name and
+``ModelArray::Type``. Fields are created automatically upon closing the XIOS
+context definition, so calls to ``setPrognosticFieldType`` and
+``setDiagnosticFieldType`` must be made before this (i.e., before any files are
+read from or written).
 
 XIOS File concept
 ^^^^^^^^^^^^^^^^^
 
 The File concept holds metadata related to input and output files, including
 which Fields are associated with it and whether it is to be used for reading or
-writing. Files are created automatically upon configuring the ``Model``.
+writing. Files are created automatically upon closing the XIOS context
+definition.
 
 Developer notes
 ---------------

--- a/physics/src/modules/ColumnPhysicsModule/NSColumnPhysics.cpp
+++ b/physics/src/modules/ColumnPhysicsModule/NSColumnPhysics.cpp
@@ -3,8 +3,8 @@
  * @author  Einar Ólason <einar.olason@nersc.no>
  */
 
-#include "include/NSColumnPhysics.hpp"
 #include "include/Finalizer.hpp"
+#include "include/NSColumnPhysics.hpp"
 #include "include/NextsimModule.hpp"
 #include "include/constants.hpp"
 
@@ -19,7 +19,8 @@ static const std::map<int, std::string> keyMap = {
 };
 
 NSColumnPhysics::NSColumnPhysics()
-    : hiceAccessor(getStore())
+    : IColumnPhysics()
+    , hiceAccessor(getStore())
     , ciceAccessor(getStore())
     , hsnowAccessor(getStore())
     , qowAccessor(getStore())

--- a/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
+++ b/physics/src/modules/IceThermodynamicsModule/ThermoWinton.cpp
@@ -3,10 +3,13 @@
  * @author  Robert Jendersie <robert.jendersie@ovgu.de>
  */
 
-#include "include/ThermoWinton.hpp"
 #include "include/IceMinima.hpp"
+#include "include/ThermoWinton.hpp"
 
 #include "include/KernelAlternatives.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#endif
 #include "include/constants.hpp"
 #include "include/gridNames.hpp"
 #include "kokkos/include/KokkosTimer.hpp"
@@ -42,6 +45,13 @@ ThermoWinton::ThermoWinton()
     topMeltAccessor.getHostRW().reinitialize();
     botMeltAccessor.getHostRW().reinitialize();
     snowToIceAccessor.getHostRW().reinitialize();
+
+#ifdef USE_XIOS
+    // Set XIOS field types
+    Xios& xiosHandler = Xios::getInstance();
+    xiosHandler.setPrognosticFieldType(tInteriorName, ModelArray::AdvectionType);
+    xiosHandler.setPrognosticFieldType(tBottomName, ModelArray::AdvectionType);
+#endif
 }
 
 static const std::map<int, std::string> keyMap = {

--- a/physics/src/modules/include/IIceThermodynamics.hpp
+++ b/physics/src/modules/include/IIceThermodynamics.hpp
@@ -13,6 +13,9 @@
 #include "include/ModelComponent.hpp"
 #include "include/Slice.hpp"
 #include "include/Time.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#endif
 #include "include/gridNames.hpp"
 
 namespace Nextsim {
@@ -102,6 +105,12 @@ protected:
         , sssAccessor(getStore())
         , qswBaseAccessor(getStore())
     {
+
+#ifdef USE_XIOS
+        // Set XIOS field types
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(tsurfName, ModelArray::AdvectionType);
+#endif
     }
 
     ModelArrayAccessor<Shared::H_ICE_DG, RW> hiceAccessor; // From PrognosticData

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -11,6 +11,9 @@
 #include "include/KernelAlternatives.hpp"
 #include "include/ModelArrayAccessor.hpp"
 #include "include/constants.hpp"
+#ifdef USE_XIOS
+#include "include/Xios.hpp"
+#endif
 #include "include/gridNames.hpp"
 
 namespace Nextsim {
@@ -48,6 +51,13 @@ public:
         , tauXOWAccessor(getStore())
         , tauYOWAccessor(getStore())
     {
+
+#ifdef USE_XIOS
+        // Set XIOS field types
+        Xios& xiosHandler = Xios::getInstance();
+        xiosHandler.setPrognosticFieldType(sssName, ModelArray::Type::H);
+        xiosHandler.setPrognosticFieldType(sstName, ModelArray::Type::H);
+#endif
     }
     virtual ~IOceanBoundary() = default;
 

--- a/physics/src/modules/include/IOceanBoundary.hpp
+++ b/physics/src/modules/include/IOceanBoundary.hpp
@@ -11,9 +11,6 @@
 #include "include/KernelAlternatives.hpp"
 #include "include/ModelArrayAccessor.hpp"
 #include "include/constants.hpp"
-#ifdef USE_XIOS
-#include "include/Xios.hpp"
-#endif
 #include "include/gridNames.hpp"
 
 namespace Nextsim {
@@ -51,13 +48,6 @@ public:
         , tauXOWAccessor(getStore())
         , tauYOWAccessor(getStore())
     {
-
-#ifdef USE_XIOS
-        // Set XIOS field types
-        Xios& xiosHandler = Xios::getInstance();
-        xiosHandler.setPrognosticFieldType(sssName, ModelArray::Type::H);
-        xiosHandler.setPrognosticFieldType(sstName, ModelArray::Type::H);
-#endif
     }
     virtual ~IOceanBoundary() = default;
 


### PR DESCRIPTION
# Drop `XiosOutput` section

Fixes #1056
Merges into #1057

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

This PR allows us to drop the temporary `XiosOutput` config section. In order to achieve this, I needed to ensure that each module that defines a `getStatePrognostic` member function also sets XIOS field types appropriately.

---
# Test Description

I noticed that some fields were slipping through the cracks in the XIOS tests so I made them more robust. That is, I added checks that the expected fields are all found in any input files.

I also dropped `damage` from the test input file to check that it gets set up automatically during model configuration, as expected.

---
# Documentation Impact

The XIOS docs page has been updated accordingly.
