### PR TITLE
Integrate interpolation support from XIOS

### DIFF
--- a/core/src/Xios.cpp
+++ b/core/src/Xios.cpp
@@ -184,7 +184,11 @@ void Xios::close_context_definition()
                 setFieldGridRef(fieldId, gridIds[baseType]);
                 setFieldGridRef(inputFieldId, gridIds[inputType]);
 
-                if ((inputType == baseType)
+                if (ioType == ERA5_FORCING) {
+                    std::string tempFieldId = fieldId + "_era5";
+                    cxios_set_field_field_ref(
+                        getField(inputFieldId), tempFieldId.c_str(), tempFieldId.length());
+                } else if ((inputType == baseType)
                     || (inputType == Type::H && (baseType == Type::U || baseType == Type::V))) {
                     // Link the input field to the base field if their types align
                     // NOTE: Here we assume that the U and V types are duplicates of H. This may not
@@ -621,6 +625,12 @@ void Xios::setupDomains()
             throw std::runtime_error("Xios: Failed to set type for domain '" + domainId + "'");
         }
 
+        // add interpolation
+        xios::CInterpolateDomain* interpDomain = NULL;
+        cxios_xml_tree_add_interpolatedomaintodomain(
+            domain, &interpDomain, Xios::era5interpId.c_str(), Xios::era5interpId.length());
+        cxios_set_interpolate_domain_order(interpDomain, 1); /*1 = bilinear, 2 = quadratic*/
+
         // Set domain extents based on model metadata
         size_t counter = 0;
         for (ModelArray::Dimension& dim : ModelArray::typeDimensions[type]) {
@@ -758,6 +768,14 @@ void Xios::setupGrids()
         xios::CDomain* domain = getDomain(domainId);
         cxios_xml_tree_add_domaintogrid(grid, &domain, domainId.c_str(), domainId.length());
     }
+    // TODO make this less hard-coded
+    // This adds temp grid for High Res version of HGrid for reading low res ERA5 data
+    // for (const auto& [type, gridId] : ERA5GridIds) {
+    //     xios::CGrid* grid = getGrid(gridId);
+    //     const std::string& domainId = domainIds[type];
+    //     xios::CDomain* domain = getDomain(domainId);
+    //     cxios_xml_tree_add_domaintogrid(grid, &domain, domainId.c_str(), domainId.length());
+    // }
 }
 
 /*!

--- a/core/src/include/Xios.hpp
+++ b/core/src/include/Xios.hpp
@@ -129,6 +129,8 @@ private:
 
     /* Axis */
     xios::CAxis* getAxis(const std::string& axisId);
+    const std::string era5interpId = "era5interp";
+    const std::string era5HGridHR = "HGridEra5HR";
 
     /* Domain */
     // NOTE: Dimension names get processed as <dim>_<domainId> by XIOS, so we define the domainIds
@@ -144,6 +146,9 @@ private:
         { ModelArray::Type::VERTEX, "vertex" },
         // CG-based x- and y-dimensions (alt. names x_cg and y_cg)
         { ModelArray::Type::CG, "cg" },
+    };
+    std::map<ModelArray::Type, std::string> EAR5domainIds = {
+        { ModelArray::Type::H, "dim" },
     };
     std::map<std::string, bool> domainWritten = {
         { "dim", false },
@@ -164,6 +169,9 @@ private:
         { ModelArray::Type::DGSTRESS, "DGSGrid" },
         { ModelArray::Type::VERTEX, "VertexGrid" },
         { ModelArray::Type::CG, "CGGrid" },
+    };
+    std::map<ModelArray::Type, std::string> ERA5GridIds = {
+        { ModelArray::Type::H, "HGridEra5HR" },
     };
     void setupGrids();
 

--- a/core/src/include/xios_c_interface.hpp
+++ b/core/src/include/xios_c_interface.hpp
@@ -19,6 +19,7 @@
 #include <file.hpp>
 #include <grid.hpp>
 #include <icdate.hpp>
+#include <interpolate_domain.hpp>
 
 extern "C" {
 
@@ -70,11 +71,27 @@ void cxios_xml_tree_add_domain(
     xios::CDomainGroup* domain_grp, xios::CDomain** domain, const char* _id, int _id_len);
 
 // domain methods
+
+void cxios_set_domain_domain_ref(
+    xios::CDomain* domain_hdl, const char* domain_ref, int domain_ref_size);
+void cxios_get_domain_domain_ref(xios::CDomain* domain_hdl, char* domain_ref, int domain_ref_size);
+bool cxios_is_defined_domain_domain_ref(xios::CDomain* domain_hdl);
+
+void cxios_set_interpolate_domain_mode(
+    xios::CInterpolateDomain* hdl, const char* mode, int mode_size);
+void cxios_get_interpolate_domain_mode(xios::CInterpolateDomain* hdl, char* mode, int mode_size);
+void cxios_set_interpolate_domain_order(xios::CInterpolateDomain* hdl, int order);
+void cxios_get_interpolate_domain_order(xios::CInterpolateDomain* hdl, int* order);
+void cxios_xml_tree_add_interpolatedomaintodomain(xios::CDomain* parent,
+    xios::CInterpolateDomain** child, const char* child_id, int child_id_size);
+
 void cxios_domain_handle_create(xios::CDomain** _ret, const char* _id, int _id_len);
 void cxios_domain_valid_id(bool* _ret, const char* _id, int _id_len);
 void cxios_set_domain_type(xios::CDomain* domain_hdl, const char* type, int type_size);
 void cxios_set_domain_dim_i_name(xios::CDomain* domain_hdl, const char* iname, int iname_size);
+void cxios_get_domain_dim_i_name(xios::CDomain* domain_hdl, char* iname, int iname_size);
 void cxios_set_domain_dim_j_name(xios::CDomain* domain_hdl, const char* jname, int jname_size);
+void cxios_get_domain_dim_j_name(xios::CDomain* domain_hdl, char* jname, int jname_size);
 void cxios_set_domain_lat_name(xios::CDomain* domain_hdl, const char* latname, int latname_size);
 void cxios_set_domain_lon_name(xios::CDomain* domain_hdl, const char* lonname, int lonname_size);
 void cxios_set_domain_ni_glo(xios::CDomain* domain_hdl, int ni_glo);

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -179,7 +179,8 @@ if(ENABLE_MPI)
                     "${ModulesRoot}/StructureModule")
         target_link_libraries(testXiosReadForcing_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosForcingInterpolation_MPI2 "XiosForcingInterpolation_test.cpp" "MainMPI.cpp")
+        add_executable(testXiosForcingInterpolation_MPI2
+          "XiosForcingInterpolation_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosForcingInterpolation_MPI2
                                    PRIVATE USE_XIOS TEST_FILES_DIR="${CMAKE_CURRENT_BINARY_DIR}")
         target_include_directories(

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -172,12 +172,21 @@ if(ENABLE_MPI)
 
         add_executable(testXiosReadForcing_MPI2 "XiosReadForcing_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosReadForcing_MPI2
-                                   PRIVATE USE_XIOS TEST_FILES_DIR=\"${CMAKE_CURRENT_BINARY_DIR}\")
+                                   PRIVATE USE_XIOS TEST_FILES_DIR="${CMAKE_CURRENT_BINARY_DIR}")
         target_include_directories(
             testXiosReadForcing_MPI2
             PRIVATE ${PHYSICS_INCLUDE_DIRS} "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}"
                     "${ModulesRoot}/StructureModule")
         target_link_libraries(testXiosReadForcing_MPI2 PRIVATE nextsimlib doctest::doctest)
+
+        add_executable(testXiosForcingInterpolation_MPI2 "XiosForcingInterpolation_test.cpp" "MainMPI.cpp")
+        target_compile_definitions(testXiosForcingInterpolation_MPI2
+                                   PRIVATE USE_XIOS TEST_FILES_DIR="${CMAKE_CURRENT_BINARY_DIR}")
+        target_include_directories(
+            testXiosForcingInterpolation_MPI2
+            PRIVATE ${PHYSICS_INCLUDE_DIRS} "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}"
+                    "${ModulesRoot}/StructureModule")
+        target_link_libraries(testXiosForcingInterpolation_MPI2 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosReadDiagnostic_MPI3 "XiosReadDiagnostic_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosReadDiagnostic_MPI3
@@ -228,6 +237,7 @@ if(ENABLE_MPI)
             testXiosCalendar_MPI1
             testXiosAxis_MPI3
             testXiosReadForcing_MPI2
+            testXiosForcingInterpolation_MPI2
             testXiosReadDiagnostic_MPI3
             testXiosReadRestart_MPI2
             testXiosWriteDiagnostic_MPI2

--- a/core/test/CMakeLists.txt
+++ b/core/test/CMakeLists.txt
@@ -179,15 +179,15 @@ if(ENABLE_MPI)
                     "${ModulesRoot}/StructureModule")
         target_link_libraries(testXiosReadForcing_MPI2 PRIVATE nextsimlib doctest::doctest)
 
-        add_executable(testXiosForcingInterpolation_MPI2
+        add_executable(testXiosForcingInterpolation_MPI3
           "XiosForcingInterpolation_test.cpp" "MainMPI.cpp")
-        target_compile_definitions(testXiosForcingInterpolation_MPI2
+        target_compile_definitions(testXiosForcingInterpolation_MPI3
                                    PRIVATE USE_XIOS TEST_FILES_DIR="${CMAKE_CURRENT_BINARY_DIR}")
         target_include_directories(
-            testXiosForcingInterpolation_MPI2
+            testXiosForcingInterpolation_MPI3
             PRIVATE ${PHYSICS_INCLUDE_DIRS} "${MODEL_INCLUDE_DIR}" "${XIOS_INCLUDE_LIST}"
                     "${ModulesRoot}/StructureModule")
-        target_link_libraries(testXiosForcingInterpolation_MPI2 PRIVATE nextsimlib doctest::doctest)
+        target_link_libraries(testXiosForcingInterpolation_MPI3 PRIVATE nextsimlib doctest::doctest)
 
         add_executable(testXiosReadDiagnostic_MPI3 "XiosReadDiagnostic_test.cpp" "MainMPI.cpp")
         target_compile_definitions(testXiosReadDiagnostic_MPI3
@@ -238,7 +238,7 @@ if(ENABLE_MPI)
             testXiosCalendar_MPI1
             testXiosAxis_MPI3
             testXiosReadForcing_MPI2
-            testXiosForcingInterpolation_MPI2
+            testXiosForcingInterpolation_MPI3
             testXiosReadDiagnostic_MPI3
             testXiosReadRestart_MPI2
             testXiosWriteDiagnostic_MPI2

--- a/core/test/XiosForcingInterpolation_test.cpp
+++ b/core/test/XiosForcingInterpolation_test.cpp
@@ -33,7 +33,7 @@ namespace Nextsim {
  *
  * Test reading of forcings via `readForcingTimeStatic` with interpolation.
  */
-MPI_TEST_CASE("TestXiosForcingInterpolation", 2)
+MPI_TEST_CASE("TestXiosForcingInterpolation", 3)
 {
     std::stringstream config;
     config << "[model]" << std::endl;
@@ -42,7 +42,7 @@ MPI_TEST_CASE("TestXiosForcingInterpolation", 2)
     config << "time_step = P0-0T00:30:00" << std::endl;
     config << "init_file = " << inputFilename << std::endl;
     config << "restart_period = P0-0T02:00:00" << std::endl;
-    config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
+    config << "partition_file = halo_cb_test_partition_metadata_3.nc" << std::endl;
     // NOTE: Assumed ERA5 period of 1 hour
     config << "[ERA5Atmosphere]" << std::endl;
     config << "file = " << era5ForcingFilename << std::endl;

--- a/core/test/XiosForcingInterpolation_test.cpp
+++ b/core/test/XiosForcingInterpolation_test.cpp
@@ -47,8 +47,8 @@ MPI_TEST_CASE("TestXiosForcingInterpolation", 3)
     config << "[ERA5Atmosphere]" << std::endl;
     config << "file = " << era5ForcingFilename << std::endl;
     // NOTE: Assumed TOPAZ period of 1 day
-    config << "[TOPAZOcean]" << std::endl;
-    config << "file = " << topazForcingFilename << std::endl;
+    // config << "[TOPAZOcean]" << std::endl;
+    // config << "file = " << topazForcingFilename << std::endl;
     std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
     Configurator::addStream(std::move(pcstream));
 
@@ -91,8 +91,7 @@ MPI_TEST_CASE("TestXiosForcingInterpolation", 3)
     // Simulate 4 iterations (timesteps), reading forcing data at each
     ModelMetadata& metadata = ModelMetadata::getInstance();
     const Duration& timestep = metadata.stepLength();
-    const std::set<std::string> era5ForcingFieldNames
-        = { "tair", "dew2m", "pair", "sw_in", "lw_in", "wind_speed", "u", "v" };
+    const std::set<std::string> era5ForcingFieldNames = { "tair" };
     const std::set<std::string> topazForcingFieldNames
         = { sssName, sstName, mldName, sshName, uName, vName };
     for (int ts = 0; ts <= 4; ts += 2) {
@@ -116,20 +115,20 @@ MPI_TEST_CASE("TestXiosForcingInterpolation", 3)
         // Read TOPAZ forcings from file, checking that they contain the expected fields and that
         // those have the expected values
         // NOTE: Only the first timestep has TOPAZ data
-        if (ts == 0) {
-            ModelState topazForcings
-                = pio->readForcingTimeStatic(topazForcingFieldNames, time, topazForcingFilename);
-            for (const auto& fieldName : topazForcingFieldNames) {
-                REQUIRE(topazForcings.data.count(fieldName) > 0);
-            }
-            for (const auto& [fieldName, modelarray] : topazForcings.data) {
-                for (size_t j = 0; j < ny; ++j) {
-                    for (size_t i = 0; i < nx; ++i) {
-                        REQUIRE(modelarray(i, j) == doctest::Approx(ts + 1));
-                    }
-                }
-            }
-        }
+        // if (ts == 0) {
+        //     ModelState topazForcings
+        //         = pio->readForcingTimeStatic(topazForcingFieldNames, time, topazForcingFilename);
+        //     for (const auto& fieldName : topazForcingFieldNames) {
+        //         REQUIRE(topazForcings.data.count(fieldName) > 0);
+        //     }
+        //     for (const auto& [fieldName, modelarray] : topazForcings.data) {
+        //         for (size_t j = 0; j < ny; ++j) {
+        //             for (size_t i = 0; i < nx; ++i) {
+        //                 REQUIRE(modelarray(i, j) == doctest::Approx(ts + 1));
+        //             }
+        //         }
+        //     }
+        // }
 
         // Update the current timestep and verify it's updated in XIOS
         metadata.incrementTime(timestep);

--- a/core/test/XiosForcingInterpolation_test.cpp
+++ b/core/test/XiosForcingInterpolation_test.cpp
@@ -1,0 +1,143 @@
+/*!
+ * @author  Joe Wallwork <jw2423@cam.ac.uk>
+ * @brief   Tests for XIOS functionality for reading forcings with interpolation
+ * @details The functionality of reading forcings via XIOS is tested with interpolation.
+ */
+#include <doctest/extensions/doctest_mpi.h>
+#undef INFO
+
+#include "StructureModule/include/ParametricGrid.hpp"
+#include "include/Finalizer.hpp"
+#include "include/Model.hpp"
+#include "include/ModelMPI.hpp"
+#include "include/NextsimModule.hpp"
+#include "include/ParaGridIO.hpp"
+#include "include/Xios.hpp"
+#include "include/gridNames.hpp"
+
+#include <filesystem>
+
+const std::string testFilesDir = TEST_FILES_DIR;
+const std::string inputFilename = testFilesDir + "/xios_test_input.nc";
+const std::string era5ForcingFilename = testFilesDir + "/xios_test_era5_forcing.nc";
+const std::string topazForcingFilename = testFilesDir + "/xios_test_topaz_forcing.nc";
+
+static const int DGCOMP = 6;
+static const int DGSTRESSCOMP = 8;
+static const int CGDEGREE = 2;
+
+namespace Nextsim {
+
+/*!
+ * TestXiosForcingInterpolation
+ *
+ * Test reading of forcings via `readForcingTimeStatic` with interpolation.
+ */
+MPI_TEST_CASE("TestXiosForcingInterpolation", 2)
+{
+    std::stringstream config;
+    config << "[model]" << std::endl;
+    config << "start = 2023-03-17T00:00:00Z" << std::endl;
+    config << "stop = 2023-03-17T02:00:00Z" << std::endl;
+    config << "time_step = P0-0T00:30:00" << std::endl;
+    config << "init_file = " << inputFilename << std::endl;
+    config << "restart_period = P0-0T02:00:00" << std::endl;
+    config << "partition_file = xios_test_partition_metadata_2.nc" << std::endl;
+    // NOTE: Assumed ERA5 period of 1 hour
+    config << "[ERA5Atmosphere]" << std::endl;
+    config << "file = " << era5ForcingFilename << std::endl;
+    // NOTE: Assumed TOPAZ period of 1 day
+    config << "[TOPAZOcean]" << std::endl;
+    config << "file = " << topazForcingFilename << std::endl;
+    std::unique_ptr<std::istream> pcstream(new std::stringstream(config.str()));
+    Configurator::addStream(std::move(pcstream));
+
+    // Create ModelMPI instance based off the test communicator
+    auto& modelMPI = ModelMPI::getInstance(test_comm);
+
+    // Create a Model and configure it so that time options are parsed
+    Model model;
+    model.configureRestarts();
+    model.configureTime();
+
+    // Get the Xios singleton instance and check it's initialized
+    // NOTE: The singleton is created when Xios::getInstance() is first called. In this test, this
+    //       happens when the time sets set by ModelMetadata::setTime(). This occurs in the call to
+    //       Model::configureTime() above.
+    Xios& xiosHandler = Xios::getInstance();
+
+    // Create ParametricGrid and ParaGridIO instances
+    // NOTE: XIOS axes, domains, and grids are created by the ParaGridIO constructor
+    Module::setImplementation<IStructure>("Nextsim::ParametricGrid");
+    ParametricGrid grid;
+    ParaGridIO* pio = new ParaGridIO(grid);
+    grid.setIO(pio);
+
+    // NOTE: Needs calling before Xios::getCurrentDate()
+    xiosHandler.close_context_definition();
+
+    // Check the input file exists
+    REQUIRE(std::filesystem::exists(era5ForcingFilename));
+
+    // Check calendar step is zero initially
+    REQUIRE(xiosHandler.getCalendarStep() == 0);
+
+    // Deduce the local lengths of the two dimensions
+    const size_t nx = ModelArray::size(ModelArray::Dimension::X);
+    const size_t ny = ModelArray::size(ModelArray::Dimension::Y);
+    REQUIRE(ModelArray::nComponents(ModelArray::Type::DG) == DGCOMP);
+    REQUIRE(ModelArray::size(ModelArray::Dimension::DG) == DGCOMP);
+
+    // Simulate 4 iterations (timesteps), reading forcing data at each
+    ModelMetadata& metadata = ModelMetadata::getInstance();
+    const Duration& timestep = metadata.stepLength();
+    const std::set<std::string> era5ForcingFieldNames
+        = { "tair", "dew2m", "pair", "sw_in", "lw_in", "wind_speed", "u", "v" };
+    const std::set<std::string> topazForcingFieldNames
+        = { sssName, sstName, mldName, sshName, uName, vName };
+    for (int ts = 0; ts <= 4; ts += 2) {
+        const TimePoint& time = xiosHandler.getCurrentDate();
+
+        // Read ERA5 forcings from file, checking that they contain the expected fields and that
+        // those have the expected values
+        ModelState era5Forcings
+            = pio->readForcingTimeStatic(era5ForcingFieldNames, time, era5ForcingFilename);
+        for (const auto& fieldName : era5ForcingFieldNames) {
+            REQUIRE(era5Forcings.data.count(fieldName) > 0);
+        }
+        for (const auto& [fieldName, modelarray] : era5Forcings.data) {
+            for (size_t j = 0; j < ny; ++j) {
+                for (size_t i = 0; i < nx; ++i) {
+                    REQUIRE(modelarray(i, j) == doctest::Approx(0.1 * ts));
+                }
+            }
+        }
+
+        // Read TOPAZ forcings from file, checking that they contain the expected fields and that
+        // those have the expected values
+        // NOTE: Only the first timestep has TOPAZ data
+        if (ts == 0) {
+            ModelState topazForcings
+                = pio->readForcingTimeStatic(topazForcingFieldNames, time, topazForcingFilename);
+            for (const auto& fieldName : topazForcingFieldNames) {
+                REQUIRE(topazForcings.data.count(fieldName) > 0);
+            }
+            for (const auto& [fieldName, modelarray] : topazForcings.data) {
+                for (size_t j = 0; j < ny; ++j) {
+                    for (size_t i = 0; i < nx; ++i) {
+                        REQUIRE(modelarray(i, j) == doctest::Approx(ts + 1));
+                    }
+                }
+            }
+        }
+
+        // Update the current timestep and verify it's updated in XIOS
+        metadata.incrementTime(timestep);
+        metadata.incrementTime(timestep);
+        REQUIRE(xiosHandler.getCalendarStep() == ts + 2);
+    }
+
+    xiosHandler.context_finalize();
+    Finalizer::finalize();
+}
+}


### PR DESCRIPTION
# Integrate interpolation support from XIOS

Fixes #979

## Open Mailing list query with XIOS devs

- I have created a MWE repo [here](https://github.com/TomMelt/xios-interp)
  - There is a PR here which implements interpolation https://github.com/TomMelt/xios-interp/pull/1
- I have emailed XIOS user mailing list for support (see [here](https://listes.ipsl.fr/sympa/arc/xios-users/2026-06/msg00000.html))
- I believe I have implemented all necessary features but I cannot get interpolation working

---

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [x] Defined the tests that specify a complete and functioning change
- [ ] Implemented the source code change that satisfies the tests
- [ ] Commented all code so that it can be understood without additional context
- [ ] No new warnings are generated or they are mentioned below
- [ ] The documentation has been updated (or an issue has been created to do so)
- [x] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

This PR exposes the interpolation functionality of `XIOS` into `nextsim`.

**Plan**
- Add new ERA5 fields which exist on the "Forcing" grid/domain
  - add a `field_ref` to this new field in the main nextsim code 
```xml
<field id="tairEra5" grid_ref="HGridEra5" />
<field id="tair" field_ref="tairEra5" grid_ref="HGridEra5Interp" /> <!-- done at runtime instead -->
```  
- Add 2 new grids `HGridEra5` and `HGridEra5Interp`
  - `HGridEra5Interp` will be same size as nextsim grid, but has the `<interpolate_domain/>` property set
  - because `tair` references field `tairEra5` but exists on `grid_ref="HGridEra5Interp"` XIOS will interpolate at runtime
```xml
<grid id="HGridEra5">
  <domain domain_ref="era5"/>
</grid>

<grid id="HGridEra5Interp" name="HGridEra5Interp">
  <domain domain_ref="era5Interp">
    <interpolate_domain/>
  </domain>
</grid>
```
- Add 2 new domains `era5` and `era5Interp`
  - `era5Interp` will be the same size as the nextsim model domain, and `era5` will match the Forcing data
  - we need to set name so that XIOS reads correct dims (I believe dims are labelled `[dim_name]_[domain_name]` which means if we didn't change the name manually it would be the same as the `domain id` leading to `x_era5` rather than `x_dim`
  - We need 2 domains because we need one for the Forcing file grid, and the second in theory matches the size of the nextsim grid... but... it has the interpolate property set to true, which would break the existing nextsim grids which don't need interpolation e.g., restart files and initialization files.
```xml
<domain id="era5" name="dim" ni_glo="3" nj_glo="5" type="rectilinear" />
<domain id="era5Interp" name="dim" type="rectilinear" /> <!-- details set at runtime -->
```

---
# Test Description

- `XiosForcingInterpolation_test.cpp` tests `XIOS` interpolation from a low resolution grid (from file) to the higher resolution grid (in the test)   

---
# Documentation Impact

To be completed

---
# Other Details

N/A
