### PR TITLE
XIOS: Account for `U` and `V` fields

### DIFF
--- a/core/src/ParaGridIO_Xios.cpp
+++ b/core/src/ParaGridIO_Xios.cpp
@@ -60,6 +60,14 @@ ModelState ParaGridIO::getModelState(const std::string& filePath)
             HField field(ModelArray::Type::H);
             field.reinitialize();
             state.merge(ModelState { { { fieldId, field } }, {} });
+        } else if (type == ModelArray::Type::U) {
+            UField field(ModelArray::Type::U);
+            field.reinitialize();
+            state.merge(ModelState { { { fieldId, field } }, {} });
+        } else if (type == ModelArray::Type::V) {
+            VField field(ModelArray::Type::V);
+            field.reinitialize();
+            state.merge(ModelState { { { fieldId, field } }, {} });
         } else if (type == ModelArray::Type::VERTEX) {
             VertexField field(ModelArray::Type::VERTEX);
             field.reinitialize();

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1654,32 +1654,35 @@ void Xios::postprocessOutputFiles()
  */
 void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
 {
+    using Type = ModelArray::Type;
+
     if (modelarray.nDimensions() != 2) {
         throw std::invalid_argument("Only ModelArrays of dimension 2 are supported");
     }
     auto& dims = modelarray.dimensions();
-    const ModelArray::Type& type = modelarray.getType();
+    const Type& type = modelarray.getType();
     domainWritten[domainIds[type]] = true;
 
     // Check the field type
-    const ModelArray::Type& expectedType = getFieldType(fieldId);
+    const Type& expectedType = getFieldType(fieldId);
     if (expectedType != type) {
         throw std::runtime_error(
             "Xios::write: field '" + fieldId + "' does not have the expected type");
     }
 
     // Write out according to field type
-    if (type == ModelArray::Type::H || type == ModelArray::Type::U || type == ModelArray::Type::V
-        || type == ModelArray::Type::CG) {
+    // Provide dimension information to XIOS so that it can write the ModelArray into the NetCDF
+    // file appropriately
+    if (type == Type::H || type == Type::U || type == Type::V || type == Type::CG) {
         cxios_write_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1], -1);
-    } else if (type == ModelArray::Type::VERTEX) {
+    } else if (type == Type::VERTEX) {
         cxios_write_data_k83(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
             dims[1], ModelArray::size(ModelArray::Dimension::NCOORDS), -1);
-    } else if (type == ModelArray::Type::DG) {
+    } else if (type == Type::DG) {
         cxios_write_data_k83(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
             dims[1], ModelArray::size(ModelArray::Dimension::DG), -1);
-    } else if (type == ModelArray::Type::DGSTRESS) {
+    } else if (type == Type::DGSTRESS) {
         cxios_write_data_k83(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
             dims[1], ModelArray::size(ModelArray::Dimension::DGSTRESS), -1);
     } else {
@@ -1696,6 +1699,8 @@ void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
  */
 void Xios::read(const std::string& fieldId, ModelArray& modelarray)
 {
+    using Type = ModelArray::Type;
+
     if (!getFieldReadAccess(fieldId)) {
         throw std::runtime_error("Xios::read: field '" + fieldId
             + "' is not configured for reading, but is being read from file.");
@@ -1703,20 +1708,21 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
     if (modelarray.nDimensions() != 2) {
         throw std::invalid_argument("Only ModelArrays of dimension 2 are supported");
     }
-    const ModelArray::Type& type = modelarray.getType();
-    const ModelArray::Type& expectedType = getFieldType(fieldId);
+    const Type& type = modelarray.getType();
+    const Type& expectedType = getFieldType(fieldId);
 
     // Account for fields to be read in as HField but converted to DGField
+    // Other field types should not need converting
     if (inputFieldsToConvert.count(fieldId)) {
-        if (expectedType != ModelArray::Type::H) {
+        if (expectedType != Type::H) {
             throw std::runtime_error(
                 "Xios::read: field '" + fieldId + "' was expected to be read as a HField");
         }
-        if (type != ModelArray::Type::DG) {
+        if (type != Type::DG) {
             throw std::runtime_error(
                 "Xios::read: field '" + fieldId + "' was expected to be converted to a DGField");
         }
-        HField inputarray(ModelArray::Type::H);
+        HField inputarray(Type::H);
         auto& dims = inputarray.dimensions();
         cxios_read_data_k82(
             fieldId.c_str(), fieldId.length(), inputarray.getData(), dims[0], dims[1]);
@@ -1726,23 +1732,26 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
         return;
     }
 
-    // Other field types should not need converting
+    // Provide dimension information to XIOS so that it can read NetCDF data into the ModelArray
+    // appropriately
+    // NOTE: Here we assume that the U and V types are duplicates of H. This may not be the case in
+    //       the future.
     auto& dims = modelarray.dimensions();
-    if (type != expectedType) {
+    if (type != expectedType
+        && !(expectedType == Type::H && (type == Type::U || type == Type::V))) {
         throw std::runtime_error(
             "Xios::read: field '" + fieldId + "' does not have the expected type");
     }
-    if (type == ModelArray::Type::H || type == ModelArray::Type::U || type == ModelArray::Type::V
-        || type == ModelArray::Type::CG) {
+    if (type == Type::H || type == Type::U || type == Type::V || type == Type::CG) {
         cxios_read_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1]);
-    } else if (type == ModelArray::Type::VERTEX) {
+    } else if (type == Type::VERTEX) {
         cxios_read_data_k83(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
             dims[1], ModelArray::size(ModelArray::Dimension::NCOORDS));
-    } else if (type == ModelArray::Type::DG) {
+    } else if (type == Type::DG) {
         cxios_read_data_k83(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
             dims[1], ModelArray::size(ModelArray::Dimension::DG));
-    } else if (type == ModelArray::Type::DGSTRESS) {
+    } else if (type == Type::DGSTRESS) {
         cxios_read_data_k83(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
             dims[1], ModelArray::size(ModelArray::Dimension::DGSTRESS));
     } else {

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1688,8 +1688,8 @@ void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
         cxios_write_data_k83(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
             dims[1], ModelArray::size(ModelArray::Dimension::DGSTRESS), -1);
     } else {
-        throw std::invalid_argument(
-            "Only HFields, VertexFields, DGFields, DGSFields, and CGFields are supported");
+        throw std::invalid_argument("Only HFields, UFields, VFields, VertexFields, DGFields, "
+                                    "DGSFields, and CGFields are supported");
     }
 }
 
@@ -1755,8 +1755,8 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
         cxios_read_data_k83(fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0],
             dims[1], ModelArray::size(ModelArray::Dimension::DGSTRESS));
     } else {
-        throw std::invalid_argument(
-            "Only HFields, VertexFields, DGFields, DGSFields, and CGFields are supported");
+        throw std::invalid_argument("Only HFields, UFields, VFields, VertexFields, DGFields, "
+                                    "DGSFields, and CGFields are supported");
     }
 }
 }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -47,6 +47,8 @@
 
 namespace Nextsim {
 
+using Type = ModelArray::Type;
+
 static const std::string xDiagnosticPfx = "XiosDiagnostic";
 static const std::map<int, std::string> keyMap = { { Xios::ENABLED_KEY, "xios.enable" },
     { Xios::DIAGNOSTIC_PERIOD_KEY, xDiagnosticPfx + ".period" },
@@ -163,18 +165,17 @@ void Xios::close_context_definition()
                     if (fieldTypes.count(fieldId) > 0) {
                         setFieldType(fieldId, getFieldType(fieldId), ioType);
                     } else {
-                        setFieldType(fieldId, ModelArray::Type::H, ioType);
+                        setFieldType(fieldId, Type::H, ioType);
                     }
                 }
-                const ModelArray::Type& inputType = getFieldType(inputFieldId);
+                const Type& inputType = getFieldType(inputFieldId);
                 if (fieldTypes.count(fieldId) == 0) {
                     // Unused base fields still need a field type
                     setFieldType(fieldId, inputType, NOT_READ);
                 }
-                const ModelArray::Type& baseType = getFieldType(fieldId);
+                const Type& baseType = getFieldType(fieldId);
                 if (ioType == ERA5_FORCING || ioType == TOPAZ_FORCING) {
-                    if (baseType != ModelArray::Type::H && baseType != ModelArray::Type::U
-                        && baseType != ModelArray::Type::V) {
+                    if (baseType != Type::H && baseType != Type::U && baseType != Type::V) {
                         throw std::runtime_error("Xios: Forcing fields must be treated as HFields");
                     }
                 }
@@ -184,12 +185,13 @@ void Xios::close_context_definition()
                 setFieldGridRef(inputFieldId, gridIds[inputType]);
 
                 if ((inputType == baseType)
-                    || (inputType == ModelArray::Type::H
-                        && (baseType == ModelArray::Type::U || baseType == ModelArray::Type::V))) {
+                    || (inputType == Type::H && (baseType == Type::U || baseType == Type::V))) {
                     // Link the input field to the base field if their types align
+                    // NOTE: Here we assume that the U and V types are duplicates of H. This may not
+                    //       be the case in the future.
                     cxios_set_field_field_ref(
                         getField(inputFieldId), fieldId.c_str(), fieldId.length());
-                } else if (baseType == ModelArray::Type::DG && inputType == ModelArray::Type::H) {
+                } else if (baseType == Type::DG && inputType == Type::H) {
                     // Record fields read in as HField but treated as DGField
                     inputFieldsToConvert.insert(inputFieldId);
                 } else {
@@ -216,7 +218,7 @@ void Xios::close_context_definition()
                 }
 
                 // Set grid references
-                const ModelArray::Type& type = getFieldType(fieldId);
+                const Type& type = getFieldType(fieldId);
                 setFieldGridRef(fieldId, gridIds[type]);
             }
         }
@@ -1654,8 +1656,6 @@ void Xios::postprocessOutputFiles()
  */
 void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
 {
-    using Type = ModelArray::Type;
-
     if (modelarray.nDimensions() != 2) {
         throw std::invalid_argument("Only ModelArrays of dimension 2 are supported");
     }
@@ -1673,6 +1673,8 @@ void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
     // Write out according to field type
     // Provide dimension information to XIOS so that it can write the ModelArray into the NetCDF
     // file appropriately
+    // NOTE: Here we assume that the U and V types are duplicates of H. This may not be the case in
+    //       the future.
     if (type == Type::H || type == Type::U || type == Type::V || type == Type::CG) {
         cxios_write_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1], -1);
@@ -1699,8 +1701,6 @@ void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
  */
 void Xios::read(const std::string& fieldId, ModelArray& modelarray)
 {
-    using Type = ModelArray::Type;
-
     if (!getFieldReadAccess(fieldId)) {
         throw std::runtime_error("Xios::read: field '" + fieldId
             + "' is not configured for reading, but is being read from file.");

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -172,16 +172,20 @@ void Xios::close_context_definition()
                     setFieldType(fieldId, inputType, NOT_READ);
                 }
                 const ModelArray::Type& baseType = getFieldType(fieldId);
-                if ((ioType == ERA5_FORCING || ioType == TOPAZ_FORCING)
-                    && baseType != ModelArray::Type::H) {
-                    throw std::runtime_error("Xios: Forcing fields must be treated as HFields");
+                if (ioType == ERA5_FORCING || ioType == TOPAZ_FORCING) {
+                    if (baseType != ModelArray::Type::H && baseType != ModelArray::Type::U
+                        && baseType != ModelArray::Type::V) {
+                        throw std::runtime_error("Xios: Forcing fields must be treated as HFields");
+                    }
                 }
 
                 // Set grid references
                 setFieldGridRef(fieldId, gridIds[baseType]);
                 setFieldGridRef(inputFieldId, gridIds[inputType]);
 
-                if (inputType == baseType) {
+                if ((inputType == baseType)
+                    || (inputType == ModelArray::Type::H
+                        && (baseType == ModelArray::Type::U || baseType == ModelArray::Type::V))) {
                     // Link the input field to the base field if their types align
                     cxios_set_field_field_ref(
                         getField(inputFieldId), fieldId.c_str(), fieldId.length());
@@ -1665,7 +1669,8 @@ void Xios::write(const std::string& fieldId, const ModelArray& modelarray)
     }
 
     // Write out according to field type
-    if ((type == ModelArray::Type::H) || (type == ModelArray::Type::CG)) {
+    if (type == ModelArray::Type::H || type == ModelArray::Type::U || type == ModelArray::Type::V
+        || type == ModelArray::Type::CG) {
         cxios_write_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1], -1);
     } else if (type == ModelArray::Type::VERTEX) {
@@ -1727,7 +1732,8 @@ void Xios::read(const std::string& fieldId, ModelArray& modelarray)
         throw std::runtime_error(
             "Xios::read: field '" + fieldId + "' does not have the expected type");
     }
-    if ((type == ModelArray::Type::H) || (type == ModelArray::Type::CG)) {
+    if (type == ModelArray::Type::H || type == ModelArray::Type::U || type == ModelArray::Type::V
+        || type == ModelArray::Type::CG) {
         cxios_read_data_k82(
             fieldId.c_str(), fieldId.length(), modelarray.getData(), dims[0], dims[1]);
     } else if (type == ModelArray::Type::VERTEX) {

--- a/core/src/discontinuousgalerkin/ModelArrayDetails.cpp
+++ b/core/src/discontinuousgalerkin/ModelArrayDetails.cpp
@@ -91,6 +91,8 @@ const std::map<ModelArray::Type, std::string> ModelArray::typeNames = {
 std::map<ModelArray::Type, ModelArray::Base> ModelArray::baseTypes = {
     { ModelArray::Type::H, ModelArray::Base::Cell },
     { ModelArray::Type::VERTEX, ModelArray::Base::Vertex },
+    { ModelArray::Type::U, ModelArray::Base::Cell },
+    { ModelArray::Type::V, ModelArray::Base::Cell },
     { ModelArray::Type::DG, ModelArray::Base::Cell },
     { ModelArray::Type::DGSTRESS, ModelArray::Base::Cell },
     { ModelArray::Type::CG, ModelArray::Base::Vertex },

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -136,6 +136,8 @@ private:
     std::map<ModelArray::Type, std::string> domainIds = {
         // Standard cell-based x- and y-dimensions (alt. names x_dim and y_dim)
         { ModelArray::Type::H, "dim" },
+        { ModelArray::Type::U, "dim" },
+        { ModelArray::Type::V, "dim" },
         { ModelArray::Type::DG, "dim" },
         { ModelArray::Type::DGSTRESS, "dim" },
         // Vertex-based x- and y-dimensions (alt. names x_vertex and y_vertex)
@@ -156,6 +158,8 @@ private:
     xios::CGrid* getGrid(const std::string& gridId);
     std::map<ModelArray::Type, std::string> gridIds = {
         { ModelArray::Type::H, "HGrid" },
+        { ModelArray::Type::U, "HGrid" },
+        { ModelArray::Type::V, "HGrid" },
         { ModelArray::Type::VERTEX, "VertexGrid" },
         { ModelArray::Type::DG, "DGGrid" },
         { ModelArray::Type::DGSTRESS, "DGSGrid" },

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -158,11 +158,11 @@ private:
     xios::CGrid* getGrid(const std::string& gridId);
     std::map<ModelArray::Type, std::string> gridIds = {
         { ModelArray::Type::H, "HGrid" },
-        { ModelArray::Type::U, "HGrid" },
-        { ModelArray::Type::V, "HGrid" },
-        { ModelArray::Type::VERTEX, "VertexGrid" },
+        { ModelArray::Type::U, "UGrid" },
+        { ModelArray::Type::V, "VGrid" },
         { ModelArray::Type::DG, "DGGrid" },
         { ModelArray::Type::DGSTRESS, "DGSGrid" },
+        { ModelArray::Type::VERTEX, "VertexGrid" },
         { ModelArray::Type::CG, "CGGrid" },
     };
     void setupGrids();

--- a/core/src/iodef.xml.jinja
+++ b/core/src/iodef.xml.jinja
@@ -16,6 +16,8 @@
 
     <grid_definition>
       <grid id="HGrid" name="HGrid"/>
+      <grid id="UGrid" name="UGrid"/>
+      <grid id="VGrid" name="VGrid"/>
       <grid id="DGGrid" name="DGGrid">
         <axis axis_ref="DGAxis"/>
       </grid>

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -47,15 +47,15 @@ public:
         // Set XIOS field types
         Xios& xiosHandler = Xios::getInstance();
 
+        // Advective velocities
+        xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::H);
+        xiosHandler.setPrognosticFieldType(vName, ModelArray::Type::H);
+
         // Advected fields
         xiosHandler.setPrognosticFieldType(hiceName, ModelArray::AdvectionType);
         xiosHandler.setPrognosticFieldType(ciceName, ModelArray::AdvectionType);
         xiosHandler.setPrognosticFieldType(damageName, ModelArray::Type::H);
         xiosHandler.setPrognosticFieldType(hsnowName, ModelArray::AdvectionType);
-
-        // FIXME: We need to write out u and v to get a perfect restart (#1066)
-        // xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::H);
-        // xiosHandler.setPrognosticFieldType(vName, ModelArray::Type::H);
 #endif
     }
     virtual ~IDynamics() = default;

--- a/core/src/modules/include/IDynamics.hpp
+++ b/core/src/modules/include/IDynamics.hpp
@@ -48,8 +48,8 @@ public:
         Xios& xiosHandler = Xios::getInstance();
 
         // Advective velocities
-        xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::H);
-        xiosHandler.setPrognosticFieldType(vName, ModelArray::Type::H);
+        xiosHandler.setPrognosticFieldType(uName, ModelArray::Type::U);
+        xiosHandler.setPrognosticFieldType(vName, ModelArray::Type::V);
 
         // Advected fields
         xiosHandler.setPrognosticFieldType(hiceName, ModelArray::AdvectionType);

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -203,12 +203,13 @@ indices (corner) in each dimension for each MPI rank. This information is
 provided to XIOS automatically upon configuring the ``Model``.
 
 Different domains are used for different field types, depending on the number of
-degrees of freedom (DoFs) they have in the horizontal. The ``HDomain`` has one
-DoF per cell and is used for the ``HField``, ``DGField``, and ``DGSField``
-types. The ``VertexDomain`` has one DoF per vertex and is used for the
-``VertexField`` type. Finally, the ``CGDomain`` has the same (degree-dependent)
+degrees of freedom (DoFs) they have in the horizontal. The ``dim`` has one DoF
+per cell and is used for the ``HField``, ``UField``, ``VField``, ``DGField``,
+and ``DGSField`` types. The ``vertex`` has one DoF per vertex and is used for
+the ``VertexField`` type. Finally, the ``cg`` has the same (degree-dependent)
 number of DoFs as the continuous Galerkin discretisation and is used by
-``CGField``.
+``CGField``. When prepended by ``x`` or ``y``, the domain names give rise to the
+dimension names used in NetCDF files, e.g., ``x_dim`` and ``y_cg``.
 
 XIOS Axis concept
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# XIOS: Account for `U` and `V` fields

Fixes #1066
Merges into #1063 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

The `u` and `v` fields are not properly handled in #1063 because they use special field types `ModelArray::Type::U` and `ModelArray::Type::V`, which aren't used by any other fields. Currently, these are duplicates of ``ModelArray::Type::H`, although this might not always be the case.

In this PR, these field types are handled in the XIOS I/O implementation. An assumption is made that `ModelArray::Type::U` and `ModelArray::Type::V` are consistent with `ModelArray::Type::H`, but `NOTE`s are included to indicate where this is relevant.

I also made use of `using Type == ModelArray::Type;` to make things a bit easier to read.

---
# Test Description

No changes to the tests were required.

---
# Documentation Impact

The XIOS documentation page has been updated to mention `UField` and `VField`. I also noticed that the domain names needed updating in the same section.
