### PR TITLE
Require CMAKE_BUILD_TYPE to be specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,17 @@ else()
     find_package(Python COMPONENTS Interpreter)
 endif()
 
+# Do not accept unspecified CMAKE_BUILD_TYPE
+set(valid_build_types Release RelWithDebInfo Debug MinSizeRel)
+if(NOT CMAKE_BUILD_TYPE IN_LIST valid_build_types)
+    string(JOIN  ", "  pretty_build_types ${valid_build_types})
+    message(FATAL_ERROR
+        "CMAKE_BUILD_TYPE '${CMAKE_BUILD_TYPE}' is invalid. "
+        "Expected one of: ${pretty_build_types}\n"
+        "Please specify `-DCMAKE_BUILD_TYPE=<value> during configuration."
+    )
+endif()
+
 # The location of the module_builder.py scripts
 set(ScriptDirectory "${PROJECT_SOURCE_DIR}/scripts")
 set(ModuleBuilderScript "${ScriptDirectory}/module_builder.py")


### PR DESCRIPTION
# Require CMAKE_BUILD_TYPE to be specified

Related to #1094 

### Task List
- [x] Linked an issue above that captures the requirements of this PR
- [ ] ~~Defined the tests that specify a complete and functioning change~~
- [ ] ~~Implemented the source code change that satisfies the tests~~
- [x] Commented all code so that it can be understood without additional context
- [ ] ~~No new warnings are generated or they are mentioned below~~
- [ ] ~~The documentation has been updated (or an issue has been created to do so)~~
- [ ] Relevant labels (e.g., enhancement, bug) have been applied to this PR
- [x] This change conforms to the conventions described in the README

---
# Change Description

The proposal here is to require the user to explicitly specify build configuration. 
The way it is done at the moment will not work correctly with multi-config generators, where my understanding is that the convention is to leave the BUILD_TYPE empty and relay on the `--config` flag during the build  stage. 

But we can potentially check for the multi config generator using [a property](https://cmake.org/cmake/help/latest/prop_gbl/GENERATOR_IS_MULTI_CONFIG.html).

I am inclined to demand the following: 
 - If generator  is single config -> Require explicit CMAKE_BUILD_TYPE
 - If generator is multi config -> Raise an error if CMAKE_BUILD_TYPE is specified

I am also like 60% convinced that perhaps a warning might work better then a fatal error....

---
# Test Description

N/A
---
# Documentation Impact

N/A

---
# Other Details

