### PR TITLE
XIOS: Throw an error for non-positive read or write periods

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1344,7 +1344,7 @@ void Xios::createFile(const std::string& fileId)
         } else {
             periodStr
                 = Configured::getConfiguration(keyMap.at(DIAGNOSTIC_PERIOD_KEY), std::string());
-            period = Duration(periodStr);
+            Duration period = periodStr;
             if (metadata.period.seconds() <= 0) {
                 throw std::runtime_error("Xios: Diagnostic period must be positive");
             }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1331,10 +1331,13 @@ void Xios::createFile(const std::string& fileId)
     cxios_duration outputFreq;
     ModelMetadata& metadata = ModelMetadata::getInstance();
     if (ioType == INPUT_RESTART || ioType == OUTPUT_RESTART) {
-        if (metadata.restartPeriod.seconds() <= 0) {
-            throw std::runtime_error("Xios: Restart period must be positive");
+        if (metadata.restartPeriod.seconds() == 0) {
+            outputFreq = convertDurationToXios(metadata.runLength());
+        } else if (metadata.restartPeriod.seconds() < 0) {
+            throw std::runtime_error("Xios: Restart period must be non-negative");
+        } else {
+            outputFreq = convertDurationToXios(metadata.restartPeriod);
         }
-        outputFreq = convertDurationToXios(metadata.restartPeriod);
     } else {
         std::string periodStr;
         if (ioType == ERA5_FORCING) {
@@ -1344,15 +1347,16 @@ void Xios::createFile(const std::string& fileId)
         } else {
             periodStr
                 = Configured::getConfiguration(keyMap.at(DIAGNOSTIC_PERIOD_KEY), std::string());
-            Duration period = periodStr;
-            if (metadata.period.seconds() <= 0) {
-                throw std::runtime_error("Xios: Diagnostic period must be positive");
-            }
-            cxios_set_file_split_freq(file, convertDurationToXios(period);
             if (periodStr.empty() || periodStr == "0") {
                 outputFreq = convertDurationToXios(metadata.runLength());
             } else {
-                outputFreq = convertDurationToXios(Duration(periodStr));
+                Duration period = periodStr;
+                if (period.seconds() == 0) {
+                    outputFreq = convertDurationToXios(metadata.runLength());
+                } else if (period.seconds() < 0) {
+                    throw std::runtime_error("Xios: Diagnostic period must be non-negative");
+                }
+                outputFreq = convertDurationToXios(period);
             }
         }
     }

--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -1331,6 +1331,9 @@ void Xios::createFile(const std::string& fileId)
     cxios_duration outputFreq;
     ModelMetadata& metadata = ModelMetadata::getInstance();
     if (ioType == INPUT_RESTART || ioType == OUTPUT_RESTART) {
+        if (metadata.restartPeriod.seconds() <= 0) {
+            throw std::runtime_error("Xios: Restart period must be positive");
+        }
         outputFreq = convertDurationToXios(metadata.restartPeriod);
     } else {
         std::string periodStr;
@@ -1341,7 +1344,11 @@ void Xios::createFile(const std::string& fileId)
         } else {
             periodStr
                 = Configured::getConfiguration(keyMap.at(DIAGNOSTIC_PERIOD_KEY), std::string());
-            cxios_set_file_split_freq(file, convertDurationToXios(Duration(periodStr)));
+            period = Duration(periodStr);
+            if (metadata.period.seconds() <= 0) {
+                throw std::runtime_error("Xios: Diagnostic period must be positive");
+            }
+            cxios_set_file_split_freq(file, convertDurationToXios(period);
             if (periodStr.empty() || periodStr == "0") {
                 outputFreq = convertDurationToXios(metadata.runLength());
             } else {

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -94,6 +94,8 @@ building without XIOS. That is, the ``model`` section should include
   restart_file = my_restart_file.nc
   restart_period = P0-0T02:00:00
 
+Note that the restart period must be positive under XIOS.
+
 Information related to fields to be read from and written to files are
 configured via the ``XiosInput``, ``XiosOutput``, and ``XiosDiagnostic``
 sections, where the first two refer to restarts. Note that all of these sections

--- a/docs/xios.rst
+++ b/docs/xios.rst
@@ -94,7 +94,9 @@ building without XIOS. That is, the ``model`` section should include
   restart_file = my_restart_file.nc
   restart_period = P0-0T02:00:00
 
-Note that the restart period must be positive under XIOS.
+Note that the restart period must be non-negative under XIOS. If the restart
+period is set to zero then this will be interpreted as the full simulation
+lenght. That is, restarts will not be written until the very end.
 
 Information related to fields to be read from and written to files are
 configured via the ``XiosInput``, ``XiosOutput``, and ``XiosDiagnostic``


### PR DESCRIPTION
# XIOS: Throw an error for non-positive read or write periods

Fixes #971

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [x] Implemented the source code change that satisfies the tests
- [x] Commented all code so that it can be understood without additional context
- [x] No new warnings are generated or they are mentioned below
- [x] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

I tried out XIOS with zero restart period and it stalled so figured we should throw a warning to stop users encountering this.

I also noticed that `0` is handled in a special way, implying that the period is the full length of the simulation.

As such, I've made it so that 0 gets handled in this way consistently and anything negative throws an error.

---
# Test Description

n/a

---
# Documentation Impact

The XIOS docs page has been updated to reflect this.