### PR TITLE
ci: add fortran mpi lib for XIOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ if(ENABLE_XIOS)
                 ${xios_EXTERNS}/rapidxml/include
     )
     if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        set(FORTRAN_RUNTIME_LIB "-lgfortran")
+        set(FORTRAN_RUNTIME_LIB "-lgfortran -lmpi_mpifh")
     elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
         set(FORTRAN_RUNTIME_LIB "-lifcore")
     endif()


### PR DESCRIPTION
This is a hotfix, to fix the failing CI for MPI XIOS test.

It appears that we need the fortran MPI library `libmpi_mpifh.so` / `-lmpi_mpifh` for XIOS features in nextsim.

I am not sure why it didn't matter before :shrug: 