### PR TITLE
Fix Halo constructor for `DGVectorHolder`

### DIFF
--- a/core/src/Halo.cpp
+++ b/core/src/Halo.cpp
@@ -50,7 +50,7 @@ void Halo::setSpatialDims()
     }
 }
 
-void Halo::intializeHaloMetadata()
+void Halo::initializeHaloMetadata()
 {
     // number of halo cells (should be general for any halo width)
     if (not isCG) {

--- a/core/src/include/Halo.hpp
+++ b/core/src/include/Halo.hpp
@@ -7,7 +7,8 @@
  *
  * All functionality for halo exchange between MPI ranks is contained in this class.
  *
- * Halo supports the main data structures of NextSim e.g., ModelArray, DGVector and CGVector.
+ * Halo supports the main data structures of NextSim e.g., ModelArray, DGVector, DGVectorHolder and
+ * CGVector.
  *
  * The halos are exchange via one-sided MPI communication using Remote Memory Access (RMA).
  */
@@ -49,14 +50,18 @@ public:
         m_numComps = ma.nComponents();
         isVertex = ma.getType() == ModelArray::Type::VERTEX;
         setSpatialDims();
-        intializeHaloMetadata();
+        initializeHaloMetadata();
     }
 
     /*!
      * @brief Constructs a halo object from DGVectorHolder
      * @param dgvh DGVectorHolder object to create halo from
      */
-    template <int N> Halo(DGVectorHolder<N>& dgvh) { Halo(static_cast<DGVector<N>&>(dgvh)); }
+    template <int N>
+    Halo(DGVectorHolder<N>& dgvh)
+        : Halo(static_cast<DGVector<N>&>(dgvh))
+    {
+    }
 
     /*!
      * @brief Constructs a halo object from DGVector
@@ -66,7 +71,7 @@ public:
     {
         m_numComps = N;
         setSpatialDims();
-        intializeHaloMetadata();
+        initializeHaloMetadata();
     }
 
     /*!
@@ -80,7 +85,7 @@ public:
         CGdegree = N;
         nCells = CGdegree;
         setSpatialDims();
-        intializeHaloMetadata();
+        initializeHaloMetadata();
     }
 
     static const size_t haloWidth = HALOWIDTH; // how many cells wide is the halo region
@@ -128,7 +133,7 @@ private:
      * - Defines edge lengths
      * - Sets up inner and outer slices for Bottom, Right, Top, Left edges
      */
-    void intializeHaloMetadata();
+    void initializeHaloMetadata();
 
     /**
      * @brief Return true if the provided edge is vertical (LEFT or RIGHT).

--- a/core/test/HaloExchangeCB_test.cpp
+++ b/core/test/HaloExchangeCB_test.cpp
@@ -8,6 +8,7 @@
  * - VertexField
  * - DGField
  * - DGVector
+ * - DGVectorHolder
  * - CGVector
  */
 
@@ -19,6 +20,7 @@
 #include "include/DGModelArray.hpp"
 #include "include/Halo.hpp"
 #include "include/Interpolations.hpp"
+#include "include/dgVectorHolder.hpp"
 
 namespace Nextsim {
 
@@ -218,6 +220,54 @@ MPI_TEST_CASE("DGVector", 3)
     halo.exchangeHalos(testData);
 
     verifyTestData(testData, localNx, localNy, offsetX, offsetY, nx, ny);
+}
+
+MPI_TEST_CASE("DGVectorHolder", 3)
+{
+    auto& modelMPI = ModelMPI::getInstance();
+    auto& metadata = ModelMetadata::getInstance();
+
+    const size_t nx = metadata.getGlobalExtentX();
+    const size_t ny = metadata.getGlobalExtentY();
+    const size_t localNx = metadata.getLocalExtentX() + 2 * Halo::haloWidth;
+    const size_t localNy = metadata.getLocalExtentY() + 2 * Halo::haloWidth;
+    const size_t offsetX = metadata.getLocalCornerX();
+    const size_t offsetY = metadata.getLocalCornerY();
+
+    ModelArray::setDimension(ModelArray::Dimension::X, nx, localNx, offsetX);
+    ModelArray::setDimension(ModelArray::Dimension::Y, ny, localNy, offsetY);
+    ModelArray::setNComponents(ModelArray::Type::DG, DG);
+
+    ParametricMesh smesh(CARTESIAN);
+    smesh.nx = localNx;
+    smesh.ny = localNy;
+    smesh.nelements = localNx * localNy;
+    smesh.nnodes = (localNx + 1) * (localNy + 1);
+    smesh.vertices.resize(smesh.nnodes, Eigen::NoChange);
+    for (size_t i = 0; i < localNx + 1; ++i) {
+        for (size_t j = 0; j < localNy + 1; ++j) {
+            smesh.vertices(i * (localNy + 1) + j, 0) = i;
+            smesh.vertices(i * (localNy + 1) + j, 1) = j;
+        }
+    }
+
+    // create example DGVector
+    DGVector<DG> testData(smesh);
+    testData.zero();
+
+    DGVectorHolder<DG> testHolder;
+    testHolder = DGVectorHolder<DG>(testData);
+
+    // create halo for testData model array
+    Halo halo(testHolder);
+
+    initializeTestData(static_cast<DGVector<DG>&>(testHolder), localNx, localNy, offsetX, offsetY);
+
+    // exchange halos
+    halo.exchangeHalos(static_cast<DGVector<DG>&>(testHolder));
+
+    verifyTestData(
+        static_cast<DGVector<DG>&>(testHolder), localNx, localNy, offsetX, offsetY, nx, ny);
 }
 
 MPI_TEST_CASE("CGVector", 3)


### PR DESCRIPTION
# Fix `Halo` constructor for `DGVectorHolder`

Fixes #1064 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

After simplifying #1005 I accidentally introduced a bug by making the `DGVectorHolder` constructor directly call the `DGVector` one i.e., 
https://github.com/nextsimhub/nextsimdg/blob/2165b00b858f7c15139b8c5a3ed581c942a568d8/core/src/include/Halo.hpp#L59

This is incorrect and leads to a segmentation fault.

I have now modified the constructor to use the Member Initializer List, which will ensure the object is stored correctly
https://github.com/nextsimhub/nextsimdg/blob/6f337fb12867865fb1a1842c64f8949098b6395b/core/src/include/Halo.hpp#L60-L64


I added a test to check it works correctly, and I have fixed a small typo in the naming of `initializeHaloMetadata` (which was `intializeHaloMetadata` before)

---
# Test Description

I added `MPI_TEST_CASE("DGVectorHolder", 3)` to `HaloExchangeCB_test.cpp` to check that halo exchange works correctly for `DGVectorHolder`
